### PR TITLE
[script][pick] Added defence against a timing issue where partial/additional traps are not recognised.

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -493,6 +493,10 @@ class Pick
     box['trap'] = trap
     box['trap_difficulty'] = difficulty
 
+    # this waitrt? is used to give more processing time for the event flags to trip.  Without this wait,
+    # occasionally its possible for the trap condition to be not recognised (in time).
+    waitrt?
+
     # Handle Triggering During Identify and Finding Another...
     if Flags['more-traps']
       echo "Saw another trap after disarming/tripping one..." if @debug
@@ -554,6 +558,10 @@ class Pick
 
     box['trapped'] = trapped
     box['trap_difficulty'] += 1 if Flags['disarm-shift']
+
+    # this waitrt? is used to give more processing time for the event flags to trip.  Without this wait,
+    # occasionally its possible for the trap condition to be not recognised (in time).
+    waitrt?
 
     if Flags['more-traps']
       echo "Saw another trap after disarming/tripping one..." if @debug
@@ -680,6 +688,10 @@ class Pick
     end
 
     box['locked'] = locked
+
+    # this waitrt? is used to give more processing time for the event flags to trip.  Without this wait,
+    # occasionally its possible for the trap condition to be not recognised (in time).
+    waitrt?
 
     if Flags['more-traps']
       box['trapped'] = true


### PR DESCRIPTION
Added waitrt? to a few locations to give time for additional traps to be recognised by the code.

Should have no normal impact other than a fractional increase in time to run the script.  Hopefully the waitrt? will allow Flags['more-traps'] to trip in time for the code to mark a partially trapped box as still trapped (rather than letting it go through as untrapped, causing death chaos and misery)

Note: this timing issue is sporadic and does not consistently present itself.