### PR TITLE
[script][combat-trainer] CT fix for magic_gain_check

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1875,6 +1875,11 @@ class SpellProcess
       echo 'Preparing a sorcery spell, held items will be stowed to prevent item loss' if $debug_mode_ct
       game_state.casting_sorcery = true
     end
+
+    # clear magic_gain_check variables for CST as we're not doing that currently.
+    @magic_last_spell = nil
+    @magic_last_exp = -1
+
     prepare_spell(data, game_state)
     Flags.reset('ct-spelllost')
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2097,7 +2097,7 @@ class SpellProcess
     echo "Blacklisting non-training spells:" if $debug_mode_ct
 
     # if there has been no gain from last cast, and its been flagged with cast_only_to_train its a little black cross against the skill
-    if (DRSkill.getxp(@magic_last_spell['skill']) <= @magic_last_exp) && @magic_last_spell['cast_only_to_train'] && (DRSkill.getxp(@magic_last_spell['skill']) < 34)
+    if (DRSkill.getxp(@magic_last_spell['skill']) <= @magic_last_exp) && (@magic_last_spell['cast_only_to_train'] || @cast_only_to_train) && (DRSkill.getxp(@magic_last_spell['skill']) < 34)
       @magic_no_gain_list[@magic_last_spell['skill']] += 1
     else
       @magic_no_gain_list[@magic_last_spell['skill']] = 0

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1312,7 +1312,6 @@ class SpellProcess
 
     @magic_last_spell = nil
     @magic_last_exp = -1
-    @magic_last_exp_sorc = -1
 
     @magic_gain_check = settings.combat_trainer_magic_gain_check
     echo("  @magic_gain_check: #{@magic_gain_check}") if $debug_mode_ct

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1875,10 +1875,6 @@ class SpellProcess
       game_state.casting_sorcery = true
     end
 
-    # clear magic_gain_check variables for CST as we're not doing that currently.
-    @magic_last_spell = nil
-    @magic_last_exp = -1
-
     prepare_spell(data, game_state)
     Flags.reset('ct-spelllost')
   end
@@ -2113,6 +2109,10 @@ class SpellProcess
       DRC.message("WARNING: Suppressing #{@magic_last_spell['skill']} due to cast_only_to_train spells within that skill not gaining mindstates.")
       @offensive_spells.reject! { |spell| spell['skill'] == @magic_last_spell['skill'] }
     end
+
+    # clear magic_gain_check variables and wait for them to be set by the next applicable casting def (OST only at this point)
+    @magic_last_spell = nil
+    @magic_last_exp = -1
   end
 
   def check_offensive(game_state)


### PR DESCRIPTION
Error can only occur when OST and other casting defs are used at the same time.

The OST code was not clearing the magic_gain_check variables as a clean-up measure.  So everytime something else other than OST is called it "looks like" an OST spell was prepped, and naturally will end up blacklisting an OST skill once the blacklist counter tickers over.

separately: removed unused var
 