### PR TITLE
[script][combat-trainer] QOL improvement to use of collect

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2955,15 +2955,14 @@ class TrainerProcess
       DRCA.activate_barb_buff?('Avalanche')
     when /^Collect$/i
       # only collect if weapon is not loaded, as collect's high RT has a high chance of overrunning weapon switch window
-      if !game_state.loaded then
-        game_state.sheath_whirlwind_offhand
-        DRC.retreat
-        game_state.engage unless game_state.npcs.empty? || game_state.retreating?
-        DRC.collect(@forage_item)
-        waitrt?
-        game_state.wield_whirlwind_offhand
-        DRC.kick_pile?
-      end
+      return if game_state.loaded
+      game_state.sheath_whirlwind_offhand
+      DRC.retreat
+      game_state.engage unless game_state.npcs.empty? || game_state.retreating?
+      DRC.collect(@forage_item)
+      waitrt?
+      game_state.wield_whirlwind_offhand
+      DRC.kick_pile?
     when /^Almanac$/i
       UserVars.almanac_last_use ||= Time.now - 600
       use_almanac(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2954,7 +2954,8 @@ class TrainerProcess
     when /^Berserk Avalanche$/i
       DRCA.activate_barb_buff?('Avalanche')
     when /^Collect$/i
-      if !game_state.loaded then         # only collect if weapon is not loaded, as collect's high RT has a high chance of overrun shoot timing 
+      # only collect if weapon is not loaded, as collect's high RT has a high chance of overrunning weapon switch window
+      if !game_state.loaded then 
         game_state.sheath_whirlwind_offhand
         DRC.retreat
         game_state.engage unless game_state.npcs.empty? || game_state.retreating?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2954,13 +2954,15 @@ class TrainerProcess
     when /^Berserk Avalanche$/i
       DRCA.activate_barb_buff?('Avalanche')
     when /^Collect$/i
-      game_state.sheath_whirlwind_offhand
-      DRC.retreat
-      game_state.engage unless game_state.npcs.empty? || game_state.retreating?
-      DRC.collect(@forage_item)
-      waitrt?
-      game_state.wield_whirlwind_offhand
-      DRC.kick_pile?
+      if !game_state.loaded          # only collect if weapon is not loaded, as collect's high RT would likely overrun shoot timing 
+        game_state.sheath_whirlwind_offhand
+        DRC.retreat
+        game_state.engage unless game_state.npcs.empty? || game_state.retreating?
+        DRC.collect(@forage_item)
+        waitrt?
+        game_state.wield_whirlwind_offhand
+        DRC.kick_pile?
+      end
     when /^Almanac$/i
       UserVars.almanac_last_use ||= Time.now - 600
       use_almanac(game_state)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2954,7 +2954,7 @@ class TrainerProcess
     when /^Berserk Avalanche$/i
       DRCA.activate_barb_buff?('Avalanche')
     when /^Collect$/i
-      if !game_state.loaded          # only collect if weapon is not loaded, as collect's high RT has a high chance of overrun shoot timing 
+      if !game_state.loaded then         # only collect if weapon is not loaded, as collect's high RT has a high chance of overrun shoot timing 
         game_state.sheath_whirlwind_offhand
         DRC.retreat
         game_state.engage unless game_state.npcs.empty? || game_state.retreating?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2954,7 +2954,7 @@ class TrainerProcess
     when /^Berserk Avalanche$/i
       DRCA.activate_barb_buff?('Avalanche')
     when /^Collect$/i
-      if !game_state.loaded          # only collect if weapon is not loaded, as collect's high RT would likely overrun shoot timing 
+      if !game_state.loaded          # only collect if weapon is not loaded, as collect's high RT has a high chance of overrun shoot timing 
         game_state.sheath_whirlwind_offhand
         DRC.retreat
         game_state.engage unless game_state.npcs.empty? || game_state.retreating?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2955,7 +2955,7 @@ class TrainerProcess
       DRCA.activate_barb_buff?('Avalanche')
     when /^Collect$/i
       # only collect if weapon is not loaded, as collect's high RT has a high chance of overrunning weapon switch window
-      if !game_state.loaded then 
+      if !game_state.loaded then
         game_state.sheath_whirlwind_offhand
         DRC.retreat
         game_state.engage unless game_state.npcs.empty? || game_state.retreating?


### PR DESCRIPTION
Mask the use of collect if we have a loaded weapon.  Its likely that the RT from collect will result in the weapon switch window being exceeded and wasting the load & aim time already invested.  Given collect is less time critical and not directly combat related, suggest its ok to drop it in preference to losing an aim slot.