### PR TITLE
chore: GitHub action workflow update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,11 +22,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Install ruby gem dependencies with bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
       - name: Release updates to Tillmen's Lich repository
         env:
           AUTHOR: ${{ secrets.repo_author }}

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45
@@ -34,18 +33,10 @@ jobs:
           files: |
             *.lic
             *.rb
-
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Install ruby gem dependencies with bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-
-      - run: bundle install
       - name: Rubocop
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do

--- a/.github/workflows/ruby_syntax_checker.yml
+++ b/.github/workflows/ruby_syntax_checker.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45
@@ -35,18 +34,10 @@ jobs:
           files: |
             *.lic
             *.rb
-
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-
-      - name: Install ruby gem dependencies with bundler
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-
       - name: Run Ruby syntax check on changed scripts
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -20,13 +20,13 @@ jobs:
   validate-yaml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v45
         with:
           files: |
             data/*.yaml

--- a/noop.lic
+++ b/noop.lic
@@ -2,10 +2,10 @@
        A simple script to allow for learning elanthia-online integration
        with Github + CI environments.
 
-              author: elanthia-online
-                game: DragonRealms
-                tags: testing
-             version: 1.0.3
+             author: elanthia-online
+               game: DragonRealms
+               tags: testing
+            version: 1.0.3
 
                 To help contribute: https://github.com/elanthia-online/dr-scripts
 =end


### PR DESCRIPTION
Remove redundant `bundle install` usage since ruby\setup-ruby action handles this with proper caching. Also updated all actions to latest v# supported.