### PR TITLE
[scripts][dependency] Add `played` to starting commands.

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '2.0.9'
+$DEPENDENCY_VERSION = '2.0.10'
 $MIN_RUBY_VERSION = '3.3.1'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/KzSAUPnDHh'
 
@@ -1824,6 +1824,7 @@ unless $DRINFOMON_IN_CORE_LICH
 else
   Lich::Util.issue_command("exp all 0", /^Circle: \d+/, /^Rested EXP Stored|type: AWAKEN|Unlock Rested Experience/, quiet: true, timeout: 1)
   Lich::Util.issue_command("info", /^Name/, /^<output class=""/, quiet: true, timeout: 1)
+  Lich::Util.issue_command("played", /^Account Info for/, quiet: true, timeout: 1)
   Lich::Util.issue_command("ability", /^You (know the Berserks|recall the spells you have learned from your training)|^From your apprenticeship you remember practicing/, /^You (recall that you have \d+ training sessions|can use SPELL STANCE \[HELP\]|have \d+ available slot)/, quiet: true, timeout: 1)
 end
 


### PR DESCRIPTION
Allows for proper setting of account-based flags, such as detecting Premium status for map purposes.