### PR TITLE
[script] [validate] Updated logic for missing setup file / bad extension

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -18,15 +18,6 @@ class DRYamlValidator
     setup_data
 
     respond("")
-    respond("  CHECKING: That #{checkname}-setup.yaml exists in the proper folder.")
-    if profiles.grep(/#{checkname}-setup/).empty?
-      echo "**WARNING**: No #{checkname}-setup.yaml file found in #{File.join(SCRIPT_DIR, 'profiles')}."
-      echo "This file is required. Check that the file exists and is in the correct folder."
-    else
-      respond("   PASSED")
-    end
-
-    respond("")
     respond("  CHECKING: That yaml file extensions are .yaml and not .yml")
 
     if !profiles.grep(/yml/).empty?
@@ -39,7 +30,18 @@ class DRYamlValidator
       respond("   PASSED")
     end
 
-    respond("")
+     respond("")
+    respond("  CHECKING: That #{checkname}-setup.yaml exists in the proper folder.")
+    if profiles.grep(/#{checkname}-setup/).empty?
+      echo "**WARNING**: No #{checkname}-setup.yaml file found in #{File.join(SCRIPT_DIR, 'profiles')}."
+      echo "This file is required. Check that the file exists and is in the correct folder."
+      echo "ENDING REMAINING CHECKS DUE TO MISSING SETUP FILE"
+      exit
+    else
+      respond("   PASSED")
+    end
+
+   respond("")
     respond("  CHECKING: That character yaml files contain valid YAML.")
     Dir.glob(File.join(SCRIPT_DIR, "profiles/#{checkname}-*.yaml")) { |file|
       begin

--- a/validate.lic
+++ b/validate.lic
@@ -30,7 +30,7 @@ class DRYamlValidator
       respond("   PASSED")
     end
 
-     respond("")
+    respond("")
     respond("  CHECKING: That #{checkname}-setup.yaml exists in the proper folder.")
     if profiles.grep(/#{checkname}-setup/).empty?
       echo "**WARNING**: No #{checkname}-setup.yaml file found in #{File.join(SCRIPT_DIR, 'profiles')}."
@@ -41,7 +41,7 @@ class DRYamlValidator
       respond("   PASSED")
     end
 
-   respond("")
+    respond("")
     respond("  CHECKING: That character yaml files contain valid YAML.")
     Dir.glob(File.join(SCRIPT_DIR, "profiles/#{checkname}-*.yaml")) { |file|
       begin


### PR DESCRIPTION
* Moved the check for invalid extension (.yml) to before the presence check for `{character}-setup.yaml` so that it always runs
* Changed outcome of missing `{character}-setup.yaml` file to end checks early since the rest of them are meaningless without that file and gives users a false picture.