### PR TITLE
[script][combat-trainer] minor necro fix - sequencing issue

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -772,8 +772,6 @@ class LootProcess
 
     if ritual.eql?('butcher')
       butcher_corpse(mob_noun, ritual, game_state)
-
-      @last_ritual = ritual
       echo "Last ritual performed: #{@last_ritual}" if $debug_mode_ct
       return
     end
@@ -821,6 +819,7 @@ class LootProcess
     loop do
       result = DRC.bput("perform #{ritual} on #{mob_noun}", @rituals['butcher'], @rituals['failures'], @rituals['construct'])
       game_state.construct(mob_noun) if result.include?(@rituals['construct'])
+      @last_ritual = 'butcher' if result.include?(@rituals['butcher'])
       break if result.empty? || @rituals['failures'].any? { |msg| result.include?(msg) || result.include?(@rituals['construct']) }
 
       DRC.bput("drop my #{DRC.right_hand}", 'You drop', 'You discard', 'Please rephrase')


### PR DESCRIPTION
If dissect_and_butcher was true and the butcher ritual is activated, the existing code would perform dissect and butcher correctly, AND it would follow up with an attempt at skin/dissect if configured as such in YAML.

The root cause was a @last_ritual = dissect command being overwritten with @last_ritual = butcher, which caused the skin/dissect code to be called.  Proposed fix addresses the root cause completely. 