### PR TITLE
[script] [combat-trainer] Add spell selection criteria based on celestial objects (3 of 3)

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1772,6 +1772,10 @@ class SpellProcess
                      .select { |skill| Time.now > (@training_spells[skill]['cyclic'] ? @training_cyclic_timer : @training_cast_timer) }
                      .select { |skill| @training_spells[skill]['night'] ? UserVars.sun['night'] : true }
                      .select { |skill| @training_spells[skill]['day'] ? UserVars.sun['day'] : true }
+                     .select { |skill| @training_spells[skill]['bright_celestial_object'] ? DRCMM.bright_celestial_object? : true }
+                     .select { |skill| @training_spells[skill]['any_celestial_object'] ? DRCMM.any_celestial_object? : true }
+                     .select { |skill| @training_spells[skill]['no_bright_celestial_object'] ? !DRCMM.bright_celestial_object? : true }
+                     .select { |skill| @training_spells[skill]['no_celestial_object'] ? !DRCMM.any_celestial_object? : true }
     DRC.message "all eligible training spells: #{needs_training}" if $debug_mode_ct
     needs_training = game_state.sort_by_rate_then_rank(needs_training).first
     return unless needs_training
@@ -2031,6 +2035,10 @@ class SpellProcess
                    .select { |spell| spell['day'] ? UserVars.sun['day'] : true }
                    .select { |spell| spell['slivers'] ? (DRSpells.slivers || @tk_ammo) : true }
                    .select { |spell| spell['starlight_threshold'] ? enough_starlight?(game_state, spell) : true }
+                   .select { |spell| spell['bright_celestial_object'] ? DRCMM.bright_celestial_object? : true }
+                   .select { |spell| spell['any_celestial_object'] ? DRCMM.any_celestial_object? : true }
+                   .select { |spell| spell['no_bright_celestial_object'] ? !DRCMM.bright_celestial_object? : true }
+                   .select { |spell| spell['no_celestial_object'] ? !DRCMM.any_celestial_object? : true }
     echo "Ready Spells: #{ready_spells.to_yaml}" if $debug_mode_ct
 
     data = if @offensive_spell_cycle.empty?


### PR DESCRIPTION
Continuation of #6933 and #7039 

Burn requires any moon or sun to be up to cast
Dazzle requires bright moon or sun to be cast

This is a part 3 of 3 changes to enable combat-trainer to cast burn/dazzle when it can, and another spell when it can't. Needs to be 3 changes due to how dr-scripts updates work.

Part 1 - new common methods 
Part 2 - new data fields in base-spells on the two spells
Part 3 - update to combat-trainer (this change)