### PR TITLE
[script][combat-trainer] finalising 5792

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4050,7 +4050,7 @@ class AttackProcess
       when 'You must be closer', 'There is nothing else', 'What are you trying'
         game_state.engage
       end
-    else unless game_state.retreating?
+    elsif !game_state.retreating?
       pause 1
     end
   end

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2769,7 +2769,7 @@ class AbilityProcess
   def check_battle_cries(game_state)
     timer = game_state.cooldown_timers['Battle Cry']
     return unless !timer || (Time.now - timer).to_i > @battle_cry_cooldown
-    return unless game_state.npcs.length > 0
+    return unless game_state.can_face?
 
     Flags.reset('ct-battle-cry-not-facing')
 
@@ -3054,7 +3054,7 @@ class TrainerProcess
       waitrt?
       DRC.fix_standing
     when /^Tactics$/i
-      DRC.bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') unless game_state.npcs.empty? || game_state.retreating?
+      DRC.bput($tactics_actions.sample, 'roundtime', 'There is nothing else', 'Face what', 'You must be closer', 'You must be standing', 'Strangely, you don\'t feel like fighting right now', 'flying too high for you to attack') if game_state.can_engage?
     when /^Analyze$/i
       analyze(game_state, 0)
     when /^Hunt$/i
@@ -3116,7 +3116,7 @@ class TrainerProcess
       return if game_state.loaded
       game_state.sheath_whirlwind_offhand
       DRC.retreat
-      game_state.engage unless game_state.npcs.empty? || game_state.retreating?
+      game_state.engage
       DRC.collect(@forage_item)
       waitrt?
       game_state.wield_whirlwind_offhand
@@ -3188,7 +3188,7 @@ class TrainerProcess
 
     game_state.sheath_whirlwind_offhand if game_state.currently_whirlwinding
     DRC.retreat
-    game_state.engage unless game_state.npcs.empty? || game_state.retreating?
+    game_state.engage
     DRC.bput("get my #{@almanac}", 'You get', 'What were')
     if training_skill
       DRC.bput("turn #{@almanac} to #{training_skill}", 'You turn', 'You attempt to turn')
@@ -3331,7 +3331,7 @@ class TrainerProcess
   end
 
   def analyze(game_state, fail_count)
-    return if game_state.npcs.empty? || game_state.retreating?
+    return unless game_state.can_engage?
     return if fail_count > @analyze_retry_count
     return if DRSkill.getxp('Tactics') >= @combat_training_abilities_target
 
@@ -3980,7 +3980,7 @@ class AttackProcess
   def execute_aiming_action?(action, game_state)
     case DRC.bput(action, 'Roundtime', 'close enough', 'What are you', 'There is nothing', 'must be closer', 'Bumbling, you slip')
     when 'close enough', 'must be closer'
-      return false if game_state.retreating?
+      return false unless game_state.can_engage?
 
       game_state.engage
     when 'What are you', 'There is nothing'
@@ -4044,18 +4044,14 @@ class AttackProcess
   end
 
   def dance(game_state)
-    return if game_state.retreating?
-
-    if game_state.npcs.empty? || game_state.retreating?
-      pause 1
-    else
+    if game_state.can_engage?
       game_state.set_dance_queue
       case DRC.bput(game_state.next_dance_action, 'You must be closer', 'There is nothing else', 'What are you trying', /.*/)
       when 'You must be closer', 'There is nothing else', 'What are you trying'
         game_state.engage
       end
-      pause 0.5
-      waitrt?
+    else unless game_state.retreating?
+      pause 1
     end
   end
 
@@ -4203,6 +4199,7 @@ class CombatTrainer
         { name: 'debug', regex: /debug/i, optional: true },
         { name: 'construct', regex: /construct/i, optional: true, description: 'Construct setting to override empath no attack settings.' },
         { name: 'undead', regex: /undead/i, optional: true, description: 'Allows hunting of undead by empaths when absolution is up.' },
+        { name: 'innocence', regex: /innocence/i, optional: true, description: 'Allows an empath using Innocence to avoid taking actions that end the spell.' },
         { name: 'dance', display: 'd#', regex: /d\d+/i, optional: true, description: 'Dance threshold, d2 would keep two enemies alive.' },
         { name: 'retreat', display: 'r#', regex: /r\d+/i, optional: true, description: 'Retreat threshold, r3 would stay at range with three or more enemies' }
       ]
@@ -4214,6 +4211,7 @@ class CombatTrainer
 
     settings.construct = args.construct
     settings.undead = args.undead
+    settings.innocence = args.innocence
 
     settings.debug_mode = args.debug
     set_dance(args.dance, settings)
@@ -4645,6 +4643,9 @@ class GameState
     @undead_mode = settings.undead || false
     echo("  @undead_mode: #{@undead_mode}") if $debug_mode_ct
 
+    @innocence_mode = settings.innocence(false)
+    echo("  @innocence_mode: #{@innocence_mode}") if $debug_mode_ct
+
     extract = get_data('mobs')
 
     @import_constructs_list = settings.import_constructs_list || false
@@ -4684,6 +4685,20 @@ class GameState
 
   def cleaning_up?
     !@clean_up_step.nil?
+  end
+
+  def can_engage?
+    return false unless can_face?
+    return false if retreating?
+
+    true
+  end
+
+  def can_face?
+    return false if @innocence_mode
+    return false if npcs.empty?
+
+    true
   end
 
   def is_offense_allowed?
@@ -4765,7 +4780,7 @@ class GameState
   end
 
   def engage
-    return if retreating?
+    return unless can_engage?
     return if stomp
     return if pounce
 
@@ -5695,6 +5710,7 @@ class GameState
   def perform_analyze?(combo_type, expertise_requirement)
     return false if combo_type != 'flame' && !Flags["ct-#{combo_type}-ready"] && DRStats.barbarian?
     return false if DRSkill.getrank('Expertise') < expertise_requirement
+    return false unless can_engage?
 
     result = DRC.bput("analyze #{combo_type}", 'cannot repeat', 'Analyze what\?', 'by landing an? .*', 'You need to hold', 'You must be closer', 'You fail to find any', 'What are you trying to attack\?')
     waitrt?


### PR DESCRIPTION
Used what was done to date, applied a bit of new thinking (more of consolidation?) to land at proposed changes:

* incorporated can_engage? into def engage.  This provides the most "coverage" out of all the edits.

* There are some cases where CT does engagey/facey things that aren't put("engage",....)  before checking can_engage? like dance.  Dance specifically is covered, and hopefully we collectively picked up all the cases that need to be covered.

* There are some mutually exclusive things that use the new can_engage? and can_face? predicates, purely because I thought it made things a bit more readable.  They should have zero impact other than readability and some minor protection against YAML misconfiguration (e.g. having tactics configured)  Didn't go so far as to check innocence_mode on necro rituals though!

* Left out a couple of original changes because I was confident they were already covered by other conditions.