### PR TITLE
[script] [stabbity] switch weapons if current is ineffective; avoid false-positives by not ignoring monsters

### DIFF
--- a/stabbity.lic
+++ b/stabbity.lic
@@ -216,12 +216,11 @@ class Stabbity
   end
 
   def get_npcs
-    # Not filtering by ignored NPCs because some nouns like "warrior"
-    # which generally refer to an Empath's Alfar warrior, are incorrectly
-    # ignoring enemy warriors like an armored necrotic warrior.
-    # And since this script is for solo thieves, there should be no other NPCs.
-    # DRRoom.npcs - @ignored_npcs
-    DRRoom.npcs
+    if arena_mode?
+      DRRoom.npcs
+    else
+      DRRoom.npcs - @ignored_npcs
+    end
   end
 
   def npc_dead?

--- a/stabbity.lic
+++ b/stabbity.lic
@@ -5,6 +5,14 @@
 custom_require.call(%w[common common-arcana drinfomon equipmanager events])
 
 class Stabbity
+  # https://elanthipedia.play.net/Genie_numerical_hit_subs
+  LIGHT_STRIKES = [
+    # harmless
+    /(a|an) (benign|brushing|gentle|glancing|grazing|harmless|ineffective|skimming) (blow|hit|strike)/,
+    # could be better
+    /(a|an) (light|good|solid|hard|strong) (blow|hit|strike)/,
+  ]
+
   def initialize
     unless DRStats.thief?
       echo("*** But you're not a thief! ***")
@@ -121,6 +129,7 @@ class Stabbity
                         /You'll need to stand up first/,
                         /flying out of reach/,
                         /to stop flying before/,
+                        LIGHT_STRIKES,
                         /Roundtime/,
                         /\[You're /,
                         /What are you trying/,
@@ -141,11 +150,30 @@ class Stabbity
       when /flying out of reach/, /to stop flying before/
         if @thrown_weapon != nil
           DRC.message("*** Switching to thrown weapon -- add '#{@target}' to your use_thrown_on setting ***")
+          @thrown_weapon_npcs.push(@target)
           use_weapon('thrown')
           kill_thrown
           return
         end
         dodge_arena_trap if arena_mode?
+      when *LIGHT_STRIKES
+        # Some enemies are resistant to slice or impact damage.
+        # If we detect that your current weapon is ineffective,
+        # we'll switch to the other weapon in hopes it does better.
+        case @current_weapon_type
+        when 'preferred'
+          @alternate_weapon_npcs.push(@target)
+          use_weapon('alternate')
+        when 'alternate'
+          @alternate_weapon_npcs.delete(@target)
+          use_weapon('preferred')
+        end
+
+        return if npc_dead?
+
+        waitrt?
+        dodge_arena_trap if arena_mode?
+        DRC.hide?
       when /Roundtime/, /\[You're /
         return if npc_dead?
 

--- a/stabbity.lic
+++ b/stabbity.lic
@@ -188,7 +188,12 @@ class Stabbity
   end
 
   def get_npcs
-    DRRoom.npcs - @ignored_npcs
+    # Not filtering by ignored NPCs because some nouns like "warrior"
+    # which generally refer to an Empath's Alfar warrior, are incorrectly
+    # ignoring enemy warriors like an armored necrotic warrior.
+    # And since this script is for solo thieves, there should be no other NPCs.
+    # DRRoom.npcs - @ignored_npcs
+    DRRoom.npcs
   end
 
   def npc_dead?


### PR DESCRIPTION
### Background

While running the Arena on my thief in Duskruin this year, identified a couple issues.

**Issue 1**
stabbity's yaml config lets you choose which weapon to use against different creatures to handle when one might be resistant to slice or impact, for example. However, this requires you to know the noun of the creature before you encounter it. When progressing through the arena, you might encounter new creatures that you haven't configured the correct weapon for. To resolve, you have to update your yaml and rerun the script.

**Issue 2**
stabbity identifies monsters in the room to attack based on NPCs and removing any ignored NPCs (e.g. 'warrior' to ignore an Empath's Alfar warrior). However, this can be a false-positive that ignores 'armored necrotic warrior' leaving the script to do nothing.

### Changes

- Swap between preferred and alternate weapon if the current weapon is not hitting effectively
- Don't ignore any NPCs so always try to watch and engage whoever is in the arena

### Usage

```
;stabbity arena
```
