### PR TITLE
[script][combat-trainer] magic_gain_check

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1314,7 +1314,7 @@ class SpellProcess
     @magic_last_exp = -1
     @magic_last_exp_sorc = -1
 
-    @magic_gain_check = settings.combat_trainer_magic_gain_check || 3
+    @magic_gain_check = settings.combat_trainer_magic_gain_check
     echo("  @magic_gain_check: #{@magic_gain_check}") if $debug_mode_ct
     
     @magic_no_gain_list = Hash.new(0)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2160,10 +2160,10 @@ class SpellProcess
       # set/reset spell mindstate tracking data
       @magic_last_spell = data
       # if there is a spell to cast, snapshot the spell and mindstate
-      @magic_last_exp = data.nil? ? -1 : DRSkill.getxp(data['skill']) 
+      @magic_last_exp = data.nil? ? -1 : DRSkill.getxp(data['skill'])
 
       prepare_spell(data, game_state)
-    end
+  end
 
     Flags.reset('ct-spelllost')
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2098,7 +2098,7 @@ class SpellProcess
     echo "Blacklisting non-training spells:" if $debug_mode_ct
 
     # if there has been no gain from last cast, and its been flagged with cast_only_to_train its a little black cross against the skill
-    if (DRSkill.getxp(@magic_last_spell['skill']) <= @magic_last_exp) && @magic_last_spell['cast_only_to_train'] 
+    if (DRSkill.getxp(@magic_last_spell['skill']) <= @magic_last_exp) && @magic_last_spell['cast_only_to_train'] && (DRSkill.getxp(@magic_last_spell['skill']) < 34)
       @magic_no_gain_list[@magic_last_spell['skill']] += 1
     else
       @magic_no_gain_list[@magic_last_spell['skill']] = 0

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1308,6 +1308,16 @@ class SpellProcess
     echo("  @offensive_spell_cycle: #{@offensive_spell_cycle}") if $debug_mode_ct
 
     @CST_before = true
+    @magic_last_spell = nil
+    @magic_last_exp = -1
+    @magic_last_exp_sorc = -1
+
+    @magic_gain_check = settings.combat_trainer_magic_gain_check
+    echo("  @magic_gain_check: #{@magic_gain_check}") if $debug_mode_ct
+    
+    @magic_no_gain_list = Hash.new(0)
+    @offensive_spells.each { |spell| @magic_no_gain_list[spell['name']] = 0 }
+    echo("  @magic_no_gain_list: #{@magic_no_gain_list}") if $debug_mode_ct
 
     @necromancer_healing = settings.necromancer_healing
     echo("  @necromancer_healing: #{@necromancer_healing}") if $debug_mode_ct
@@ -1780,6 +1790,10 @@ class SpellProcess
     game_state.casting_cfb = false
     game_state.casting_cfw = false
     game_state.casting_cyclic = false
+
+    # once spell is cast, check on its mindstate performance and make decision if it needs blacklisting
+    blacklist_spells(game_state)
+
     if game_state.casting_sorcery
       game_state.casting_sorcery = false
       @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
@@ -1809,6 +1823,7 @@ class SpellProcess
 
     fput("command #{@command}")
     @command = nil
+
   end
 
   def check_spell_timer?(data)
@@ -2079,33 +2094,33 @@ class SpellProcess
     prepare_spell(data, game_state, true)
   end
 
+  def blacklist_spells(game_state)
+    return if game_state.casting
+
+    if @magic_gain_check > 0
+      echo "Blacklisting non-training spells:" if $debug_mode_ct
+
+      # if there has been no gain from last cast, its a little black cross against the spell
+      # right now, it checks for no gain of either spell skill OR sorcery skill (if sorcerous).  Logic will need refining in review / testing.
+      if (DRSkill.getxp(@magic_last_spell['skill']) <= @magic_last_exp || DRSkill.getxp('Sorcery') <= @magic_last_exp_sorc) 
+        @magic_no_gain_list[@magic_last_spell['name']] += 1
+      else
+        @magic_no_gain_list[@magic_last_spell['name']] = 0
+      end
+
+      # blacklist offensive spell by removing from @offensive_spells if threshold is exceeded
+      if (@magic_no_gain_list[@magic_last_spell['name']] > @magic_gain_check)
+        DRC.message("WARNING: Suppressing #{@magic_last_spell['name']} due to spell not training")
+       @offensive_spells.reject! { |spell| spell['name'] == @magic_last_spell['name'] }
+      end    
+    end
+  end
+
   def check_offensive(game_state)
     echo "Checking offensive spells:" if $debug_mode_ct
     return if game_state.casting
     return if game_state.npcs.empty?
     return if DRStats.mana < @offensive_spell_mana_threshold
