### PR TITLE
[common][travel] failure pattern added

### DIFF
--- a/common-travel.lic
+++ b/common-travel.lic
@@ -23,7 +23,8 @@ module DRCT
       /I need to examine the merchandise first/,
       /That's not worth anything/,
       /I only deal in pelts/,
-      /There's folk around here that'd slit a throat for this/
+      /There's folk around here that'd slit a throat for this/,
+      /isn't worth my time/,
     ]
 
     case DRC.bput("sell my #{item}", *success_patterns, *failure_patterns)


### PR DESCRIPTION
Added pattern on account of some B&E items which currently hangs bput in sell_item, when called from ;pawn-items.

Example:
Cormyn shakes his head and says, "A tall silver desk lamp with an ornate acanth base isn't worth my time."