### PR TITLE
[scripts][combat-trainer][hunting-buddy][yiamura] Add yiamura support

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2401,7 +2401,6 @@ class AbilityProcess
     DRC.wait_for_script_to_complete('yiamura', ['raise'])
   end
 
-
   # Sets up our warhorn and/or egg use. Sets timers. Allows legacy use of warhorn: egg. Checks to
   # see if we're using a wearable warhorn or have it in a bag.
   def set_warhorn_or_egg

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2351,6 +2351,9 @@ class AbilityProcess
     @pounce_on_cooldown = settings.pounce_on_cooldown
     echo("  @pounce_on_cooldown: #{@pounce_on_cooldown}") if $debug_mode_ct
 
+    @yiamura_exists = settings.combat_trainer_use_yiamura
+    echo("  @yiamura_exists: #{@yiamura_exists}") if $debug_mode_ct
+
     # Egg settings, for egg only
     @egg = settings.egg
     echo("  @egg: #{@egg}") if $debug_mode_ct
@@ -2373,15 +2376,31 @@ class AbilityProcess
 
   def execute(game_state)
     check_paladin_skills
+    check_yiamura if @yiamura_exists
     check_nonspell_buffs(game_state)
     check_battle_cries(game_state)
     use_warhorn_or_egg(game_state) unless @warhorn_or_egg.nil? || @warhorn_or_egg.empty?
-    game_state.stomp if @stomp_on_cooldown && game_state.npcs && Flags['war-stomp-ready']
+    game_state.stomp if DRStats.barbarian? && @stomp_on_cooldown && game_state.npcs && Flags['war-stomp-ready']
     game_state.pounce if DRStats.ranger? && @pounce_on_cooldown && game_state.npcs && Flags['pounce-ready']
     false
   end
 
   private
+
+  def check_yiamura
+    return unless @yiamura_exists
+    if UserVars.yiamura['last_raised']
+      return unless ((Time.now - UserVars.yiamura['last_raised'].to_i).to_i > 7200)
+    end
+
+    unless DRCI.exists?("yiamura")
+      echo "Yiamura is not present." if $debug_mode_ct
+      @yiamura_exists = false
+      return
+    end
+    DRC.wait_for_script_to_complete('yiamura', ['raise'])
+  end
+
 
   # Sets up our warhorn and/or egg use. Sets timers. Allows legacy use of warhorn: egg. Checks to
   # see if we're using a wearable warhorn or have it in a bag.
@@ -4164,7 +4183,7 @@ class GameState
   $staff_skills = ['Staves']
   $polearm_skills = ['Polearms']
   $melee_skills = $edged_skills + $blunt_skills + $staff_skills + $polearm_skills + ['Melee Mastery']
-  $thrown_skills = ['Heavy Thrown', 'Light Thrown']
+  $thrown_skills = ['Heavy Thrown', 'Light Thrown', 'Missile Mastery']
   $twohanded_skills = ['Twohanded Edged', 'Twohanded Blunt']
   $aim_skills = ['Bow', 'Slings', 'Crossbow']
   $ranged_skills = $thrown_skills + $aim_skills + ['Missile Mastery']
@@ -5140,7 +5159,7 @@ class GameState
   def dual_load?
     @dual_load && weapon_skill == 'Bow' &&
       DRSkill.getrank('Bow') >= 201 && DRStats.agility >= 30 && DRStats.reflex >= 30 &&
-      (DRSpells.active_spells['See the Wind'] || DRStats.barbarian? || DRSpells.active_spells['Khri Steady'])
+      (DRSpells.active_spells['See the Wind'] || DRSpells.active_spells['Eagle'] || DRSpells.active_spells['Khri Steady'])
   end
 
   def prepare_summoned_weapon(weapon_already_summoned)

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -446,6 +446,13 @@ class HuntingBuddy
   end
 
   # ------------------------------------------------------------
+  def yiamura_all_done?
+    return true unless UserVars.yiamura
+    return true unless UserVars.yiamura['last_raised_room_id'] == Map.current.id
+
+    return (Time.now - UserVars.yiamura['last_raised'].to_i).to_i > 600
+  end
+  # ------------------------------------------------------------
 
   # Is your current encumbrance at or higher than the threshold?
   # Threshold is a number from 0 (None) to 11 (It's amazing you aren't squashed!)
@@ -513,11 +520,11 @@ class HuntingBuddy
         DRC.message("***STATUS*** Stopping because no moons")
         break
       end
-      if should_stop_for_high_skills?(stop_on_high_skills)
+      if should_stop_for_high_skills?(stop_on_high_skills) && yiamura_all_done?
         DRC.message("***STATUS*** Stopping because skills reached learning threshold: #{stop_on_high_skills}")
         break
       end
