### PR TITLE
[script][combat-trainer]  make aiming_trainables stop attacking if locked/close to lock

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3669,7 +3669,7 @@ class AttackProcess
       echo "attack_aimed::aiming_trainables:skill: #{skill}" if $debug_mode_ct
       return unless skill
 
-# if aiming_trainable is locked, don't continue to train it!
+      # if aiming_trainable is locked, don't continue to train it!
       return if DRSkill.getxp(skill) > 32
 
       weapon_name = game_state.wield_offhand_weapon(skill)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3669,6 +3669,9 @@ class AttackProcess
       echo "attack_aimed::aiming_trainables:skill: #{skill}" if $debug_mode_ct
       return unless skill
 
+# if aiming_trainable is locked, don't continue to train it!
+      return if DRSkill.getxp(skill) > 32
+
       weapon_name = game_state.wield_offhand_weapon(skill)
 
       actions = if skill.eql?('Tactics')


### PR DESCRIPTION
Aiming_trainables have a tendency to lock early due to low RTs + being able to be off-handed.  The current behaviour is that even if the aiming_trainable is locked, it will continue to be used, and have a significant chance of "kill-stealing" from the loadable weapon, with no benefit.  

The check introduced here will stop the aiming_trainable if its (near-) locked and give the loadable weapon a chance to fire.  This should work where the aiming_trainable and the loadable weapon competing for kills are close-ish in rank.  Conversely if an overskilled aiming_trainable is used in a backhunt, the dabbling MS will not trigger the check; CT will continue to spam the dabbling aiming_trainable in that case (which will never lock due to nature of backhunt - same as main hand weapons).

Don't believe we need a yaml switch for this, the change should become the new default behaviour?
