### PR TITLE
[script][combat-trainer]  Updates for focus_threshold

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4310,6 +4310,7 @@ class GameState
 
     @target_action_count = settings.combat_trainer_action_count
     echo("  @target_action_count: #{@target_action_count}") if $debug_mode_ct
+    @target_action_count_original = @target_action_count
 
     @dance_threshold = settings.dance_threshold.to_i
     echo("  @dance_threshold: #{@dance_threshold}") if $debug_mode_ct
@@ -4337,6 +4338,7 @@ class GameState
 
     @target_increment = settings.combat_trainer_target_increment
     echo("  @target_increment: #{@target_increment}") if $debug_mode_ct
+    @target_increment_original = @target_increment
 
     @gain_check = settings.combat_trainer_gain_check
     echo("  @gain_check: #{@gain_check}") if $debug_mode_ct
@@ -4956,8 +4958,8 @@ class GameState
       elsif @focus_threshold_active && weapon_training.any? { |skill, _| DRSkill.getxp(skill) < (@focus_threshold / 2) }
         # any weapon below threshold/2
         DRC.message("Spreading attention to all weapons")
-        @target_action_count = settings.combat_trainer_action_count
-        @target_increment = settings.combat_trainer_target_increment
+        @target_action_count = @target_action_count_original
+        @target_increment = @target_increment_original
         @focus_threshold_active = false
         return true
       end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4945,7 +4945,7 @@ class GameState
     # The code will allow CT to focus on a single weapon once we know all weapons are draining;
     # the focus means there is no weapon switching costs being incurred.
 
-    if (@focus_threshold >= 10)
+    if (@focus_threshold > 1)
       if !@focus_threshold_active && weapon_training.reject { |skill, _| DRSkill.getxp(skill) > @focus_threshold }.empty?
         # all weapons above threshold
         DRC.message("Focussing on single weapon")


### PR DESCRIPTION
 updates

1.  The hard minimum for focus_threshold may be too conservative.  A value of ~4 may be workable for a weapon tert.  For other skillset placements focus_threshold may need to be higher to account for drain whilst stuck on a weapon going for 34/34 (so you don't end up with 0 ms on a skill with no ability to correct until the 34 is done).  Setting the minimum to say > 1 gives the player freedom to set what is needed for their char and specific circumstances. 
2. Conditional CT break bug fix (if focus_threshold was activated + the bottom of the hysterisis band was reached).  Rookie mistake :(