### PR TITLE
[script][combat-trainer] Another necro fix - missing messages for using-corpse Flag

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -506,7 +506,7 @@ class LootProcess
       echo("  @box_loot_limit: #{@box_loot_limit}") if $debug_mode_ct
     end
 
-    Flags.add('using-corpse', 'begins arranging', 'completes arranging', 'kneels down briefly and draws a knife', 'cruelly into the body and carving out a chunk', 'makes additional cuts, purposeful but seemingly at random')
+    Flags.add('using-corpse', 'begins arranging', 'completes arranging', 'kneels down briefly and draws a knife', 'cruelly into the body and carving out a chunk', 'makes additional cuts, purposeful but seemingly at random', 'cutting into where vital fluids once flowed', 'You begin to dismember the corpse')
     Flags.add('pouch-full', 'You think the .* is too full to fit another gem into', /You'd better tie it up before putting/)
     Flags.add('container-full', 'There isn\'t any more room')
   end


### PR DESCRIPTION
The using-corpse Flag is used to suppressed the double ritual/skinning from happening due to short loot timers and bodies not decomposing quickly enough.  However the Flag was missing messages for dissect and butcher (was ok on other messages like preserve), which meant the suppression didn't work in those cases.
