### PR TITLE
[data] [base-spells] Update spell data for dazzle and burn (2 of 3)

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -1621,6 +1621,7 @@ spell_data:
     mana_type: lunar
     prep: target
     guild: Moon Mage
+    any_celestial_object: true
   Cage of Light:
     skill: Warding
     abbrev: CoL
@@ -1662,6 +1663,7 @@ spell_data:
     mana_type: lunar
     prep: prepare
     guild: Moon Mage
+    bright_celestial_object: true
   Destiny Cipher:
     skill: Utility
     abbrev: DC


### PR DESCRIPTION
Continuation of #6933 

Burn requires any moon or sun to be up to cast
Dazzle requires bright moon or sun to be cast

This is a part 2 of 3 changes to enable combat-trainer to cast burn/dazzle when it can, and another spell when it can't. Needs to be 3 changes due to how dr-scripts updates work.

Part 1 - new common methods (this change)
Part 2 - new data fields in base-spells on the two spells 
Part 3 - update to combat-trainer.