### PR TITLE
[script][combat-trainer] cleanup to include removing symb prep

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1485,9 +1485,11 @@ class SpellProcess
       end
       DRCA.release_cyclics(@settings.cyclic_no_release)
 
-      DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
-      DRC.bput('release symb', 'You release the', "But you haven't prepared a symbiosis") if @symbiosis
+      unless checkprep
+        DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+        DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+        DRC.bput('release symb', 'You release the', "But you haven't prepared a symbiosis") if @symbiosis
+      end
 
       if @tk_ammo
         waitrt?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1484,10 +1484,11 @@ class SpellProcess
         DRCA.segue?(@settings.segue_spell_on_stop, @settings.segue_prep_on_stop)
       end
       DRCA.release_cyclics(@settings.cyclic_no_release)
-      if checkprep != 'None'
-        DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
-        DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
-      end
+
+      DRC.bput('release spell', 'You let your concentration lapse', "You aren't preparing a spell")
+      DRC.bput('release mana', 'You release all', "You aren't harnessing any mana")
+      DRC.bput('release symb', 'You release the', "But you haven't prepared a symbiosis") if @symbiosis
+
       if @tk_ammo
         waitrt?
         pause


### PR DESCRIPTION
For some reason cleanup process was not getting rid of an in-progress spell's symb prep; this is a fix for that.  Also removed an orphan condition.

I've tested this ok on my char but I don't have access to !chaos symbs, which I understand has slightly different behaviour and possibly different messaging.

The main idea is of course to not accidentally wipe out your researched symb when CT ends its run.

Can someone test, verify and confirm with a comment here please?

