### PR TITLE
[script][combat-trainer] YACTOM - yet another CT optimisation mod - "focus_threshold" 

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4878,25 +4878,25 @@ class GameState
     # The code will allow CT to focus on a single weapon once we know all weapons are draining;
     # the focus means there is no weapon switching costs being incurred.
 
-    if @focus_threshold then
-      if (@focus_threshold > 10) then
-        if !@focus_threshold_active && weapon_training.reject { |skill, _| DRSkill.getxp(skill) > @focus_threshold }.empty? then
-          # all weapons above threshold
-          DRC.message("Focussing on single weapon")
-          @target_action_count = 1000
-          @target_increment = 34
-          @focus_threshold_active = true
-          return true
-        elsif @focus_threshold_active && weapon_training.any? { |skill, _| DRSkill.getxp(skill) < (@focus_threshold / 2) } then
-          # any weapon below threshold/2
-          DRC.message("Spreading attention to all weapons")
-          @target_action_count = settings.combat_trainer_action_count
-          @target_increment = settings.combat_trainer_target_increment
-          @focus_threshold_active = false
-          return true
-        end
-      end
+  if (@focus_threshold > 10)
+    if !@focus_threshold_active && weapon_training.reject { |skill, _| DRSkill.getxp(skill) > @focus_threshold }.empty?
+      # all weapons above threshold
+      DRC.message("Focussing on single weapon")
+      @target_action_count = 1000
+      @target_increment = 34
+      @focus_threshold_active = true
+      return true
+    elsif @focus_threshold_active && weapon_training.any? { |skill, _| DRSkill.getxp(skill) < (@focus_threshold / 2) }
+      # any weapon below threshold/2
+      DRC.message("Spreading attention to all weapons")
+      @target_action_count = settings.combat_trainer_action_count
+      @target_increment = settings.combat_trainer_target_increment
+      @focus_threshold_active = false
+      return true
+    else
+      return false
     end
+  end
     @action_count >= @target_action_count || current_exp >= @target_weapon_skill
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4874,7 +4874,7 @@ class GameState
     # a decent minimum hysterisis band.
     # @focus_threshold is mapped to yaml value combat_trainer_focus_threshold
     # Setting the yaml value turns this code on, it will remain dormant otherwise.
-    # 
+    #
     # The code will allow CT to focus on a single weapon once we know all weapons are draining;
     # the focus means there is no weapon switching costs being incurred.
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4878,25 +4878,25 @@ class GameState
     # The code will allow CT to focus on a single weapon once we know all weapons are draining;
     # the focus means there is no weapon switching costs being incurred.
 
-  if (@focus_threshold > 10)
-    if !@focus_threshold_active && weapon_training.reject { |skill, _| DRSkill.getxp(skill) > @focus_threshold }.empty?
-      # all weapons above threshold
-      DRC.message("Focussing on single weapon")
-      @target_action_count = 1000
-      @target_increment = 34
-      @focus_threshold_active = true
-      return true
-    elsif @focus_threshold_active && weapon_training.any? { |skill, _| DRSkill.getxp(skill) < (@focus_threshold / 2) }
-      # any weapon below threshold/2
-      DRC.message("Spreading attention to all weapons")
-      @target_action_count = settings.combat_trainer_action_count
-      @target_increment = settings.combat_trainer_target_increment
-      @focus_threshold_active = false
-      return true
-    else
-      return false
+    if (@focus_threshold > 10)
+      if !@focus_threshold_active && weapon_training.reject { |skill, _| DRSkill.getxp(skill) > @focus_threshold }.empty?
+        # all weapons above threshold
+        DRC.message("Focussing on single weapon")
+        @target_action_count = 1000
+        @target_increment = 34
+        @focus_threshold_active = true
+        return true
+      elsif @focus_threshold_active && weapon_training.any? { |skill, _| DRSkill.getxp(skill) < (@focus_threshold / 2) }
+        # any weapon below threshold/2
+        DRC.message("Spreading attention to all weapons")
+        @target_action_count = settings.combat_trainer_action_count
+        @target_increment = settings.combat_trainer_target_increment
+        @focus_threshold_active = false
+        return true
+      else
+        return false
+      end
     end
-  end
     @action_count >= @target_action_count || current_exp >= @target_weapon_skill
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4878,24 +4878,25 @@ class GameState
     # The code will allow CT to focus on a single weapon once we know all weapons are draining;
     # the focus means there is no weapon switching costs being incurred.
 
