### PR TITLE
[script][combat-trainer] Stop training untrainable weapon skills in CT - optional feature

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4287,6 +4287,9 @@ class GameState
     @target_increment = settings.combat_trainer_target_increment
     echo("  @target_increment: #{@target_increment}") if $debug_mode_ct
 
+    @gain_check = settings.combat_trainer_gain_check
+    echo("  @gain_check: #{@gain_check}") if $debug_mode_ct
+
     @strict_weapon_stance = settings.strict_weapon_stance
     echo("  @strict_weapon_stance: #{@strict_weapon_stance}") if $debug_mode_ct
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -173,8 +173,11 @@ class SetupProcess
 
     echo('new skill needed for training') if $debug_mode_ct
 
+    # reset counters for game_state.skill_done? after decision to switch to new skill
+    # as counts for previous weapon is now invalid
     game_state.reset_action_count
-    @last_exp = -1
+    game_state.last_exp = -1
+    game_state.last_action_count = 0
 
     # If you're training with summoned moon weapons but you haven't cast the moonblade spell yet
     # then skip those weapon skills and train something else while we wait for moonblade spell to be cast.
@@ -4175,7 +4178,7 @@ class GameState
                 :casting, :casting_cfb, :casting_cfw, :casting_nr, :casting_consume, :casting_cyclic, :casting_moonblade,
                 :casting_regalia, :casting_sorcery, :casting_weapon_buff, :charges, :charges_total,
                 :clean_up_step, :constructs, :cooldown_timers, :current_weapon_skill,
-                :currently_whirlwinding, :dance_queue, :dancing, :danger, :hide_on_cast,
+                :currently_whirlwinding, :dance_queue, :dancing, :danger, :hide_on_cast, :last_action_count, :last_exp,
                 :last_regalia_type, :last_weapon_skill, :loaded, :mob_died, :need_bundle,
                 :no_loot, :no_skins, :no_stab_current_mob, :no_stab_mobs, :parrying, :prepare_cfb, :prepare_cfw, :prepare_nr,
                 :prepare_consume, :regalia_cancel, :reset_stance, :retreating, :starlight_values,
@@ -4313,6 +4316,7 @@ class GameState
     end
 
     @last_exp = -1
+    @last_action_count = 0
     @no_gain_list = Hash.new(0)
     @weapons_to_train.each { |skill_name, _weapon_name| @no_gain_list[skill_name] = 0 }
     echo("  @no_gain_list: #{@no_gain_list}") if $debug_mode_ct
@@ -4825,16 +4829,22 @@ class GameState
     current_exp = DRSkill.getxp(weapon_skill)
     echo("action count: #{@action_count} vs #{@target_action_count}") if $debug_mode_ct
     echo("skill exp: #{current_exp} vs #{@target_weapon_skill}") if $debug_mode_ct
+    echo("no_gain_list: #{@no_gain_list}") if $debug_mode_ct
+    echo("last_exp: #{@last_exp}") if $debug_mode_ct
+    echo("last_action_count: #{@last_action_count}") if $debug_mode_ct
 
     # gain_check code: logic to account for a skill that is not gaining any MS at all
     if @gain_check && (weapon_skill != nil) then
-      if (current_exp <= @last_exp) && (current_exp != 34) && (@weapons_to_train.size > 1) then
-        @no_gain_list[weapon_skill] += 1
-      else
-        @no_gain_list[weapon_skill] = 0
+      # only check for mindstate movement if there was actually some action in the last CT cycle
+      if (@action_count > @last_action_count) then
+        if (current_exp <= @last_exp) && (current_exp != 34) && (@weapons_to_train.size > 1) then
+          @no_gain_list[weapon_skill] += 1
+        else
+          @no_gain_list[weapon_skill] = 0
+        end
       end
       @last_exp = current_exp
-      echo("updated @no_gain_list: #{@no_gain_list}") if $debug_mode_ct
+      @last_action_count = @action_count
 
       # blacklist skill if it hasn't been gaining for a while
       if (@no_gain_list[weapon_skill] > @gain_check) then

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4840,7 +4840,7 @@ class GameState
        @last_exp = current_exp
 
        # blacklist skill if it hasn't been gaining for a while
