### PR TITLE
[data] [base] Updates for changes to walkingastro and astrology

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2215,6 +2215,7 @@ walkingastro_no_use_scripts:
   - combat-trainer
   - craft
   - enchant
+  - faskinner
   - first-aid
   - forge
   - go2

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1981,6 +1981,9 @@ astrology_training:
   - weather
   - attunement
   #- events
+#Allows user to force visions even if divination_tool is set rather than having to delete the settings.
+#Useful if another script makes use of the tool settings and still wants to them.
+astrology_force_visions: false
 
 astrology_prediction_skills:
   defense: defense
@@ -1988,6 +1991,22 @@ astrology_prediction_skills:
   magic: magic
   offense: offense
   survival: survival
+
+#settings for the ;walkingastro script
+# Recommended to add Piercing Gaze to the walkingastro waggle set. 
+# Clear Vision and Aura Sight are also useful there, but not as necessary.
+walkingastro:
+  startup_delay: 10
+  use_tools: true
+  use_partial_pools: false
+# Setting walkingastro_predict_regardless_of_mindstate to true is meant to allow 
+# passive tool bonding via more frequent predictions, so also set 
+# walkingastro_use_partial_pools to false to maximize the chance of a bond if using it for that purpose.
+# Recommended to add Destiny Cipher to the walkingastro waggle set for this purpose as well.
+  predict_regardless_of_mindstate: true
+# Set to true if you want to analyze your divination tool after every prediction.
+# Only useful for logging prediction tracking, does not add any in-game benefit.
+  analyze_divination_tool: true
 
 learned_column_count: 2
 sort_auto_head: true
@@ -2189,7 +2208,6 @@ walkingastro_no_use_scripts:
   - alchemy
   - astrology
   - athletics
-  - attunement
   - bescort
   - burgle
   - buff
@@ -2197,14 +2215,15 @@ walkingastro_no_use_scripts:
   - combat-trainer
   - craft
   - enchant
-  - faskinner
   - first-aid
   - forge
+  - go2
+  - hunting-buddy
   - mech-lore
-  - outdoorsmanship
   - performance
   - pick
   - remedy
+  - safe-room
   - sew
   - shape
   - smelt

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1983,7 +1983,7 @@ astrology_training:
   #- events
 #Allows user to force visions even if divination_tool is set rather than having to delete the settings.
 #Useful if another script makes use of the tool settings and still wants to them.
-astrology_force_visions: false
+astrology_force_visions: 
 
 astrology_prediction_skills:
   defense: defense
@@ -1996,17 +1996,17 @@ astrology_prediction_skills:
 # Recommended to add Piercing Gaze to the walkingastro waggle set. 
 # Clear Vision and Aura Sight are also useful there, but not as necessary.
 walkingastro:
-  startup_delay: 10
-  use_tools: true
-  use_partial_pools: false
+  startup_delay: 
+  use_tools: 
+  use_partial_pools: 
 # Setting walkingastro_predict_regardless_of_mindstate to true is meant to allow 
 # passive tool bonding via more frequent predictions, so also set 
 # walkingastro_use_partial_pools to false to maximize the chance of a bond if using it for that purpose.
 # Recommended to add Destiny Cipher to the walkingastro waggle set for this purpose as well.
-  predict_regardless_of_mindstate: true
+  predict_regardless_of_mindstate: 
 # Set to true if you want to analyze your divination tool after every prediction.
 # Only useful for logging prediction tracking, does not add any in-game benefit.
-  analyze_divination_tool: true
+  analyze_divination_tool: 
 
 learned_column_count: 2
 sort_auto_head: true

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1999,13 +1999,13 @@ walkingastro:
   startup_delay: 
   use_tools: 
   use_partial_pools: 
-# Setting walkingastro_predict_regardless_of_mindstate to true is meant to allow 
-# passive tool bonding via more frequent predictions, so also set 
-# walkingastro_use_partial_pools to false to maximize the chance of a bond if using it for that purpose.
-# Recommended to add Destiny Cipher to the walkingastro waggle set for this purpose as well.
+  # Setting walkingastro_predict_regardless_of_mindstate to true is meant to allow 
+  # passive tool bonding via more frequent predictions, so also set 
+  # walkingastro_use_partial_pools to false to maximize the chance of a bond if using it for that purpose.
+  # Recommended to add Destiny Cipher to the walkingastro waggle set for this purpose as well.
   predict_regardless_of_mindstate: 
-# Set to true if you want to analyze your divination tool after every prediction.
-# Only useful for logging prediction tracking, does not add any in-game benefit.
+  # Set to true if you want to analyze your divination tool after every prediction.
+  # Only useful for logging prediction tracking, does not add any in-game benefit.
   analyze_divination_tool: 
 
 learned_column_count: 2

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1982,7 +1982,7 @@ astrology_training:
   - attunement
   #- events
 #Allows user to force visions even if divination_tool is set rather than having to delete the settings.
-#Useful if another script makes use of the tool settings and still wants to them.
+#Useful if another script makes use of the tool settings and still wants to use them with that script.
 astrology_force_visions: 
 
 astrology_prediction_skills:


### PR DESCRIPTION
Part 2 of 5 of a suite of astrology changes
-- Part 1: https://github.com/elanthia-online/lich-5/pull/783 common-moonmage - update to peer_telescope for multi-line parsing of observation results
-- Part 2: #7127 base - addition of settings support for astrology and walkingastro changes
-- Part 3: #7125 astrology - refactor to account for peer_telescope change and addition of option to force vision predictions
-- Part 4: #7124 walkingastro - extensive quality of life changes to default behaviour and new optional features
-- Part 5: #7126 combat-trainer - refactor to account for peer_telescope change, no change to function

- added new default settings for use with walkingastro and astrology
- adjusted walkingastro_no_use_scripts due to changes in walkingastro capabilities