### PR TITLE
[script][combat-trainer] Updates for focus_threshold, offhand_trainables

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -208,13 +208,14 @@ class SetupProcess
 
     if @offhand_trainables && game_state.focus_threshold_active
 
-      # define what mainhand skills look like
+      # define what mainhand and offhand skills look like
       mainhand_skills = $melee_skills + $thrown_skills + $martial_skills - game_state.aiming_trainables
+      offhand_skills = game_state.aiming_trainables + ['Offhand Weapon']
 
       # create selection pools of bow/mainhand/offhand groupings
       bow_selection_pool = new_weapon_skills.select { |skill| $aim_skills.include?(skill) && DRSkill.getxp(skill) < 30 }
       mainhand_selection_pool = new_weapon_skills.select { |skill| mainhand_skills.include?(skill) && DRSkill.getxp(skill) < 30 }
-      offhand_selection_pool = new_weapon_skills.select { |skill| game_state.aiming_trainables.include?(skill) && DRSkill.getxp(skill) < 30 }
+      offhand_selection_pool = new_weapon_skills.select { |skill| offhand_skills.include?(skill) && DRSkill.getxp(skill) < 30 }
 
       echo("bow_selection_pool #{bow_selection_pool}") if $debug_mode_ct
       echo("mainhand_selection_pool #{mainhand_selection_pool}") if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4960,8 +4960,6 @@ class GameState
         @target_increment = settings.combat_trainer_target_increment
         @focus_threshold_active = false
         return true
-      else
-        return false
       end
     end
     @action_count >= @target_action_count || current_exp >= @target_weapon_skill

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4944,7 +4944,7 @@ class GameState
     # The code will allow CT to focus on a single weapon once we know all weapons are draining;
     # the focus means there is no weapon switching costs being incurred.
 
-    if (@focus_threshold > 10)
+    if (@focus_threshold >= 10)
       if !@focus_threshold_active && weapon_training.reject { |skill, _| DRSkill.getxp(skill) > @focus_threshold }.empty?
         # all weapons above threshold
         DRC.message("Focussing on single weapon")


### PR DESCRIPTION
This is a running list to track items so I don't forget, **please don't merge yet** these are non-fatal issues. 

focus_threshold - min threshold check should be >= 10 rather than > 10 
offhand_trainables - offhand skills selection pool to include .... "Offhand Weapon"
focus_threshold - an errant return false removed, it cause behaviour similar to a focus_threshold of zero 