-
-    @OST_gain_check = settings.ct_blah
-    @OST_last_spell = nil
-    @OST_last_exp = -1
-    @OST_last_exp_sorc = -1
-    @OST_no_gain_list = Hash.new(0)
-    @offensive_spells.each { |spell| @OST_no_gain_list[spell['name']] = 0 }
-    echo("  @OST_no_gain_list: #{@OST_no_gain_list}") if $debug_mode_ct
-
-    # if there has been no gain from last cast (there may be edge cases due to lag / long RT actions), its a little black cross against the skill
-    # right now, it checks for no gain of either spell skill OR sorcery skill (if sorcerous).  Logic will need refining in review / testing.
-    if (DRSkill.getxp(@magic_last_spell['skill']) <= @OST_last_exp || DRSkill.getxp('Sorcery') <= @OST_last_exp_sorc) 
-      @OST_no_gain_list[@magic_last_spell['name']] += 1
-    else
-      @OST_no_gain_list[@magic_last_spell['name']] = 0
-    end
-    
-    # blacklist offensive spell by removing from @offensive_spells if threshold is exceeded
-    if (@OST_no_gain_list[@OST_last_spell['name']] > @OST_gain_check)
-        DRC.message("WARNING: Suppressing #{@OST_last_spell['name']} due to spell not training")
-        @offensive_spells.reject! { |spell| spell['name'] == @OST_last_spell['name'] }
-    end
 
     echo "Figuring out ready offensive spells..." if $debug_mode_ct
     ready_spells = @offensive_spells
@@ -2148,14 +2163,14 @@ class SpellProcess
       end
     else
       # set/reset spell mindstate tracking data
-      @OST_last_spell = data
-      @OST_last_exp = -1
-      @OST_last_exp_sorc = -1
+      @magic_last_spell = data
+      @magic_last_exp = -1
+      @magic_last_exp_sorc = -1
       # if there is a spell to cast, snapshot the spell and mindstate
       unless data.nil?
         @CST_before = false # to force a switch to CST after this OST cast is done
-        @OST_last_exp = DRSkill.getxp(data['skill'])
-        @OST_last_exp_sorc = DRSkill.getxp('Sorcery') if spell_is_sorcery?(data)
+        @magic_last_exp = DRSkill.getxp(data['skill'])
+        @magic_last_exp_sorc = DRSkill.getxp('Sorcery') if spell_is_sorcery?(data)
       end
       prepare_spell(data, game_state)
     end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2085,6 +2085,28 @@ class SpellProcess
     return if game_state.npcs.empty?
     return if DRStats.mana < @offensive_spell_mana_threshold
 
+    @OST_gain_check = settings.ct_blah
+    @OST_last_spell = nil
+    @OST_last_exp = -1
+    @OST_last_exp_sorc = -1
+    @OST_no_gain_list = Hash.new(0)
+    @offensive_spells.each { |spell| @OST_no_gain_list[spell['name']] = 0 }
+    echo("  @OST_no_gain_list: #{@OST_no_gain_list}") if $debug_mode_ct
+
+    # if there has been no gain from last cast (there may be edge cases due to lag / long RT actions), its a little black cross against the skill
+    # right now, it checks for no gain of either spell skill OR sorcery skill (if sorcerous).  Logic will need refining in review / testing.
+    if (DRSkill.getxp(@magic_last_spell['skill']) <= @OST_last_exp || DRSkill.getxp('Sorcery') <= @OST_last_exp_sorc) 
+      @OST_no_gain_list[@magic_last_spell['name']] += 1
+    else
+      @OST_no_gain_list[@magic_last_spell['name']] = 0
+    end
+    
+    # blacklist offensive spell by removing from @offensive_spells if threshold is exceeded
+    if (@OST_no_gain_list[@OST_last_spell['name']] > @OST_gain_check)
+        DRC.message("WARNING: Suppressing #{@OST_last_spell['name']} due to spell not training")
+        @offensive_spells.reject! { |spell| spell['name'] == @OST_last_spell['name'] }
+    end
+
     echo "Figuring out ready offensive spells..." if $debug_mode_ct
     ready_spells = @offensive_spells
                    .select { |spell| spell['target_enemy'] ? game_state.npcs.include?(spell['target_enemy']) : true }
@@ -2125,8 +2147,17 @@ class SpellProcess
         return
       end
     else
