### PR TITLE
[script][hunting-buddy] allow multiple HB configs in same file

### DIFF
--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -58,7 +58,7 @@ class HuntingBuddy
     echo("  hunting_files: #{hunting_files}") if $debug_mode_hunting
 
     hunting_files.each do |character_file_suffix|
-      infos = get_settings([character_file_suffix]).hunting_info
+      infos = retrieve_settings(character_file_suffix)
       infos.each do |info|
         info['args'] ||= []
         # Hunting info from extra config needs the config name passed on in args
@@ -68,6 +68,16 @@ class HuntingBuddy
         end
       end
       @hunting_info += infos
+    end
+  end
+
+  # make it possible to have all hunting profiles in single file (assuming true multiple yamls aren't needed)
+  def retrieve_settings(character_file_suffix)
+    if @settings.hunting_profiles_single_yaml
+      suffix = character_file_suffix == 'setup' ? '' : '_'+character_file_suffix
+      return eval('@settings.hunting_info'+suffix)
+    else
+      return get_settings([character_file_suffix]).hunting_info
     end
   end
 

--- a/hunting-buddy.lic
+++ b/hunting-buddy.lic
@@ -74,8 +74,8 @@ class HuntingBuddy
   # make it possible to have all hunting profiles in single file (assuming true multiple yamls aren't needed)
   def retrieve_settings(character_file_suffix)
     if @settings.hunting_profiles_single_yaml
-      suffix = character_file_suffix == 'setup' ? '' : '_'+character_file_suffix
-      return eval('@settings.hunting_info'+suffix)
+      suffix = character_file_suffix == 'setup' ? '' : '_' + character_file_suffix
+      return eval('@settings.hunting_info' + suffix)
     else
       return get_settings([character_file_suffix]).hunting_info
     end


### PR DESCRIPTION
hunting_profiles_single_yaml: true  will allow multiple HB configs in the same file, by attaching the charname-suffix to hunting_info instead.  See example below

```
hunting_profiles_single_yaml: true

hunting_info:               # default HB profile for circle hunt (TM/Thana/FA/Skin/etc)
- :zone:
  - elder_blue_dappled_prereni
  args:
  :duration: 5
  avoid_buddies: true

hunting_info_weapon:        # HB profile for weapon hunt
- :zone:
  - the_other_elder_blue_dappled_prereni
  args:
  :duration: 6
  avoid_buddies: true
```
The 2nd profile is accessed when ";hunting-buddy weapon" is called, rather than loading char-weapon.yaml.  Obviously this won't have the benefit of actually loading char-weapon.yaml with all of its non-HB settings that could be paired with the 'weapon' HB profile.  The benefit is that it makes it much easier to edit, everything being located in the -setup yaml.