-      if should_stop_for_low_skills?(stop_on_low_skills)
+      if should_stop_for_low_skills?(stop_on_low_skills) && yiamura_all_done?
         DRC.message("***STATUS*** Stopping because skills dropped below learning threshold: #{stop_on_low_skills}")
         break
       end
@@ -526,11 +533,11 @@ class HuntingBuddy
         @next_hunt = false
         break
       end
-      if duration && (counter / 60) >= duration
+      if (duration && (counter / 60) >= duration) && yiamura_all_done?
         DRC.message("***STATUS*** Stopping because time")
         break
       end
-      if Flags['hunting-buddy-stop-to-burgle'] && (@stop_to_burgle || stop_on_burgle_cooldown)
+      if Flags['hunting-buddy-stop-to-burgle'] && (@stop_to_burgle || stop_on_burgle_cooldown) && yiamura_all_done?
         DRC.message("***STATUS*** Stopping because it's burgle time!")
         Flags.reset('hunting-buddy-stop-to-burgle')
         break

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -109,6 +109,8 @@ cycle_armors_time: 125
 cycle_armors_hysteresis: true
 # works with cycle_armors, regalia, and hysteresis.  Which armor type to use when all others on your list are trained.
 default_armor_type:
+# Whether to use a yiamura in combat
+combat_trainer_use_yiamura: false
 # Skinning/dissect settings
 skinning:
   skin: true                     # Whether to skin or not

--- a/yiamura.lic
+++ b/yiamura.lic
@@ -39,7 +39,6 @@ class Yiamura
 
   def observe_yiamura
     case DRC.bput("observe my yiamura", /but nothing happens/, /Very quickly, your head reels as knowledge fills your mind/)
-    when /but nothing happens/
     when /Very quickly, your head reels as knowledge fills your mind/
       UserVars.yiamura['last_observed'] = Time.now
     end

--- a/yiamura.lic
+++ b/yiamura.lic
@@ -44,7 +44,6 @@ class Yiamura
       UserVars.yiamura['last_observed'] = Time.now
     end
   end
-
 end
 
 Yiamura.new

--- a/yiamura.lic
+++ b/yiamura.lic
@@ -1,0 +1,50 @@
+=begin
+  Documentation: https://elanthipedia.play.net/Lich_script_repository#find
+=end
+
+class Yiamura
+  def initialize
+    arg_definitions = [
+      [
+        { name: 'option', options: ['raise', 'observe', 'reset'], optional: true, description: 'Action to take.' }
+      ]
+    ]
+
+    args = parse_args(arg_definitions, true)
+
+    UserVars.yiamura = {} unless UserVars.yiamura
+    if args.option == "raise"
+      raise_yiamura
+    elsif args.option == "observe"
+      observe_yiamura
+    elsif args.option == "reset"
+      UserVars.yiamura = {}
+    else
+      echo("Yiamura raised: #{UserVars.yiamura['last_raised']}")
+      echo("Yiamura last observed: #{UserVars.yiamura['last_observed'].nil? ? 'never' : UserVars.yiamura['last_observed']}")
+      echo("Yiamura last raised room: #{UserVars.yiamura['last_raised_room_id']}")
+    end
+  end
+
+  def raise_yiamura
+    case DRC.bput("raise my yiamura", /but nothing happens/, /The air takes on a noticeable chill/)
+    when /but nothing happens/
+      echo("Yiamura already raised.")
+    when /The air takes on a noticeable chill/
+      echo("Yiamura raised.")
+      UserVars.yiamura['last_raised'] = Time.now
+      UserVars.yiamura['last_raised_room_id'] = Map.current.id
+    end
+  end
+
+  def observe_yiamura
+    case DRC.bput("observe my yiamura", /but nothing happens/, /Very quickly, your head reels as knowledge fills your mind/)
+    when /but nothing happens/
+    when /Very quickly, your head reels as knowledge fills your mind/
+      UserVars.yiamura['last_observed'] = Time.now
+    end
+  end
+
+end
+
+Yiamura.new


### PR DESCRIPTION
This adds yiamura support to combat-trainer. To enable usage add `combat_trainer_use_yiamura: true` to your yaml. Defaults to `false`

Adds checks in hunting-buddy for the corresponding UserVars that the new `yiamura.lic` sets when called.

At present it will prioritize staying in combat for 10 minutes post successful yiamura raise for `should_stop_for_high_skills`, `should_stop_for_low_skills`. `duration` and `stop_on_burgle_cooldown`