+      # set/reset spell mindstate tracking data
+      @OST_last_spell = data
+      @OST_last_exp = -1
+      @OST_last_exp_sorc = -1
+      # if there is a spell to cast, snapshot the spell and mindstate
+      unless data.nil?
+        @CST_before = false # to force a switch to CST after this OST cast is done
+        @OST_last_exp = DRSkill.getxp(data['skill'])
+        @OST_last_exp_sorc = DRSkill.getxp('Sorcery') if spell_is_sorcery?(data)
+      end
       prepare_spell(data, game_state)
-      @CST_before = false unless data.nil?
     end
 
     Flags.reset('ct-spelllost')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2106,7 +2106,7 @@ class SpellProcess
     # blacklist offensive spell's skill by removing from @offensive_spells if threshold is exceeded
     # side effect is that any spells with cast_only_to_train not set will also get hit by blacklist (discord consensus 28/1/2025)
     if (@magic_no_gain_list[@magic_last_spell['skill']] > @magic_gain_check)
-      DRC.message("WARNING: Suppressing #{@magic_last_spell['skill']} due to spells within that skill that has cast_only_to_train set, not gaining mindstates.")
+      DRC.message("WARNING: Suppressing #{@magic_last_spell['skill']} due to cast_only_to_train spells within that skill not gaining mindstates.")
       @offensive_spells.reject! { |spell| spell['skill'] == @magic_last_spell['skill'] }
     end
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1318,7 +1318,7 @@ class SpellProcess
     echo("  @magic_gain_check: #{@magic_gain_check}") if $debug_mode_ct
     
     @magic_no_gain_list = Hash.new(0)
-    @offensive_spells.each { |spell| @magic_no_gain_list[spell['name']] = 0 }
+    @offensive_spells.each { |spell| @magic_no_gain_list[spell['skill']] = 0 }
     echo("  @magic_no_gain_list: #{@magic_no_gain_list}") if $debug_mode_ct
 
     @necromancer_healing = settings.necromancer_healing
@@ -2097,16 +2097,17 @@ class SpellProcess
 
     echo "Blacklisting non-training spells:" if $debug_mode_ct
 
-    # if there has been no gain from last cast, its a little black cross against the spell
+    # if there has been no gain from last cast, and its been flagged with cast_only_to_train its a little black cross against the skill
     if (DRSkill.getxp(@magic_last_spell['skill']) <= @magic_last_exp) && @magic_last_spell['cast_only_to_train'] 
-      @magic_no_gain_list[@magic_last_spell['name']] += 1
+      @magic_no_gain_list[@magic_last_spell['skill']] += 1
     else
-      @magic_no_gain_list[@magic_last_spell['name']] = 0
+      @magic_no_gain_list[@magic_last_spell['skill']] = 0
     end
 
     # blacklist offensive spell's skill by removing from @offensive_spells if threshold is exceeded
-    if (@magic_no_gain_list[@magic_last_spell['name']] > @magic_gain_check)
-      DRC.message("WARNING: Suppressing #{@magic_last_spell['skill']} due to #{@magic_last_spell['name']} not training and was marked cast_only_to_train")
+    # side effect is that any spells with cast_only_to_train not set will also get hit by blacklist (discord consensus 28/1/2025)
+    if (@magic_no_gain_list[@magic_last_spell['skill']] > @magic_gain_check)
+      DRC.message("WARNING: Suppressing #{@magic_last_spell['skill']} due to spells within that skill that has cast_only_to_train set, not gaining mindstates.")
       @offensive_spells.reject! { |spell| spell['skill'] == @magic_last_spell['skill'] }
     end
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1289,6 +1289,9 @@ class SpellProcess
     end
     echo("  @buff_spells: #{@buff_spells}") if $debug_mode_ct
 
+    @prioritize_offensive_spells = settings.prioritize_offensive_spells
+    echo("  @prioritize_offensive_spells: #{@prioritize_offensive_spells}") if $debug_mode_ct
+
     @offensive_spells = settings.offensive_spells
     echo("  @offensive_spells: #{@offensive_spells}") if $debug_mode_ct
 
@@ -1307,12 +1310,11 @@ class SpellProcess
     @offensive_spell_cycle = settings.offensive_spell_cycle
     echo("  @offensive_spell_cycle: #{@offensive_spell_cycle}") if $debug_mode_ct
 
-    @CST_before = true
     @magic_last_spell = nil
     @magic_last_exp = -1
     @magic_last_exp_sorc = -1
 
