### PR TITLE
[script] [combat-trainer] refactor to account for DRCMM.peer_telescop…

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3455,9 +3455,9 @@ class TrainerProcess
       when 'The pain is too much'
         injured = true
       end
-    else    
-      full_pool = result.any? { |line| line.match?(Regexp.union(get_data('constellations').observe_full_messages) ) }
-      injured = result.any? { |line| line.match?(Regexp.union(get_data('constellations').observe_injured_messages) ) }
+    else
+      full_pool = result.any? { |line| line.match?(Regexp.union(get_data('constellations').observe_full_messages)) }
+      injured = result.any? { |line| line.match?(Regexp.union(get_data('constellations').observe_injured_messages)) }
     end
     case
     when full_pool

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3447,12 +3447,24 @@ class TrainerProcess
   end
 
   def observe
-    case DRCMM.peer_telescope
-    when "You believe you've learned all that you can about survival", 'Too many futures cloud your mind - you learn nothing.'
+    result = DRCMM.peer_telescope
+    if Gem::Version.new(LICH_VERSION) < Gem::Version.new('5.11.0')
+      case result
+      when "You believe you've learned all that you can about survival", 'Too many futures cloud your mind - you learn nothing.'
+        full_pool = true
+      when 'The pain is too much'
+        injured = true
+      end
+    else    
+      full_pool = result.any? { |line| line.match?(Regexp.union(get_data('constellations').observe_full_messages) ) }
+      injured = result.any? { |line| line.match?(Regexp.union(get_data('constellations').observe_injured_messages) ) }
+    end
+    case
+    when full_pool
       waitrt?
       DRCMM.store_telescope(@telescope_storage)
       check_predict
-    when 'The pain is too much'
+    when injured
       waitrt?
       DRCMM.store_telescope(@telescope_storage)
       @training_abilities.delete('Astro')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3448,7 +3448,7 @@ class TrainerProcess
 
   def observe
     result = DRCMM.peer_telescope
-    if Gem::Version.new(LICH_VERSION) < Gem::Version.new('5.11.0')
+    if Gem::Version.new(LICH_VERSION) <= Gem::Version.new('5.11.0')
       case result
       when "You believe you've learned all that you can about survival", 'Too many futures cloud your mind - you learn nothing.'
         full_pool = true


### PR DESCRIPTION
…e changes

Part 5 of 5 of a suite of astrology changes
-- Part 1: https://github.com/elanthia-online/lich-5/pull/783 common-moonmage - update to peer_telescope for multi-line parsing of observation results
-- Part 2: #7127 base - addition of settings support for astrology and walkingastro changes
-- Part 3: #7125 astrology - refactor to account for peer_telescope change and addition of option to force vision predictions
-- Part 4: #7124 walkingastro - extensive quality of life changes to default behaviour and new optional features
-- Part 5: #7126 combat-trainer - refactor to account for peer_telescope change, no change to function