### PR TITLE
[data] [base-spells] missing failure message

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -73,6 +73,7 @@ prep_messages:
 - You shouldn't disrupt the area right now
 - You mutter incoherently
 - You are already preparing
+- But you're already preparing
 - You have already fully prepared
 - In a low tone you begin
 - You begin to chant a


### PR DESCRIPTION
Added missing failure message for targeted magic spells when already preparing a spell