### PR TITLE
sort-scrolls - Added unleash option

### DIFF
--- a/sort-scrolls.lic
+++ b/sort-scrolls.lic
@@ -19,16 +19,22 @@ class ScrollSorter
     @stacker_container = @settings.scroll_sorter['stacker_container']
     @custom_nouns = @settings.scroll_sorter['scroll_nouns']
     @scroll_nouns = get_data('items').scroll_nouns + @custom_nouns
+    @unleash_mana = @settings.scroll_sorter['unleash_mana']
+    @unleash_harnesses = @settings.scroll_sorter['unleash_harnesses']
 
     arg_definitions =
       [
         [
-          { name: 'container', regex: /\w+/, optional: true, description: 'The container to collect scrolls from' }
+          { name: 'container', regex: /\w+/, optional: true, description: 'The container to collect scrolls from.' }
         ],
 
         [
-          { name: 'find', regex: /find/i, description: 'Find the specified spell scroll in your stackers' },
-          { name: 'spell', regex: /\w+/i, optional: false, description: 'Name of spell to find.  Use full name, enclose in double quotes if more than one word' }
+          { name: 'find', regex: /find/i, description: 'Find the specified spell scroll in your stackers.' },
+          { name: 'spell', regex: /\w+/i, optional: false, description: 'Name of spell to find.  Use full name, enclose in double quotes if more than one word.' }
+        ],
+        [
+          { name: 'unleash', regex: /unleash/i, description: 'Unleash the specified spell scroll in your stackers.'},
+          { name: 'spell', regex: /\w+/i, optional: false, description: 'Name of spell to unleash.  Use full name, enclose in double quotes if more than one word.' }
         ]
       ]
 
@@ -38,6 +44,9 @@ class ScrollSorter
 
     if args.find
       find_spell(args.spell)
+    elsif args.unleash
+      find_spell(args.spell)
+      unleash_spell
     else
       sort_scrolls
     end
@@ -80,6 +89,10 @@ class ScrollSorter
 
   def find_abbrev(spell)
     return @all_spells.select { |s, _g| s.casecmp(spell) == 0 }.flatten[2]
+  end
+
+  def find_full_spell_name(abbrev)
+    return @all_spells.select { |s, g, a| a.casecmp(abbrev) == 0 }.flatten[0]
   end
 
   def check_scroll(scroll)
@@ -141,6 +154,10 @@ class ScrollSorter
   def find_spell(name, guild = nil)
     if guild.nil?
       guild = find_guild(name)
+      if guild.nil?
+        name = find_full_spell_name(name)
+        guild = find_guild(name)
+      end
       unknown(guild) if guild.nil? || guild == 'Analogous'
     end
     ord = find_case(guild)
@@ -171,7 +188,30 @@ class ScrollSorter
       end
       DRC.bput("pull my #{@stacker}", /This was the last copy/, /Carefully, you remove a copy/)
     end
-    DRC.bput("put my #{@stacker} in my #{@stacker_container}", /You put your/)
+    stow_and_refactor_cases(guild)
+  end
+
+  def unleash_spell
+    DRC.wait_for_script_to_complete('buff', ['unleash'])
+    if DRCA.spell_preparing?
+      /You are preparing.*spell at (.*) mana/ =~ DRC.bput('per', /You are preparing.*spell at (.*) mana/)
+      mana = DRC.text2num(Regexp.last_match(1).to_s)
+      harn = calculate_harness_array((@unleash_mana - mana), @unleash_harnesses)
+      pause 1 until DRCA.spell_prepared?
+      DRCA.harness_mana(harn)
+      DRCA.cast?
+    else
+      DRC.message('Unleash failed!')
+    end
+    stack_scroll('scroll', check_scroll('scroll'))
+  end
+
+  def calculate_harness_array(number, n)
+    base_part = number / n
+    remainder = number % n
+    parts = Array.new(n, base_part)
+    remainder.times { |i| parts[i] += 1 }
+    parts
   end
 end
 

--- a/sort-scrolls.lic
+++ b/sort-scrolls.lic
@@ -21,6 +21,7 @@ class ScrollSorter
     @scroll_nouns = get_data('items').scroll_nouns + @custom_nouns
     @unleash_mana = @settings.scroll_sorter['unleash_mana']
     @unleash_harnesses = @settings.scroll_sorter['unleash_harnesses']
+    @unleash_harnesses ||= 1
 
     arg_definitions =
       [
@@ -33,7 +34,7 @@ class ScrollSorter
           { name: 'spell', regex: /\w+/i, optional: false, description: 'Name of spell to find.  Use full name, enclose in double quotes if more than one word.' }
         ],
         [
-          { name: 'unleash', regex: /unleash/i, description: 'Unleash the specified spell scroll in your stackers.'},
+          { name: 'unleash', regex: /unleash/i, description: 'Unleash the specified spell scroll in your stackers.' },
           { name: 'spell', regex: /\w+/i, optional: false, description: 'Name of spell to unleash.  Use full name, enclose in double quotes if more than one word.' }
         ]
       ]
@@ -92,7 +93,7 @@ class ScrollSorter
   end
 
   def find_full_spell_name(abbrev)
-    return @all_spells.select { |s, g, a| a.casecmp(abbrev) == 0 }.flatten[0]
+    return @all_spells.select { |_s, _g, a| a.casecmp(abbrev) == 0 }.flatten[0]
   end
 
   def check_scroll(scroll)


### PR DESCRIPTION
Added option to specify a scroll to pull out, cast unleash on it, and then cast the spell if it was successful.

A waggle set for unleash is needed for this.  It needs to be set as follows, but you can edit how much mana you want to cast unleash at:

```
waggle_sets:
  unleash:
    Unleash:
      mana: 15
      cast: cast scroll
```
For this functionality I added 2 new yaml settings, `unleash_mana` and `unleash_harnesses`.  They are both integers and `unleash_mana` is the total mana you want to cast the unleased spell at and `unleash_harnesses` is how many times you want to harness to hold that much mana for the cast.

For example, if you set `unleash_mana` to 100 and then cast unleash on a scroll, it will perceive to see how much mana the spell is prepped at, take 100 - that, and then harness the rest by harnessing `unleash_harnesses` times.

I also added the option to specify the  spell by abbreviation so instead of this:
`;sort-scrolls find "whispers of the muse"`
You can now do this:
`;sort-scrolls find wotm`