-    @magic_gain_check = settings.combat_trainer_magic_gain_check
+    @magic_gain_check = settings.combat_trainer_magic_gain_check || 3
     echo("  @magic_gain_check: #{@magic_gain_check}") if $debug_mode_ct
     
     @magic_no_gain_list = Hash.new(0)
@@ -1529,16 +1531,13 @@ class SpellProcess
     check_starlight(game_state)
     check_avtalia(game_state)
     check_buffs(game_state)
-
-    # alternates between CST and OST to give both groups of spells a chance to cast
-    if @CST_before
+    if @prioritize_offensive_spells
       check_offensive(game_state)
       check_training(game_state)
     else
       check_training(game_state)
       check_offensive(game_state)
     end
-
     check_current(game_state)
 
     false
@@ -1878,7 +1877,6 @@ class SpellProcess
       game_state.casting_sorcery = true
     end
     prepare_spell(data, game_state)
-    @CST_before = true unless data.nil?
     Flags.reset('ct-spelllost')
   end
 
@@ -2097,25 +2095,22 @@ class SpellProcess
   def blacklist_spells(game_state)
     return if game_state.casting
 
-    if @magic_gain_check > 0
-      echo "Blacklisting non-training spells:" if $debug_mode_ct
+    echo "Blacklisting non-training spells:" if $debug_mode_ct
 
-      # if there has been no gain from last cast, its a little black cross against the spell
-      # right now, it checks for no gain of either spell skill OR sorcery skill (if sorcerous).  Logic will need refining in review / testing.
-      if (DRSkill.getxp(@magic_last_spell['skill']) <= @magic_last_exp || DRSkill.getxp('Sorcery') <= @magic_last_exp_sorc) 
-        @magic_no_gain_list[@magic_last_spell['name']] += 1
-      else
-        @magic_no_gain_list[@magic_last_spell['name']] = 0
-      end
+    # if there has been no gain from last cast, its a little black cross against the spell
+    if (DRSkill.getxp(@magic_last_spell['skill']) <= @magic_last_exp) && @magic_last_spell['cast_only_to_train'] 
+      @magic_no_gain_list[@magic_last_spell['name']] += 1
+    else
+      @magic_no_gain_list[@magic_last_spell['name']] = 0
+    end
 
-      # blacklist offensive spell by removing from @offensive_spells if threshold is exceeded
-      if (@magic_no_gain_list[@magic_last_spell['name']] > @magic_gain_check)
-        DRC.message("WARNING: Suppressing #{@magic_last_spell['name']} due to spell not training")
-       @offensive_spells.reject! { |spell| spell['name'] == @magic_last_spell['name'] }
-      end    
+    # blacklist offensive spell's skill by removing from @offensive_spells if threshold is exceeded
+    if (@magic_no_gain_list[@magic_last_spell['name']] > @magic_gain_check)
+      DRC.message("WARNING: Suppressing #{@magic_last_spell['skill']} due to #{@magic_last_spell['name']} not training and was marked cast_only_to_train")
+      @offensive_spells.reject! { |spell| spell['skill'] == @magic_last_spell['skill'] }
     end
   end
-
+  
   def check_offensive(game_state)
     echo "Checking offensive spells:" if $debug_mode_ct
     return if game_state.casting
@@ -2164,14 +2159,9 @@ class SpellProcess
     else
       # set/reset spell mindstate tracking data
       @magic_last_spell = data
-      @magic_last_exp = -1
-      @magic_last_exp_sorc = -1
       # if there is a spell to cast, snapshot the spell and mindstate
-      unless data.nil?
-        @CST_before = false # to force a switch to CST after this OST cast is done
-        @magic_last_exp = DRSkill.getxp(data['skill'])
-        @magic_last_exp_sorc = DRSkill.getxp('Sorcery') if spell_is_sorcery?(data)
-      end
+      @magic_last_exp = data.nil? ? -1 : DRSkill.getxp(data['skill']) 
+      
       prepare_spell(data, game_state)
     end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1307,6 +1307,8 @@ class SpellProcess
     @offensive_spell_cycle = settings.offensive_spell_cycle
     echo("  @offensive_spell_cycle: #{@offensive_spell_cycle}") if $debug_mode_ct
 
+    @CST_before = true
+
     @necromancer_healing = settings.necromancer_healing
     echo("  @necromancer_healing: #{@necromancer_healing}") if $debug_mode_ct
 
@@ -1517,8 +1519,16 @@ class SpellProcess
     check_starlight(game_state)
     check_avtalia(game_state)
     check_buffs(game_state)
