### PR TITLE
[script][combat-trainer] YACTOM: "offhand_trainables"

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -208,7 +208,7 @@ class SetupProcess
       # define what mainhand skills look like
       mainhand_skills = $melee_skills + $thrown_skills + $martial_skills - game_state.aiming_trainables
 
-      # create selection pools of bow/mainhand/offhand groupings 
+      # create selection pools of bow/mainhand/offhand groupings
       bow_selection_pool = new_weapon_skills.select { |skill| $aim_skills.include?(skill) && DRSkill.getxp(skill) < 30 }
       mainhand_selection_pool = new_weapon_skills.select { |skill| mainhand_skills.include?(skill) && DRSkill.getxp(skill) < 30 }
       offhand_selection_pool = new_weapon_skills.select { |skill| game_state.aiming_trainables.include?(skill) && DRSkill.getxp(skill) < 30 }

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -31,6 +31,9 @@ class SetupProcess
     echo("  @ignore_weapon_mindstate: #{@ignore_weapon_mindstate}") if $debug_mode_ct
     @gearsets = settings.gear_sets
 
+    @offhand_trainables = settings.combat_trainer_offhand_trainables
+    echo("  @offhand_trainables: #{@offhand_trainables}") if $debug_mode_ct
+
     validate_regalia(settings)
   end
 
@@ -188,7 +191,49 @@ class SetupProcess
 
     # Exclude current skill so that a new one is selected.
     new_weapon_skills = weapon_training.keys.reject { |skill| skill == game_state.weapon_skill }
-    new_weapon_skill = game_state.sort_by_rate_then_rank(new_weapon_skills, @priority_weapons).first
+
+    # optional & advanced feature:
+    # offhand_trainables is used to preference bows first, and aiming_trainables in mainhand last, to indirectly force
+    # aiming_trainables to be used in the offhand rather than pushing out the training for mainhand only weapons.  
+    # It is only active when focus_threshold is active, after all the mindstates are off zero and have a drain buffer.
+    # There are three selection pools, one for bows, one for mainhand and one for aiming_trainables in mainhand, and skill is chosen
+    # preferentially in that order
+    # Each selection pool has a threshold that is needed to "break out" of a selection pool.  e.g. when all bow weapons are > 30
+    # the code will move onto the mainhand selection pool.
+    # 30 is a magic number and there are multiple factors determining what would be an optimal value, which may not practically 
+    # exist for the wide range of CT use cases.
+
+    if @offhand_trainables && game_state.focus_threshold_active then
+
+      # define what mainhand skills look like
+      mainhand_skills = $melee_skills + $thrown_skills + $martial_skills - game_state.aiming_trainables
+
+      # create selection pools of bow/mainhand/offhand groupings 
+      bow_selection_pool = new_weapon_skills.select {|skill| $aim_skills.include?(skill) && DRSkill.getxp(skill) < 30 }
+      mainhand_selection_pool = new_weapon_skills.select {|skill| mainhand_skills.include?(skill) && DRSkill.getxp(skill) < 30 }
+      offhand_selection_pool = new_weapon_skills.select {|skill| game_state.aiming_trainables.include?(skill) && DRSkill.getxp(skill) < 30 }
+
+      echo("bow_selection_pool #{bow_selection_pool}") if $debug_mode_ct
+      echo("mainhand_selection_pool #{mainhand_selection_pool}") if $debug_mode_ct
+      echo("offhand_selection_pool #{offhand_selection_pool}") if $debug_mode_ct
+
+      if bow_selection_pool.length > 0 then
+        # choose a bow from this restricted pool (i.e. preferencing bow)
+        new_weapon_skill = game_state.sort_by_rate_then_rank(bow_selection_pool).first
+      elsif mainhand_selection_pool.length > 0 then
+        # choose a mainhander from this restricted pool (once bows are done)
+        new_weapon_skill = game_state.sort_by_rate_then_rank(mainhand_selection_pool).first
+      elsif offhand_selection_pool.length > 0 then
+        # choose an offhand weapon (wielded in the main hand) from this restricted pool
+        new_weapon_skill = game_state.sort_by_rate_then_rank(offhand_selection_pool).first
+      else
+        # use normal selection method as a default when everything is above 30 as maintenance
+        new_weapon_skill = game_state.sort_by_rate_then_rank(new_weapon_skills, @priority_weapons).first
+      end
+    else
+      # normal selection method
+      new_weapon_skill = game_state.sort_by_rate_then_rank(new_weapon_skills, @priority_weapons).first
+    end
 
     # Update weapon skill to train next, if a new one was chosen.
     # If you're training exactly one weapon then won't change.

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -203,7 +203,7 @@ class SetupProcess
     # 30 is a magic number and there are multiple factors determining what would be an optimal value, which may not practically
     # exist for the wide range of CT use cases.
 