-    if (@focus_threshold > 10) then
-      if !@focus_threshold_active && weapon_training.reject { |skill, _| DRSkill.getxp(skill) > @focus_threshold }.empty? then
-        # all weapons above threshold
-        DRC.message("Focussing on single weapon")
-        @target_action_count = 1000
-        @target_increment = 34
-        @focus_threshold_active = true
-        return true
-      elsif @focus_threshold_active && weapon_training.any? { |skill, _| DRSkill.getxp(skill) < (@focus_threshold / 2) } then
-        # any weapon below threshold/2
-        DRC.message("Spreading attention to all weapons")
-        @target_action_count = settings.combat_trainer_action_count
-        @target_increment = settings.combat_trainer_target_increment
-        @focus_threshold_active = false
-        return true
+    if @focus_threshold then
+      if (@focus_threshold > 10) then
+        if !@focus_threshold_active && weapon_training.reject { |skill, _| DRSkill.getxp(skill) > @focus_threshold }.empty? then
+          # all weapons above threshold
+          DRC.message("Focussing on single weapon")
+          @target_action_count = 1000
+          @target_increment = 34
+          @focus_threshold_active = true
+          return true
+        elsif @focus_threshold_active && weapon_training.any? { |skill, _| DRSkill.getxp(skill) < (@focus_threshold / 2) } then
+          # any weapon below threshold/2
+          DRC.message("Spreading attention to all weapons")
+          @target_action_count = settings.combat_trainer_action_count
+          @target_increment = settings.combat_trainer_target_increment
+          @focus_threshold_active = false
+          return true
+        end
       end
     end
-
     @action_count >= @target_action_count || current_exp >= @target_weapon_skill
   end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4886,7 +4886,7 @@ class GameState
         @target_increment = 34
         @focus_threshold_active = true
         return true
-      elsif @focus_threshold_active && weapon_training.any? { |skill, _| DRSkill.getxp(skill) < (@focus_threshold/2) } then
+      elsif @focus_threshold_active && weapon_training.any? { |skill, _| DRSkill.getxp(skill) < (@focus_threshold / 2) } then
         # any weapon below threshold/2
         DRC.message("Spreading attention to all weapons")
         @target_action_count = settings.combat_trainer_action_count

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4324,6 +4324,10 @@ class GameState
     @weapons_to_train.each { |skill_name, _weapon_name| @no_gain_list[skill_name] = 0 }
     echo("  @no_gain_list: #{@no_gain_list}") if $debug_mode_ct
 
+    @focus_threshold_active = false
+    @focus_threshold = settings.combat_trainer_focus_threshold
+    echo("  @focus_threshold: #{@focus_threshold}") if $debug_mode_ct
+
     @use_stealth_attacks = settings.use_stealth_attacks
     echo("  @use_stealth_attacks: #{@use_stealth_attacks}") if $debug_mode_ct
 
@@ -4858,6 +4862,36 @@ class GameState
 
       # if weapon is at 34, don't black list but do (try to) switch weapons.
       if current_exp == 34 then
+        return true
+      end
+    end
+
+    # focus_threshold code: if all the weapons being trained are above focus_threshold,
+    # @target_increment is set to 34 and @target_action_count to 1000.
+    # If at any time any weapon is at or below focus_threshold/2, parameters
+    # are restored to yaml values.  The divide by 2 is hysterisis to prevent this
+    # code from bouncing between the two states.  Focus_threshold has a min value of 10 to ensure
+    # a decent minimum hysterisis band.
+    # @focus_threshold is mapped to yaml value combat_trainer_focus_threshold
+    # Setting the yaml value turns this code on, it will remain dormant otherwise.
+    # 
+    # The code will allow CT to focus on a single weapon once we know all weapons are draining;
+    # the focus means there is no weapon switching costs being incurred.
+
+    if (@focus_threshold > 10) then
+      if !@focus_threshold_active && weapon_training.reject { |skill, _| DRSkill.getxp(skill) > @focus_threshold }.empty? then
+        # all weapons above threshold
+        DRC.message("Focussing on single weapon")
+        @target_action_count = 1000
+        @target_increment = 34
+        @focus_threshold_active = true
+        return true
+      elsif @focus_threshold_active && weapon_training.any? { |skill, _| DRSkill.getxp(skill) < (@focus_threshold/2) } then
+        # any weapon below threshold/2
+        DRC.message("Spreading attention to all weapons")
+        @target_action_count = settings.combat_trainer_action_count
+        @target_increment = settings.combat_trainer_target_increment
+        @focus_threshold_active = false
         return true
       end
     end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -381,6 +381,10 @@ combat_trainer_ignore_weapon_mindstate: false
 combat_trainer_target_increment: 3
 # how many actions to do if you dont hit the mindstate goal before swapping weapons
 combat_trainer_action_count: 10
+# minimum mindstate threshold (for all weapons being trained) to begin focussing on single weapons to minimise weapon switching.
+# default is 0 which means feature is not active.  Change to 10 or higher to activate.
+combat_trainer_focus_threshold: 0
+
 dual_load: false
 # use_stealth_attacks true will train stealth by hiding and attacking/backstabbing from stealth.  Thieves also use backstab: below
 use_stealth_attacks: false


### PR DESCRIPTION
The idea is that once all weapons being trained reach focus_threshold, CT will begin to focus solely on that single weapon.
This will stop the constant weapon switching that most people take for granted with a low target_increment value, and improve
gain efficiency for the typical CT user who is training everything.
Focus mode will disable once ANY skill drops below the threshold.

Initial testing seems ok, let this bake for a bit and/or take it out for a spin if you'd like.

More details are in the code comments.