### PR TITLE
[script][combat-trainer] Bypass the tendme script if devour is active

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1163,6 +1163,8 @@ class SafetyProcess
       echo("Couldn't tend bleeders after trying three times. Stopping hunt. Get healed!")
       $HUNTING_BUDDY.stop_hunting
       $COMBAT_TRAINER.stop
+    # special handling for devour - if its active, don't bother going to tendme.  Otherwise, fall through to tendme as the default
+    elsif DRSpells.active_spells['Devour'] && bleeding?
     elsif bleeding? && !Script.running?('tendme')
       echo('Checking for tendable bleeders...') if $debug_mode_ct
       if DRCH.has_tendable_bleeders?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1163,10 +1163,8 @@ class SafetyProcess
       echo("Couldn't tend bleeders after trying three times. Stopping hunt. Get healed!")
       $HUNTING_BUDDY.stop_hunting
       $COMBAT_TRAINER.stop
-    # special handling for devour - if its active, don't bother going to tendme.  Otherwise, fall through to tendme as the default
-    elsif DRSpells.active_spells['Devour'] && bleeding?
-      echo('Letting devour heal bleeders over time...') if $debug_mode_ct
-    elsif bleeding? && !Script.running?('tendme')
+    # If no heal-over-time spells are active then attempt to tend using ;tendme
+    elsif bleeding? && !Script.running?('tendme') && !(DRSpells.active_spells['Devour'] || DRSpells.active_spells['Heal'] || DRSpells.active_spells['Regenerate'])
       echo('Checking for tendable bleeders...') if $debug_mode_ct
       if DRCH.has_tendable_bleeders?
         DRC.wait_for_script_to_complete('tendme')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1165,6 +1165,7 @@ class SafetyProcess
       $COMBAT_TRAINER.stop
     # special handling for devour - if its active, don't bother going to tendme.  Otherwise, fall through to tendme as the default
     elsif DRSpells.active_spells['Devour'] && bleeding?
+      echo('Letting devour heal bleeders over time...') if $debug_mode_ct
     elsif bleeding? && !Script.running?('tendme')
       echo('Checking for tendable bleeders...') if $debug_mode_ct
       if DRCH.has_tendable_bleeders?

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1163,7 +1163,7 @@ class SafetyProcess
       echo("Couldn't tend bleeders after trying three times. Stopping hunt. Get healed!")
       $HUNTING_BUDDY.stop_hunting
       $COMBAT_TRAINER.stop
-    # If no heal-over-time spells are active then attempt to tend using ;tendme
+    # If no heal-over-time spells are active then attempt to tend bleeders using ;tendme
     elsif bleeding? && !Script.running?('tendme') && !(DRSpells.active_spells['Devour'] || DRSpells.active_spells['Heal'] || DRSpells.active_spells['Regenerate'])
       echo('Checking for tendable bleeders...') if $debug_mode_ct
       if DRCH.has_tendable_bleeders?


### PR DESCRIPTION
This resolves the tendme loop for necros under specific conditions.  If devour is active & char is bleeding, the safety code ignores the condition and allows devour to do its job.

Current behaviour is still in place for:
  * devour falls off at some point whilst bleed is still active
  * devour was not up in the first place when bleeding occurs (e.g. sorcery blows up hand)

With this mod, !redeemed necros should consider setting stop_hunting_if_bleeding: true like other chars.  If you happen to have devour up when sorcery goes wrong, your char will have a chance to just power through.  If devour is not up and sorcery goes wrong, then CT stops and segues into whatever you have next action you have.  

