### PR TITLE
chore: Github Workflow Update

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,8 @@
 name: Rubocop
 on:
   push:
+    branches: 
+      - 'main'
     paths:
       - "*.lic"
       - "*.rb"

--- a/.github/workflows/ruby_syntax_checker.yml
+++ b/.github/workflows/ruby_syntax_checker.yml
@@ -2,6 +2,8 @@ name: Valid Ruby syntax
 
 on:
   push:
+    branches: 
+      - 'main'
     paths:
       - "*.lic"
       - "*.rb"

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -2,6 +2,8 @@ name: Valid YAML syntax
 
 on: 
   push:
+    branches: 
+      - 'main'
     paths:
       - "data/*.yaml"
       - "profiles/**.yaml"


### PR DESCRIPTION
Make github workflows only run on push's to `main` branch. Should prevent double workflow running on PRs that are opened.