-    if @offhand_trainables && game_state.focus_threshold_active then
+    if @offhand_trainables && game_state.focus_threshold_active
 
       # define what mainhand skills look like
       mainhand_skills = $melee_skills + $thrown_skills + $martial_skills - game_state.aiming_trainables
@@ -217,13 +217,13 @@ class SetupProcess
       echo("mainhand_selection_pool #{mainhand_selection_pool}") if $debug_mode_ct
       echo("offhand_selection_pool #{offhand_selection_pool}") if $debug_mode_ct
 
-      if bow_selection_pool.length > 0 then
+      if bow_selection_pool.length > 0
         # choose a bow from this restricted pool (i.e. preferencing bow)
         new_weapon_skill = game_state.sort_by_rate_then_rank(bow_selection_pool).first
-      elsif mainhand_selection_pool.length > 0 then
+      elsif mainhand_selection_pool.length > 0
         # choose a mainhander from this restricted pool (once bows are done)
         new_weapon_skill = game_state.sort_by_rate_then_rank(mainhand_selection_pool).first
-      elsif offhand_selection_pool.length > 0 then
+      elsif offhand_selection_pool.length > 0
         # choose an offhand weapon (wielded in the main hand) from this restricted pool
         new_weapon_skill = game_state.sort_by_rate_then_rank(offhand_selection_pool).first
       else

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -194,13 +194,13 @@ class SetupProcess
 
     # optional & advanced feature:
     # offhand_trainables is used to preference bows first, and aiming_trainables in mainhand last, to indirectly force
-    # aiming_trainables to be used in the offhand rather than pushing out the training for mainhand only weapons.  
+    # aiming_trainables to be used in the offhand rather than pushing out the training for mainhand only weapons.
     # It is only active when focus_threshold is active, after all the mindstates are off zero and have a drain buffer.
     # There are three selection pools, one for bows, one for mainhand and one for aiming_trainables in mainhand, and skill is chosen
     # preferentially in that order
     # Each selection pool has a threshold that is needed to "break out" of a selection pool.  e.g. when all bow weapons are > 30
     # the code will move onto the mainhand selection pool.
-    # 30 is a magic number and there are multiple factors determining what would be an optimal value, which may not practically 
+    # 30 is a magic number and there are multiple factors determining what would be an optimal value, which may not practically
     # exist for the wide range of CT use cases.
 
     if @offhand_trainables && game_state.focus_threshold_active then
@@ -209,9 +209,9 @@ class SetupProcess
       mainhand_skills = $melee_skills + $thrown_skills + $martial_skills - game_state.aiming_trainables
 
       # create selection pools of bow/mainhand/offhand groupings 
-      bow_selection_pool = new_weapon_skills.select {|skill| $aim_skills.include?(skill) && DRSkill.getxp(skill) < 30 }
-      mainhand_selection_pool = new_weapon_skills.select {|skill| mainhand_skills.include?(skill) && DRSkill.getxp(skill) < 30 }
-      offhand_selection_pool = new_weapon_skills.select {|skill| game_state.aiming_trainables.include?(skill) && DRSkill.getxp(skill) < 30 }
+      bow_selection_pool = new_weapon_skills.select { |skill| $aim_skills.include?(skill) && DRSkill.getxp(skill) < 30 }
+      mainhand_selection_pool = new_weapon_skills.select { |skill| mainhand_skills.include?(skill) && DRSkill.getxp(skill) < 30 }
+      offhand_selection_pool = new_weapon_skills.select { |skill| game_state.aiming_trainables.include?(skill) && DRSkill.getxp(skill) < 30 }
 
       echo("bow_selection_pool #{bow_selection_pool}") if $debug_mode_ct
       echo("mainhand_selection_pool #{mainhand_selection_pool}") if $debug_mode_ct

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -381,6 +381,10 @@ combat_trainer_ignore_weapon_mindstate: false
 combat_trainer_target_increment: 3
 # how many actions to do if you dont hit the mindstate goal before swapping weapons
 combat_trainer_action_count: 10
+# Optional feature to preference using aiming_trainables on the offhand ONLY, to reduce competition from aiming_trainables using mainhand attacks
+# It is contingent on combat_trainer_focus_threshold being active.
+combat_trainer_offhand_trainables: false
+
 dual_load: false
 # use_stealth_attacks true will train stealth by hiding and attacking/backstabbing from stealth.  Thieves also use backstab: below
 use_stealth_attacks: false


### PR DESCRIPTION
This optional - and its kind of advance-ish  - feature is turned on by combat_trainer_offhand_trainables: true in yaml.

It will intentionally preference loadable weapons (bow, xbow, sling) first, all weapons which are NOT aiming_trainables second, and aiming_trainables last.  This indirectly forces skills tagged for aiming_trainables to be used in the offhand, and not take up valuable time being wielded in the mainhand and competing for timeslots with other mainhand/twohand only weapons.

It has a functional dependency on focus_threshold feature in PR #7071, requiring focus to be active.  This means that the preferencing will NOT start until all mindstates have achieved some minimum value, to ensure all weapons are draining. 
