### PR TITLE
[script][combat-trainer] Arbitrary condition checks for non-spell buffs

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2708,7 +2708,7 @@ class AbilityProcess
       timer = game_state.cooldown_timers[action]
 
       # break apart the blob into OG cooldown timer and the new optional conditional string using a fake && as a delimiter
-      blob_array = blob.to_s.split(/ && /,2)
+      blob_array = blob.to_s.split(/ && /, 2)
       cooldown = blob_array[0].to_i
       conditional = blob_array[1][1..-2] # strip out the leading and following double quotes
 

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2704,13 +2704,23 @@ class AbilityProcess
   end
 
   def check_nonspell_buffs(game_state)
-    @buffs.each do |action, cooldown|
+    @buffs.each do |action, blob|
       timer = game_state.cooldown_timers[action]
+
+      # break apart the blob into OG cooldown timer and the new optional conditional string using a delimiter that doesn't mess with Ruby code
+      blob_array = blob.to_s.split(/ &&& /)
+      cooldown = blob_array[0].to_i
+      conditional = blob_array[1][1..-2] # strip out the leading and following double quotes
+
       next unless !timer || (Time.now - timer).to_i > cooldown
 
       game_state.cooldown_timers[action] = Time.now
-      fput action
-      waitrt?
+
+      # do action if there is no conditional (OG behaviour), or do action if there is a conditional and it evaluated as true
+      if conditional.nil? || (conditional && eval(conditional))
+        fput action
+        waitrt?
+      end
     end
 
     @khri

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2707,8 +2707,8 @@ class AbilityProcess
     @buffs.each do |action, blob|
       timer = game_state.cooldown_timers[action]
 
-      # break apart the blob into OG cooldown timer and the new optional conditional string using a delimiter that doesn't mess with Ruby code
-      blob_array = blob.to_s.split(/ &&& /)
+      # break apart the blob into OG cooldown timer and the new optional conditional string using a fake && as a delimiter
+      blob_array = blob.to_s.split(/ && /,2)
       cooldown = blob_array[0].to_i
       conditional = blob_array[1][1..-2] # strip out the leading and following double quotes
 


### PR DESCRIPTION
A direct extension of the custom checks idea to non-spell buffs, to facilitate, amongst other things, conditional release of spells.
The original custom condition checks affects the start of a spell; this PR is used to affect the end of a spell (or to affect other non-spell buffs)

Example of original syntax (before PR).  This is still valid and completely functional post PR. 
```
buff_nonspells:
  release usol: 300
```

What the PR allows for:
```
buff_nonspells:
  release usol: 60 && "DRSpells.active_spells['Universal Solvent'] && DRSkill.getxp('Targeted Magic') > 30 && DRSkill.getxp('Thanatology') > 30 && DRSkill.getxp('First Aid') > 30 && DRSkill.getxp('Skinning') > 30"
```

The fake  " && "  is used as a delimiter after the timer value, and before the conditional wrapped up in double quotes.  This variant will shut down USOL only after achieving the defined mindstate targets, rather than based solely on the timer.  In this scenario, the timer is more of a polling period, determining how frequently a check is made on mindstate progress.
  