### PR TITLE
[script][yiamura][mining-buddy][mine] Add yiamura mining

### DIFF
--- a/mine.lic
+++ b/mine.lic
@@ -6,6 +6,12 @@ custom_require.call(%w[common common-crafting common-items events common-travel]
 
 class Mine
   def initialize
+    arg_definitions = [
+      [
+        { name: 'yiamura', regex: /yiamura/i, optional: true, description: 'Mine a single room using a yiamura gatherer' },
+      ]
+    ]
+    @args = parse_args(arg_definitions)
     Flags.add('mine-danger', 'The ground rumbles ominously', 'A bitter smell seeps into the air', 'The floor shudders briefly', 'continued mining .* hazardous', 'slightly dangerous because the ground')
     Flags.add('mine-exit', 'The entire wall of rock fractures at your blow and comes crashing down atop you')
     Flags.add('mine-pinned', 'You seem to be pinned in place', 'You finally manage to clear away enough rubble')
@@ -26,23 +32,42 @@ class Mine
     @bag = settings.crafting_container
     @bag_items = settings.crafting_items_in_container
     @belt = settings.forging_belt
+    @yiamura_resource_minimum = settings.mining_yiamura_resource_minimum + 1
+    Flags.add('yiamura-done', 'stills its flailing as it observes the area') if @args.yiamura
+    Flags.add('yiamura-gone', 'You sense the tether binding your') if @args.yiamura
+    @forage_item = settings.forage_item
     DRCI.stow_hands
     unless settings.adjustable_tongs && @mining_implement.include?('tongs') && DRCC.get_adjust_tongs?('reset shovel', @bag, @bag_items, @belt)
       @mining_implement.sub!(/.* tongs/, "shovel")
     end
-    DRCC.get_crafting_item(@mining_implement, @bag, @bag_items, @belt)
 
-    DRC.wait_for_script_to_complete('buff', ['mining'])
-    if DRStats.trader? && DRStats.circle >= 65
-      DRC.bput('speculate luck',
-               /^You focus your mind on the world around you/,
-               /^You are already focusing on the world around you/,
-               /^Your pattern-matching skills are still exhausted/,
-               /^The world already seems less chaotic and capricious than normal/)
+    unless @args.yiamura
+      DRCC.get_crafting_item(@mining_implement, @bag, @bag_items, @belt)
+
+      DRC.wait_for_script_to_complete('buff', ['mining'])
+      if DRStats.trader? && DRStats.circle >= 65
+        DRC.bput('speculate luck',
+                 /^You focus your mind on the world around you/,
+                 /^You are already focusing on the world around you/,
+                 /^Your pattern-matching skills are still exhausted/,
+                 /^The world already seems less chaotic and capricious than normal/)
+      end
     end
     DRC.bput('prospect', 'roundtime', 'You carefully scan')
 
-    @multiplier = @mining_implement =~ /pick/i ? 4 : 5
+    @multiplier = case
+                  when @args.yiamura
+                    20
+                  when @mining_implement =~ /pick/i
+                    4
+                  else
+                    5
+                  end
+
+    if @args.yiamura
+      exit if resource_level < @yiamura_resource_minimum
+      DRC.wait_for_script_to_complete('yiamura', ['point'])
+    end
 
     mine(@multiplier * resource_level)
     while DRC.bput('prospect careful', 'roundtime', 'You carefully scan')
@@ -54,7 +79,7 @@ class Mine
       mine(@multiplier * resource_level)
     end
 
-    DRCC.stow_crafting_item(@mining_implement, @bag, @belt)
+    DRCC.stow_crafting_item(@mining_implement, @bag, @belt) unless @args.yiamura
   end
 
   def resource_level
@@ -125,7 +150,12 @@ class Mine
       return
     end
 
-    DRC.bput('mine', 'roundtime')
+    if @args.yiamura
+      DRC.retreat
+      DRC.collect(@forage_item)
+    else
+      DRC.bput('mine', 'roundtime')
+    end
     pause @mining_attempt_timer
     waitrt?
 
@@ -145,6 +175,16 @@ class Mine
       end
     end
 
+    if Flags['yiamura-gone']
+      # Our 10 minutes are up
+      exit
+    elsif Flags['yiamura-done']
+      # We need to prospect again.
+      Flags.reset('yiamura-done')
+      count = 0
+      return
+    end
+
     mine(count - 1)
   end
 
@@ -158,6 +198,8 @@ before_dying do
   Flags.delete('mine-exit')
   Flags.delete('resource-level')
   Flags.delete('mine-pinned')
+  Flags.delete('yiamura-done')
+  Flags.delete('yiamura-gone')
 end
 
 Mine.new

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -6,6 +6,12 @@ custom_require.call(%w[common common-items common-crafting common-money common-t
 
 class MiningBuddy
   def initialize
+    arg_definitions = [
+      [
+        { name: 'yiamura', regex: /yiamura/i, optional: true, description: 'Mine a single room using a yiamura gatherer' },
+      ]
+    ]
+    @args = parse_args(arg_definitions)
     settings = get_settings
     @area_list = get_data('mining').mining_buddy_rooms
     @forging_belt = settings.forging_belt
@@ -24,6 +30,8 @@ class MiningBuddy
     @mine_repair_own_tools = settings.mine_repair_own_tools
     DRC.message("#{@areas}:#{@vein_list}") if UserVars.mining_debug
     Flags.add('proper-repair', 'Your excellent training in the ways of tool repair')
+
+    exit if @args.yiamura && Time.now() <= UserVars.yiamura['last_pointed'] + 7200
 
     # checks yaml settings against tools
     # corrects settings when tongs are wrongly set as adjustable, and/or when implement is tongs.
@@ -46,9 +54,11 @@ class MiningBuddy
         DRCC.stow_crafting_item('packet', @bag, @forging_belt)
       end
     end
-    check_repair
-    DRC.wait_for_script_to_complete('buff', ['mining-buddy'])
-    DRC.bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
+    unless @args.yiamura
+      check_repair
+      DRC.wait_for_script_to_complete('buff', ['mining-buddy'])
+      DRC.bput('speculate luck', '^You focus your mind on the world around you', '^You are already focusing on the world around you.', '^Your pattern-matching skills are still exhausted') if DRStats.trader? && DRStats.circle >= 65
+    end
     @areas.each { |area_name| mine_rooms(@area_list[area_name]) }
   end
 
@@ -91,11 +101,12 @@ class MiningBuddy
       DRC.wait_for_script_to_complete('safe-room') if bleeding?
       next unless mine?(room)
 
-      check_repair
+      check_repair unless @args.yiamura
     end
   end
 
   def mine?(room)
+    exit if @args.yiamura && Time.now() <= UserVars.yiamura['last_pointed'] + 7200
     waitrt?
     DRCT.walk_to(room)
     unless DRRoom.pcs.empty?
@@ -119,11 +130,11 @@ class MiningBuddy
                           .map(&:downcase)
                           .any? { |vein| @vein_list.map(&:downcase).include?(vein) }
     end
-
     waitrt?
 
-    DRC.wait_for_script_to_complete('mine')
-    DRC.wait_for_script_to_complete('buff', ['mining-buddy'])
+    DRC.wait_for_script_to_complete('mine', @args.yiamura ? ['yiamura'] : nil)
+    DRC.wait_for_script_to_complete('buff', ['mining-buddy']) unless @args.yiamura
+    
     true
   end
 end

--- a/mining-buddy.lic
+++ b/mining-buddy.lic
@@ -134,7 +134,7 @@ class MiningBuddy
 
     DRC.wait_for_script_to_complete('mine', @args.yiamura ? ['yiamura'] : nil)
     DRC.wait_for_script_to_complete('buff', ['mining-buddy']) unless @args.yiamura
-    
+
     true
   end
 end

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1231,6 +1231,9 @@ mining_attempt_timer: 0
 # If you have basic and/or advanced tool repair blacksmithing techniques, this allows you to repair mining tool in place, rather than returning
 # to town whenever a repair is necessary. Not recommended for use without those techs, requires wire brush and flask of oil.
 mine_repair_own_tools: false
+# If mining with a yiamura, what's the minimum acceptable level of resources the room should have before using it? Higher is more gathered 
+# material and more EXP, but may take longer to find a suitable room. Valid values are 0-5.
+mining_yiamura_resource_minimum: 4
 
 ## Locksmithing Settings ##
 # https://elanthipedia.play.net/Lich_script_repository#locksmithing

--- a/yiamura.lic
+++ b/yiamura.lic
@@ -6,7 +6,7 @@ class Yiamura
   def initialize
     arg_definitions = [
       [
-        { name: 'option', options: ['raise', 'observe', 'reset'], optional: true, description: 'Action to take.' }
+        { name: 'option', options: ['raise', 'point', 'observe', 'invoke', 'reset'], optional: true, description: 'Action to take.' }
       ]
     ]
 
@@ -15,13 +15,19 @@ class Yiamura
     UserVars.yiamura = {} unless UserVars.yiamura
     if args.option == "raise"
       raise_yiamura
+    elsif args.option == "point"
+      point_yiamura
     elsif args.option == "observe"
       observe_yiamura
+    elsif args.option == "invoke"
+      invoke_yiamura
     elsif args.option == "reset"
       UserVars.yiamura = {}
     else
       echo("Yiamura raised: #{UserVars.yiamura['last_raised']}")
+      echo("Yiamura pointed: #{UserVars.yiamura['last_pointed']}")
       echo("Yiamura last observed: #{UserVars.yiamura['last_observed'].nil? ? 'never' : UserVars.yiamura['last_observed']}")
+      echo("Yiamura last invoked: #{UserVars.yiamura['last_invoked'].nil? ? 'never' : UserVars.yiamura['last_invoked']}")
       echo("Yiamura last raised room: #{UserVars.yiamura['last_raised_room_id']}")
     end
   end
@@ -37,10 +43,30 @@ class Yiamura
     end
   end
 
+  def point_yiamura
+    case DRC.bput('point my yiamura', 'You grab the yiamura and direct it', 'You cannot use POINT until (.+)')
+    when /You cannot use POINT until (.+)/
+      if (date_match = $1.match(/\b\w{3} \w{3} +\d{1,2} \d{2}:\d{2}:\d{2} ET \d{4}\b/))
+        # Replace "ET" with "-0500" to indicate Eastern Time explicitly
+        formatted_date = date_match[0].gsub("ET", "-0500")
+        UserVars.yiamura['last_pointed'] = DateTime.strptime(formatted_date, "%a %b %e %H:%M:%S %z %Y").to_time - 7200 # 2 hour delay between points
+      end
+    else
+      UserVars.yiamura['last_pointed'] = Time.now
+    end
+  end
+
   def observe_yiamura
     case DRC.bput("observe my yiamura", /but nothing happens/, /Very quickly, your head reels as knowledge fills your mind/)
     when /Very quickly, your head reels as knowledge fills your mind/
       UserVars.yiamura['last_observed'] = Time.now
+    end
+  end
+
+  def invoke_yiamura
+    case DRC.bput("observe my yiamura", /but otherwise fails to respond/, /As you make contact with a /)
+    when /As you make contact with a /
+      UserVars.yiamura['last_invoked'] = Time.now
     end
   end
 end

--- a/yiamura.lic
+++ b/yiamura.lic
@@ -64,7 +64,7 @@ class Yiamura
   end
 
   def invoke_yiamura
-    case DRC.bput("observe my yiamura", /but otherwise fails to respond/, /As you make contact with a /)
+    case DRC.bput("invoke my yiamura", /but otherwise fails to respond/, /As you make contact with a /)
     when /As you make contact with a /
       UserVars.yiamura['last_invoked'] = Time.now
     end


### PR DESCRIPTION
This update allows the yiamura to be used in mining as a method of training Outdoorsmanship by running `mining-buddy yiamura`. It will take you to 1 room from your `mines_to_mine` list, summon the yiamura gatherer, and allow it to harvest the room. If the resources mined are in your `mining_buddy_vein_list`, it will store the materials like usual.

Although mining tools aren't necessary, you should still set the standard mining YAML settings if you haven't already, such as `mine_use_packet`, `mines_to_mine`, and `mining_buddy_vein_list`.

There is also one new optional YAML setting:
```yaml
mining_yiamura_resource_minimum: 4
```
Valid options are 0-5. This will ensure that the room you use your yiamura in has at least this amount of minable resources. Using it in 1/5 is a waste. Using it in 5/5 is ideal, but may take time to find a suitable room.

An example of how to incorporate this into your t2 training_list:
```yaml
- skill: Outdoorsmanship
  start: 15
  scripts:
  - yiamura invoke
  - mining-buddy yiamura
  - gosafe
  - outdoorsmanship
```

This starts by absorbing any stored gathering experience (`yiamura invoke`), and then attempts to gather more (`mining-buddy yiamura`). If your yiamura gatherer is still on the 2 hour cooldown, `mining-buddy yiamura` will exit immediately, so it's good to have a backup method of training like `outdoorsmanship`.