-    check_training(game_state)
-    check_offensive(game_state)
+
+    # alternates between CST and OST to give both groups of spells a chance to cast
+    if @CST_before
+      check_offensive(game_state)
+      check_training(game_state)
+    else
+      check_training(game_state)
+      check_offensive(game_state)
+    end
+
     check_current(game_state)
 
     false
@@ -1853,6 +1863,7 @@ class SpellProcess
       game_state.casting_sorcery = true
     end
     prepare_spell(data, game_state)
+    @CST_before = true unless data.nil?
     Flags.reset('ct-spelllost')
   end
 
@@ -2115,6 +2126,7 @@ class SpellProcess
       end
     else
       prepare_spell(data, game_state)
+      @CST_before = false unless data.nil?
     end
 
     Flags.reset('ct-spelllost')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2164,7 +2164,6 @@ class SpellProcess
 
       prepare_spell(data, game_state)
     end
-  end
 
     Flags.reset('ct-spelllost')
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1316,7 +1316,7 @@ class SpellProcess
 
     @magic_gain_check = settings.combat_trainer_magic_gain_check
     echo("  @magic_gain_check: #{@magic_gain_check}") if $debug_mode_ct
-    
+
     @magic_no_gain_list = Hash.new(0)
     @offensive_spells.each { |spell| @magic_no_gain_list[spell['skill']] = 0 }
     echo("  @magic_no_gain_list: #{@magic_no_gain_list}") if $debug_mode_ct
@@ -1822,7 +1822,6 @@ class SpellProcess
 
     fput("command #{@command}")
     @command = nil
-
   end
 
   def check_spell_timer?(data)
@@ -2111,7 +2110,7 @@ class SpellProcess
       @offensive_spells.reject! { |spell| spell['skill'] == @magic_last_spell['skill'] }
     end
   end
-  
+
   def check_offensive(game_state)
     echo "Checking offensive spells:" if $debug_mode_ct
     return if game_state.casting
@@ -2162,7 +2161,7 @@ class SpellProcess
       @magic_last_spell = data
       # if there is a spell to cast, snapshot the spell and mindstate
       @magic_last_exp = data.nil? ? -1 : DRSkill.getxp(data['skill']) 
-      
+
       prepare_spell(data, game_state)
     end
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2157,12 +2157,13 @@ class SpellProcess
         return
       end
     else
-      # set/reset spell mindstate tracking data
+      # track last spell for magic_gain_check
       @magic_last_spell = data
-      # if there is a spell to cast, snapshot the spell and mindstate
+      # if there is a spell to cast, snapshot the relevant skill's mindstate
       @magic_last_exp = data.nil? ? -1 : DRSkill.getxp(data['skill'])
 
       prepare_spell(data, game_state)
+    end
   end
 
     Flags.reset('ct-spelllost')

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -333,6 +333,9 @@ summoned_weapons_ingot:
 # See combat-trainer documentation above for some attributes.
 buff_spells:
 combat_buff_waggle:
+
+# Default setting is combat_spells will take priority over offensive_spells
+prioritize_offensive_spells: false
 # offensive_spells are what combat-trainer will use offensively.
 # See combat-trainer documentation above for some attributes.
 offensive_spells:

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -333,8 +333,7 @@ summoned_weapons_ingot:
 # See combat-trainer documentation above for some attributes.
 buff_spells:
 combat_buff_waggle:
-
-# Default setting is combat_spells will take priority over offensive_spells
+# Default setting is combat_spell_training: will take priority over offensive_spells:
 prioritize_offensive_spells: false
 # offensive_spells are what combat-trainer will use offensively.
 # See combat-trainer documentation above for some attributes.
@@ -396,6 +395,8 @@ combat_trainer_offhand_trainables: false
 # minimum mindstate threshold (for all weapons being trained) to begin focussing on single weapons to minimise weapon switching.
 # default is 0 which means feature is not active.  Change to 10 or higher to activate.
 combat_trainer_focus_threshold: 0
+# roughly number of consecutive spell casts of a single skill (e.g. Targeted Magic)that need to not gain mindstate (mob too low) before it is blacklisted.
+combat_trainer_magic_gain_check: 3
 
 dual_load: false
 # use_stealth_attacks true will train stealth by hiding and attacking/backstabbing from stealth.  Thieves also use backstab: below


### PR DESCRIPTION
1. Checking mindstate gains for OST spells and blacklisting skills if they're not performing. notionally this is enabled by cast_only_to_train for individual spells.  
    the threshold (consecutive gain fails) for blacklisting is defined by combat_trainer_magic_gain_check

2. added switch to flip priority between  OST and  CST 