-       if ((@no_gain_list[weapon_skill] > @gain_check) then
+       if (@no_gain_list[weapon_skill] > @gain_check) then
           DRC.message("WARNING: Supppressing #{weapon_skill} due to skill not training")
           @weapons_to_train.delete(weapon_skill)
           return true

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4834,10 +4834,8 @@ class GameState
       else
         @no_gain_list[weapon_skill] = 0
       end
-      
-      echo("updated @no_gain_list: #{@no_gain_list}") if $debug_mode_ct
-
       @last_exp = current_exp
+      echo("updated @no_gain_list: #{@no_gain_list}") if $debug_mode_ct
 
       # blacklist skill if it hasn't been gaining for a while
       if (@no_gain_list[weapon_skill] > @gain_check) then

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4314,7 +4314,7 @@ class GameState
     end
 
     @last_exp = -1
-    @no_gain_list = Hash.new
+    @no_gain_list = Hash.new(0)
     @weapons_to_train.each { |skill_name, _weapon_name| @no_gain_list[skill_name] = 0 }
     echo("  @no_gain_list: #{@no_gain_list}") if $debug_mode_ct
 
@@ -4828,8 +4828,8 @@ class GameState
     echo("skill exp: #{current_exp} vs #{@target_weapon_skill}") if $debug_mode_ct
 
     # gain_check code: logic to account for a skill that is not gaining any MS at all
-    if @gain_check then
-      if (current_exp <= @last_exp) && (current_exp != 34) then
+    if @gain_check && (weapon_skill != nil) then
+      if (current_exp <= @last_exp) && (current_exp != 34) && (@weapons_to_train.size > 1) then
         @no_gain_list[weapon_skill] += 1
       else
         @no_gain_list[weapon_skill] = 0

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -174,6 +174,7 @@ class SetupProcess
     echo('new skill needed for training') if $debug_mode_ct
 
     game_state.reset_action_count
+    @last_exp = -1
 
     # If you're training with summoned moon weapons but you haven't cast the moonblade spell yet
     # then skip those weapon skills and train something else while we wait for moonblade spell to be cast.
@@ -4312,6 +4313,11 @@ class GameState
       $ranged_skills << 'Brawling'
     end
 
+    @last_exp = -1
+    @no_gain_list = Hash.new
+    @weapons_to_train.each { |skill_name, weapon_name| @no_gain_list[skill_name] = 0 }
+    echo("  @no_gain_list: #{@no_gain_list}") if $debug_mode_ct
+
     @use_stealth_attacks = settings.use_stealth_attacks
     echo("  @use_stealth_attacks: #{@use_stealth_attacks}") if $debug_mode_ct
 
@@ -4820,6 +4826,31 @@ class GameState
     current_exp = DRSkill.getxp(weapon_skill)
     echo("action count: #{@action_count} vs #{@target_action_count}") if $debug_mode_ct
     echo("skill exp: #{current_exp} vs #{@target_weapon_skill}") if $debug_mode_ct
+
+    # gain_check code: logic to account for a weapon that is not gaining any MS at all
+
+    if @gain_check then
+        if (current_exp <= @last_exp) && (current_exp != 34) then
+            @no_gain_list[weapon_skill] += 1
+        else
+            @no_gain_list[weapon_skill] = 0
+        end
+        echo("updated @no_gain_list: #{@no_gain_list}") if $debug_mode_ct
+
+       @last_exp = current_exp
+
+       # blacklist skill if it hasn't been gaining for a while
+       if ((@no_gain_list[weapon_skill] > @gain_check) then
+          DRC.message("WARNING: Supppressing #{weapon_skill} due to skill not training")
+          @weapons_to_train.delete(weapon_skill)
+          return true
+        end
+
+        # if weapon is at 34, don't black list but do (try to) switch weapons.
+        if current_exp == 34 then
+          return true
+        return
+    end
 
     @action_count >= @target_action_count || current_exp >= @target_weapon_skill
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4848,7 +4848,7 @@ class GameState
 
       # blacklist skill if it hasn't been gaining for a while
       if (@no_gain_list[weapon_skill] > @gain_check) then
-        DRC.message("WARNING: Supppressing #{weapon_skill} due to skill not training")
+        DRC.message("WARNING: Suppressing #{weapon_skill} due to skill not training")
         @weapons_to_train.delete(weapon_skill)
         return true
       end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4849,7 +4849,7 @@ class GameState
         # if weapon is at 34, don't black list but do (try to) switch weapons.
         if current_exp == 34 then
           return true
-        return
+        end
     end
 
     @action_count >= @target_action_count || current_exp >= @target_weapon_skill

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4315,7 +4315,7 @@ class GameState
 
     @last_exp = -1
     @no_gain_list = Hash.new
-    @weapons_to_train.each { |skill_name, weapon_name| @no_gain_list[skill_name] = 0 }
+    @weapons_to_train.each { |skill_name, _weapon_name| @no_gain_list[skill_name] = 0 }
     echo("  @no_gain_list: #{@no_gain_list}") if $debug_mode_ct
 
     @use_stealth_attacks = settings.use_stealth_attacks
@@ -4827,29 +4827,29 @@ class GameState
     echo("action count: #{@action_count} vs #{@target_action_count}") if $debug_mode_ct
     echo("skill exp: #{current_exp} vs #{@target_weapon_skill}") if $debug_mode_ct
 
-    # gain_check code: logic to account for a weapon that is not gaining any MS at all
-
+    # gain_check code: logic to account for a skill that is not gaining any MS at all
     if @gain_check then
-        if (current_exp <= @last_exp) && (current_exp != 34) then
-            @no_gain_list[weapon_skill] += 1
-        else
-            @no_gain_list[weapon_skill] = 0
-        end
-        echo("updated @no_gain_list: #{@no_gain_list}") if $debug_mode_ct
+      if (current_exp <= @last_exp) && (current_exp != 34) then
+        @no_gain_list[weapon_skill] += 1
+      else
+        @no_gain_list[weapon_skill] = 0
+      end
+      
+      echo("updated @no_gain_list: #{@no_gain_list}") if $debug_mode_ct
 
-       @last_exp = current_exp
+      @last_exp = current_exp
 
-       # blacklist skill if it hasn't been gaining for a while
-       if (@no_gain_list[weapon_skill] > @gain_check) then
-          DRC.message("WARNING: Supppressing #{weapon_skill} due to skill not training")
-          @weapons_to_train.delete(weapon_skill)
-          return true
-        end
+      # blacklist skill if it hasn't been gaining for a while
+      if (@no_gain_list[weapon_skill] > @gain_check) then
+        DRC.message("WARNING: Supppressing #{weapon_skill} due to skill not training")
+        @weapons_to_train.delete(weapon_skill)
+        return true
+      end
 
-        # if weapon is at 34, don't black list but do (try to) switch weapons.
-        if current_exp == 34 then
-          return true
-        end
+      # if weapon is at 34, don't black list but do (try to) switch weapons.
+      if current_exp == 34 then
+        return true
+      end
     end
 
     @action_count >= @target_action_count || current_exp >= @target_weapon_skill


### PR DESCRIPTION
Extra logic to stop training a weapon that can't be trained, due to:
1. at max mindstate
2. skill is being used against a mob that's not high level enough (overhunting)
3. skill is being used against a mob that's too high level where there are strings of consecutive misses.

It will do so before the action_count threshold (eventually) takes effect; target_increment is not applicable here.

For 1, the logic will simply speed up weapon switch to something else that needs training
For 2 and 3, the logic will blacklist the weapon skill for a given run of CT, and move onto next weapon

The logic is turned on by declaring "combat_trainer_gain_check: \<value\>" in char-setup 
initial setting of 5 is suggested pending further experience.  Enabling gain_check will allow some finetuning of existing action_count threshold to reduce unnecessary weapon switch.

If the setting is not included in the yaml, the new logic will not be activated.
