### PR TITLE
[script][combat-trainer] Added ability to import mob nouns for undeads and constructs

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4628,6 +4628,20 @@ class GameState
 
     @undead_mode = settings.undead || false
     echo("  @undead_mode: #{@undead_mode}") if $debug_mode_ct
+
+    extract = get_data('mobs')
+
+    @import_constructs_list = settings.import_constructs_list || false
+    echo("  @import_constructs_list: #{@import_constructs_list}") if $debug_mode_ct
+
+    @import_undeads_list = settings.import_undeads_list || false
+    echo("  @import_undeads_list: #{@import_undeads_list}") if $debug_mode_ct
+
+    @constructs = @import_constructs_list ? extract['constructs'] : []
+    echo("  @constructs: #{@constructs}") if $debug_mode_ct
+
+    @undeads = @import_undeads_list ? extract['undeads'] : []
+    echo("  @undeads: #{@undeads}") if $debug_mode_ct
   end
 
   def next_clean_up_step
@@ -5098,12 +5112,23 @@ class GameState
     @no_dissect.push(mob_noun)
   end
 
-  def construct?(mob_noun)
-    @constructs.include?(mob_noun)
+  def construct?(mob_noun = nil)
+    return @constructs.include?(mob_noun) if mob_noun
+    # for use by must_be_true without arg -> find the first npc that's not on ignore list
+    @constructs.include?(npcs.first)
   end
 
   def construct(mob_noun)
     @constructs.push(mob_noun)
+  end
+
+  def undead?(mob_noun = nil)
+    return @undeads.include?(mob_noun) if mob_noun
+    @undeads.include?(npcs.first)
+  end
+
+  def undead(mob_noun)
+    @undeads.push(mob_noun)
   end
 
   def stabbable?(mob_noun)

--- a/data/base-mobs.yaml
+++ b/data/base-mobs.yaml
@@ -1,0 +1,13 @@
+---
+undeads:
+- skeleton
+- zombie
+- ghoul
+- lich
+- wight
+- nightcrawler
+
+constructs:
+- mouse
+- origami
+- gargoyle


### PR DESCRIPTION
construct? (existing def) and undead? (new def) can now 
1. check a mob name against the list imported from base-mobs.yaml (if the mob name is passed in the argument), or
2. check the first non-ignored npc in the room against the list imported from base-mobs

To enable the import function, settings import_constructs_list: true and import_undeads_list: true are needed in the char yaml.

base-mobs has been pre-populated with test/sample entries, they need to be replaced with real lists.

Use 1 is typically for internal use within CT
Use 2 is typically for the must_be_true setting associated with CT spells
```
offensive_spells:
- skill: Targeted Magic
  name: Harm Horde
  ... stuff ...
  must_be_true: "game_state.undead? && game_state.npcs.length > 2"
```
I've done some quick checks and the code is behaving as expected; ready for testers.