### PR TITLE
[script] [wand-watcher] add 'once' option to run and exit

### DIFF
--- a/wand-watcher.lic
+++ b/wand-watcher.lic
@@ -22,6 +22,12 @@ class WandWatcher
           regex: /^reset$/,
           optional: true,
           description: 'Clear timing variables'
+        },
+        {
+          name: 'once',
+          regex: /^once$/,
+          optional: true,
+          description: 'Run once and exit'
         }
       ]
     ]
@@ -35,6 +41,7 @@ class WandWatcher
     @no_use_rooms = settings.wand_watcher_no_use_rooms
     @startup_delay = args.delay || settings.wand_watcher_startup_delay
     @passive_delay = settings.wand_watcher_passive_delay
+    @run_once = args.once
     @activation_failure_messages = [/^(The|An|A) .* remains inert/]
     @activation_blocked_messages = [/^Something in the area is interfering/,
                                     /^This is not a good place for that/,
@@ -81,7 +88,6 @@ class WandWatcher
 
     # Run passively in a loop
     passive_run
-    # TODO: run once option
   end
 
   def passive_run
@@ -93,6 +99,7 @@ class WandWatcher
         exit
       end
       check_timers
+      exit if @run_once
       pause @passive_delay
     end
   end


### PR DESCRIPTION
### Background

I'm running a script that needs to NOT be interrupted by `wand-watcher`, so my yaml lists my script as one when `wand-watcher` should not run. But at certain times in the script it does become safe for wands to be checked and used. And at that time I'd like to run `wand-watcher` once, and if wands are ready, reapply them.

### Changes

- Add `once` script arg to only perform one loop to check/use wands then exit
  - If wands are ready at the time you run the script, they'll be used, then script exits
  - Otherwise, the script exits having done nothing

### Manual Usage

```shell
# Run once after normal configured startup delay
;wand-watcher once

--- Lich: wand-watcher active.
(does stuff after a delay)
--- Lich: wand-watcher has exited.

# Run once, immediately
;wand-watcher once 0

--- Lich: wand-watcher active.
(no delay, runs immediately)
--- Lich: wand-watcher has exited.
```

### Script Usage

```ruby
# In my script, I call this function when it's safe for wands to be checked and used
def do_stuff
  ...
  check_wands
  ...
end

def check_wands
  start_script('wand-watcher', ['once', 0])
  pause 0.5 while Script.running?('wand-watcher')
end
```