### PR TITLE
Added Learned Ranks tracking to exp-monitor.lic

### DIFF
--- a/exp-monitor.lic
+++ b/exp-monitor.lic
@@ -1,5 +1,6 @@
 no_pause_all
 no_kill_all
+silence_me
 
 custom_require.call(['drinfomon'])
 
@@ -12,9 +13,83 @@ before_dying do
   # continue to append data to DRSkill.gained_skills array as a memory leak.
   UserVars.echo_exp = false
   DRSkill.gained_skills.clear
+  DownstreamHook.remove('exp_hook')
 end
 
-loop do
+### THIS SECTION IS FOR DISPLAYING RANKS GAINED OVER A SESSION###
+# To track when the last time was we checked experience/info.
+@info_check_interval = get_settings.drinfomon_passive_delay
+@info_check_time = Time.now
+@skills_check_interval = UserVars.echo_exp_time
+@skills_check_time = Time.now
+@parsing_exp_output = false
+@squelch_exp_output = false
+@learning_rates = ['clear', 'dabbling', 'perusing', 'learning', 'thoughtful', 'thinking', 'considering', 'pondering', 'ruminating', 'concentrating', 'attentive', 'deliberative', 'interested', 'examining', 'understanding', 'absorbing', 'intrigued', 'scrutinizing', 'analyzing','studious','focused','very focused','engaged','very engaged','cogitating','fascinated','captivated','engrossed','riveted','very riveted','rapt','very rapt','enthralled','nearly locked','mind lock']
+@longest_learning_rate_length = @learning_rates.sort_by(&:length).last.length
+@regex_flag_briefexp_on = %r{<component id='exp .*?<d cmd='skill (?<skill>[a-zA-Z\s]+)'.*:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s*\[\s?(?<rate>\d+)\/34\].*?<\/component>}
+@regex_flag_briefexp_off = %r{<component id='exp .*?\b(?<skill>[a-zA-Z\s]+)\b:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s+\b(?<rate>[a-zA-Z\s]+)\b.*?<\/component>}
+@regex_exp_clear_mindstate = %r{<component id='exp (?<skill>[a-zA-Z\s]+)'><\/component>}
+@regex_exp_columns = /(?:\s*(?<skill>[a-zA-Z\s]+)\b:\s*(?<rank>\d+)\s+(?<percent>\d+)%\s+(?<rate>[a-zA-Z\s]+)\b)/
+
+def exp_hook
+  exp_hook = proc do |server_string|
+    match_briefexp_on = @regex_flag_briefexp_on.match(server_string)
+    if match_briefexp_on
+      skill = match_briefexp_on[:skill]
+      rank = match_briefexp_on[:rank]
+      rate = match_briefexp_on[:rate] # already a number
+      percent = match_briefexp_on[:percent]
+      DRSkill.update(skill, rank, rate, percent)
+      if UserVars.track_exp || UserVars.track_exp.nil?
+        UserVars.track_exp ||= true
+	    server_string.sub!(/(....).(..)%..\[(..)\/34\]/, "\\1\.\\2 ~\\3 #{sprintf('%0.2f', DRSkill.gained_exp(skill))}")
+      end
+    end
+
+    case server_string
+    when /^(Circle: (\d+)|Showing all skills that you have skill in)/
+      @parsing_exp_output = true
+    when @regex_exp_columns
+      if @parsing_exp_output
+        server_string.scan(@regex_exp_columns) do |skill_value, rank_value, percent_value, rate_as_word|
+          rate_as_number = @learning_rates.index(rate_as_word) # convert word to number
+          DRSkill.update(skill_value, rank_value, rate_as_number, percent_value)
+        end
+      end
+    when /^EXP HELP for more information/
+      if @parsing_exp_output && @squelch_exp_output
+        server_string = nil
+      end
+      if @parsing_exp_output
+        @parsing_exp_output = false
+        @squelch_exp_output = false
+      end
+    when %r{^<output class=""/>}
+      if @parsing_exp_output
+        @parsing_exp_output = false
+        @squelch_exp_output = false
+      end
+    end
+    if @parsing_exp_output && @squelch_exp_output
+      server_string = nil
+    end
+    server_string
+  end
+end
+### END of exp_hook - turned exp_hook proc into a method.
+
+# Checks `exp all`, squelching the output to the user.
+# A downstream hook parses the data from exp_hook and
+# is called in the main execution below.
+def check_exp_all
+  check_exp_all = proc do
+    DownstreamHook.add('exp_hook', exp_hook)
+    @squelch_exp_output = !UserVars.drinfomon_debug
+    fput('exp all 0')
+  end
+end
+
+def skills_gained
   new_skills = DRSkill.gained_skills.shift(DRSkill.gained_skills.size)
   # Some actions may pulse the same skill multiple times.
   # When this happens then we aggregate the individual pulses
@@ -27,5 +102,36 @@ loop do
   end
   new_skills = new_skills.keys.map { |skill| "#{skill}(+#{new_skills[skill]})" }
   respond("Gained: #{new_skills.join(', ')}") unless new_skills.empty?
-  pause UserVars.echo_exp_time
+end
+
+def skill_check
+  if (Time.now - @skills_check_time > @skills_check_interval)
+    skills_gained
+    @skills_check_time = Time.now
+  end
+end
+
+def exp_check(checkline)
+  if checkline =~ /^\* Log-on system converted \d+% of your character/
+    check_exp_all
+  end
+  if (Time.now - @info_check_time > @info_check_interval)
+    check_exp_all
+    @info_check_time = Time.now
+  end
+end
+
+### MAIN EXECUTABLE PART OF THE SCRIPT ###
+DownstreamHook.add('exp_hook', exp_hook)
+check_exp_all.call
+# Start loop to process incoming data.
+while (line = script.gets)
+  begin
+    skill_check
+	exp_check(line)
+  rescue
+    echo $ERROR_INFO
+    echo $ERROR_INFO.backtrace.first
+    sleep 1
+  end
 end

--- a/exp-monitor.lic
+++ b/exp-monitor.lic
@@ -18,78 +18,72 @@ end
 
 ### THIS SECTION IS FOR DISPLAYING RANKS GAINED OVER A SESSION###
 # To track when the last time was we checked experience/info.
-@info_check_interval = get_settings.drinfomon_passive_delay
-@info_check_time = Time.now
-@skills_check_interval = UserVars.echo_exp_time
-@skills_check_time = Time.now
-@parsing_exp_output = false
-@squelch_exp_output = false
-@learning_rates = ['clear', 'dabbling', 'perusing', 'learning', 'thoughtful', 'thinking', 'considering', 'pondering', 'ruminating', 'concentrating', 'attentive', 'deliberative', 'interested', 'examining', 'understanding', 'absorbing', 'intrigued', 'scrutinizing', 'analyzing','studious','focused','very focused','engaged','very engaged','cogitating','fascinated','captivated','engrossed','riveted','very riveted','rapt','very rapt','enthralled','nearly locked','mind lock']
-@longest_learning_rate_length = @learning_rates.sort_by(&:length).last.length
-@regex_flag_briefexp_on = %r{<component id='exp .*?<d cmd='skill (?<skill>[a-zA-Z\s]+)'.*:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s*\[\s?(?<rate>\d+)\/34\].*?<\/component>}
-@regex_flag_briefexp_off = %r{<component id='exp .*?\b(?<skill>[a-zA-Z\s]+)\b:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s+\b(?<rate>[a-zA-Z\s]+)\b.*?<\/component>}
-@regex_exp_clear_mindstate = %r{<component id='exp (?<skill>[a-zA-Z\s]+)'><\/component>}
-@regex_exp_columns = /(?:\s*(?<skill>[a-zA-Z\s]+)\b:\s*(?<rank>\d+)\s+(?<percent>\d+)%\s+(?<rate>[a-zA-Z\s]+)\b)/
+info_check_interval = get_settings.drinfomon_passive_delay
+info_check_time = Time.now
+skills_check_interval = UserVars.echo_exp_time
+skills_check_time = Time.now
+parsing_exp_output = false
+squelch_exp_output = false
+learning_rates = ['clear', 'dabbling', 'perusing', 'learning', 'thoughtful', 'thinking', 'considering', 'pondering', 'ruminating', 'concentrating', 'attentive', 'deliberative', 'interested', 'examining', 'understanding', 'absorbing', 'intrigued', 'scrutinizing', 'analyzing', 'studious', 'focused', 'very focused', 'engaged', 'very engaged', 'cogitating', 'fascinated', 'captivated', 'engrossed', 'riveted', 'very riveted', 'rapt', 'very rapt', 'enthralled', 'nearly locked', 'mind lock']
+longest_learning_rate_length = learning_rates.sort_by(&:length).last.length
+regex_flag_briefexp_on = %r{<component id='exp .*?<d cmd='skill (?<skill>[a-zA-Z\s]+)'.*:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s*\[\s?(?<rate>\d+)\/34\].*?<\/component>}
+regex_flag_briefexp_off = %r{<component id='exp .*?\b(?<skill>[a-zA-Z\s]+)\b:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s+\b(?<rate>[a-zA-Z\s]+)\b.*?<\/component>}
+regex_exp_clear_mindstate = %r{<component id='exp (?<skill>[a-zA-Z\s]+)'><\/component>}
+regex_exp_columns = /(?:\s*(?<skill>[a-zA-Z\s]+)\b:\s*(?<rank>\d+)\s+(?<percent>\d+)%\s+(?<rate>[a-zA-Z\s]+)\b)/
 
-def exp_hook
-  exp_hook = proc do |server_string|
-    match_briefexp_on = @regex_flag_briefexp_on.match(server_string)
-    if match_briefexp_on
-      skill = match_briefexp_on[:skill]
-      rank = match_briefexp_on[:rank]
-      rate = match_briefexp_on[:rate] # already a number
-      percent = match_briefexp_on[:percent]
-      DRSkill.update(skill, rank, rate, percent)
-      if UserVars.track_exp || UserVars.track_exp.nil?
-        UserVars.track_exp ||= true
-	    server_string.sub!(/(....).(..)%..\[(..)\/34\]/, "\\1\.\\2 ~\\3 #{sprintf('%0.2f', DRSkill.gained_exp(skill))}")
+### This thing has to be a proc not a function/method because it is called in DownstreamHook.
+### It is a pared down version from the now obselete drinfomon.lic
+exp_hook = proc do |server_string|
+  match_briefexp_on = regex_flag_briefexp_on.match(server_string)
+  if match_briefexp_on
+    skill = match_briefexp_on[:skill]
+    rank = match_briefexp_on[:rank]
+    rate = match_briefexp_on[:rate] # already a number
+    percent = match_briefexp_on[:percent]
+    DRSkill.update(skill, rank, rate, percent)
+    if UserVars.track_exp || UserVars.track_exp.nil?
+      UserVars.track_exp ||= true
+      server_string.sub!(/(....).(..)%..\[(..)\/34\]/, "\\1\.\\2 ~\\3 #{sprintf('%0.2f', DRSkill.gained_exp(skill))}")
+    end
+  end
+
+  case server_string
+  when /^(Circle: (\d+)|Showing all skills that you have skill in)/
+    parsing_exp_output = true
+  when regex_exp_columns
+    if parsing_exp_output
+      server_string.scan(regex_exp_columns) do |skill_value, rank_value, percent_value, rate_as_word|
+        rate_as_number = learning_rates.index(rate_as_word) # convert word to number
+        DRSkill.update(skill_value, rank_value, rate_as_number, percent_value)
       end
     end
-
-    case server_string
-    when /^(Circle: (\d+)|Showing all skills that you have skill in)/
-      @parsing_exp_output = true
-    when @regex_exp_columns
-      if @parsing_exp_output
-        server_string.scan(@regex_exp_columns) do |skill_value, rank_value, percent_value, rate_as_word|
-          rate_as_number = @learning_rates.index(rate_as_word) # convert word to number
-          DRSkill.update(skill_value, rank_value, rate_as_number, percent_value)
-        end
-      end
-    when /^EXP HELP for more information/
-      if @parsing_exp_output && @squelch_exp_output
-        server_string = nil
-      end
-      if @parsing_exp_output
-        @parsing_exp_output = false
-        @squelch_exp_output = false
-      end
-    when %r{^<output class=""/>}
-      if @parsing_exp_output
-        @parsing_exp_output = false
-        @squelch_exp_output = false
-      end
-    end
-    if @parsing_exp_output && @squelch_exp_output
+  when /^EXP HELP for more information/
+    if parsing_exp_output && squelch_exp_output
       server_string = nil
     end
-    server_string
+    if parsing_exp_output
+      parsing_exp_output = false
+      squelch_exp_output = false
+    end
+  when %r{^<output class=""/>}
+    if parsing_exp_output
+      parsing_exp_output = false
+      squelch_exp_output = false
+    end
   end
-end
-### END of exp_hook - turned exp_hook proc into a method.
-
-# Checks `exp all`, squelching the output to the user.
-# A downstream hook parses the data from exp_hook and
-# is called in the main execution below.
-def check_exp_all
-  check_exp_all = proc do
-    DownstreamHook.add('exp_hook', exp_hook)
-    @squelch_exp_output = !UserVars.drinfomon_debug
-    fput('exp all 0')
+  if parsing_exp_output && squelch_exp_output
+    server_string = nil
   end
+  server_string
 end
 
-def skills_gained
+check_exp_all = proc do
+  DownstreamHook.add('exp_hook', exp_hook)
+  squelch_exp_output = !UserVars.drinfomon_debug
+  fput('exp all 0')
+end
+
+skills_gained = proc do
   new_skills = DRSkill.gained_skills.shift(DRSkill.gained_skills.size)
   # Some actions may pulse the same skill multiple times.
   # When this happens then we aggregate the individual pulses
@@ -104,31 +98,28 @@ def skills_gained
   respond("Gained: #{new_skills.join(', ')}") unless new_skills.empty?
 end
 
-def skill_check
-  if (Time.now - @skills_check_time > @skills_check_interval)
-    skills_gained
-    @skills_check_time = Time.now
+skill_check = proc do
+  if (Time.now - skills_check_time > skills_check_interval)
+    skills_gained.call
+    skills_check_time = Time.now
   end
 end
 
-def exp_check(checkline)
-  if checkline =~ /^\* Log-on system converted \d+% of your character/
-    check_exp_all
-  end
-  if (Time.now - @info_check_time > @info_check_interval)
-    check_exp_all
-    @info_check_time = Time.now
-  end
-end
-
-### MAIN EXECUTABLE PART OF THE SCRIPT ###
+### THE REAL START OF THE SCRIPT. THIS IS THE PART THAT EXECUTES ###
 DownstreamHook.add('exp_hook', exp_hook)
 check_exp_all.call
+
 # Start loop to process incoming data.
 while (line = script.gets)
   begin
-    skill_check
-	exp_check(line)
+    skill_check.call
+    if line =~ /^\* Log-on system converted \d+% of your character/
+      check_exp_all.call
+    end
+    if (Time.now - info_check_time > info_check_interval)
+      check_exp_all.call
+      info_check_time = Time.now
+    end
   rescue
     echo $ERROR_INFO
     echo $ERROR_INFO.backtrace.first

--- a/exp-monitor.lic
+++ b/exp-monitor.lic
@@ -26,8 +26,8 @@ parsing_exp_output = false
 squelch_exp_output = false
 learning_rates = ['clear', 'dabbling', 'perusing', 'learning', 'thoughtful', 'thinking', 'considering', 'pondering', 'ruminating', 'concentrating', 'attentive', 'deliberative', 'interested', 'examining', 'understanding', 'absorbing', 'intrigued', 'scrutinizing', 'analyzing', 'studious', 'focused', 'very focused', 'engaged', 'very engaged', 'cogitating', 'fascinated', 'captivated', 'engrossed', 'riveted', 'very riveted', 'rapt', 'very rapt', 'enthralled', 'nearly locked', 'mind lock']
 regex_flag_briefexp_on = %r{<component id='exp .*?<d cmd='skill (?<skill>[a-zA-Z\s]+)'.*:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s*\[\s?(?<rate>\d+)\/34\].*?<\/component>}
-#regex_flag_briefexp_off = %r{<component id='exp .*?\b(?<skill>[a-zA-Z\s]+)\b:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s+\b(?<rate>[a-zA-Z\s]+)\b.*?<\/component>}
-#regex_exp_clear_mindstate = %r{<component id='exp (?<skill>[a-zA-Z\s]+)'><\/component>}
+# regex_flag_briefexp_off = %r{<component id='exp .*?\b(?<skill>[a-zA-Z\s]+)\b:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s+\b(?<rate>[a-zA-Z\s]+)\b.*?<\/component>}
+# regex_exp_clear_mindstate = %r{<component id='exp (?<skill>[a-zA-Z\s]+)'><\/component>}
 regex_exp_columns = /(?:\s*(?<skill>[a-zA-Z\s]+)\b:\s*(?<rank>\d+)\s+(?<percent>\d+)%\s+(?<rate>[a-zA-Z\s]+)\b)/
 
 ### This thing has to be a proc not a function/method because it is called in DownstreamHook.

--- a/exp-monitor.lic
+++ b/exp-monitor.lic
@@ -25,10 +25,9 @@ skills_check_time = Time.now
 parsing_exp_output = false
 squelch_exp_output = false
 learning_rates = ['clear', 'dabbling', 'perusing', 'learning', 'thoughtful', 'thinking', 'considering', 'pondering', 'ruminating', 'concentrating', 'attentive', 'deliberative', 'interested', 'examining', 'understanding', 'absorbing', 'intrigued', 'scrutinizing', 'analyzing', 'studious', 'focused', 'very focused', 'engaged', 'very engaged', 'cogitating', 'fascinated', 'captivated', 'engrossed', 'riveted', 'very riveted', 'rapt', 'very rapt', 'enthralled', 'nearly locked', 'mind lock']
-longest_learning_rate_length = learning_rates.sort_by(&:length).last.length
 regex_flag_briefexp_on = %r{<component id='exp .*?<d cmd='skill (?<skill>[a-zA-Z\s]+)'.*:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s*\[\s?(?<rate>\d+)\/34\].*?<\/component>}
-regex_flag_briefexp_off = %r{<component id='exp .*?\b(?<skill>[a-zA-Z\s]+)\b:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s+\b(?<rate>[a-zA-Z\s]+)\b.*?<\/component>}
-regex_exp_clear_mindstate = %r{<component id='exp (?<skill>[a-zA-Z\s]+)'><\/component>}
+#regex_flag_briefexp_off = %r{<component id='exp .*?\b(?<skill>[a-zA-Z\s]+)\b:\s+(?<rank>\d+)\s+(?<percent>\d+)%\s+\b(?<rate>[a-zA-Z\s]+)\b.*?<\/component>}
+#regex_exp_clear_mindstate = %r{<component id='exp (?<skill>[a-zA-Z\s]+)'><\/component>}
 regex_exp_columns = /(?:\s*(?<skill>[a-zA-Z\s]+)\b:\s*(?<rank>\d+)\s+(?<percent>\d+)%\s+(?<rate>[a-zA-Z\s]+)\b)/
 
 ### This thing has to be a proc not a function/method because it is called in DownstreamHook.


### PR DESCRIPTION

With the switchover to lich5, Wrayth/Stormfront users lost the function to track EXP/RANKS gained over a session.

I have taken the portion of the script that handles tracking and displaying the learned ranks in the field experience window.

Also, I have updated the output to Field Experience Window display to not increase the number of characters, respacing the information to fit in the original space.

I have included a screenshot of the before and after.

![expmoniter_learned_ranks](https://github.com/user-attachments/assets/419b92ef-38ed-47fa-900c-3b11eb9b6b4f)