### PR TITLE
[script] [vanity-pet] handle more pet messaging and when homes must be worn

### DIFF
--- a/vanity-pet.lic
+++ b/vanity-pet.lic
@@ -43,29 +43,30 @@ class VanityPet
 
   def stow_pet(pet_name, pet_container)
     echo "stowing pet" if $debug_mode_pet
-    unless DRCI.in_hands?(pet_name) || DRCI.get_item_if_not_held?(pet_name, pet_container)
+    unless DRCI.in_hands?(pet_name) || DRCI.get_item_if_not_held?(pet_name, pet_container) || DRCI.get_item_if_not_held?(pet_name)
       wait_for_pet_to_arrive(pet_name, 15)
       unless DRCI.get_item_unsafe(pet_name)
         DRC.message("Could not pick up pet, where did it go?")
         exit
       end
     end
-    DRCI.put_away_item?(pet_name, pet_container)
+    unless DRCI.put_away_item?(pet_name, pet_container)
+      DRC.message("Unable to stow pet. Ensure you are either holding or wearing your pet's home.")
+    end
   end
 
   def drop_pet(pet_name, pet_container)
     echo "dropping pet" if $debug_mode_pet
-    unless DRCI.get_item_if_not_held?(pet_name, pet_container)
+    unless DRCI.get_item_if_not_held?(pet_name, pet_container) || DRCI.get_item_if_not_held?(pet_name)
       DRC.message("Could not find pet, are you sure you have it?")
       exit
     end
     case DRC.bput("drop my #{pet_name}",
                   /^You set the .* on the ground/,
+                  /^You give your .*#{pet_name}/,
                   /^No littering in the bank/,
                   /you can't drop anything here/,
-                  /^What were you referring/,
-                  /^You give your \w+ puppy/,
-                  /^You give your .*#{pet_name} an affectionate smooch/)
+                  /^What were you referring/)
     when /^No littering in the bank/, /you can't drop anything here/
       DRC.message("Can't drop pets in this room")
       DRCI.put_away_item?(pet_name, pet_container)


### PR DESCRIPTION
I got my first puppy at this year's Duskruin. Noticed some new messaging that the script wasn't expecting, and scenarios where the pet home needed to be worn, not simply stowed in another container. Maybe they always had to be worn, not sure, but now the script handles it and warns user.

```
[vanity-pet]>get wolf-hound puppy

You carefully lift the puppy up by the scruff of its neck and then tuck it gently into the crook of your arm.

[vanity-pet]>put my wolf-hound puppy in my wooden crate

Your wolf-hound puppy nips at your fingers and doesn't seem to want to leave you.
>

... waiting ...

[vanity-pet: *** No match was found after 15 seconds, dumping info]

... text ...

[vanity-pet: for command put my wolf-hound puppy in my wooden crate]

Unable to stow pet. Ensure you are either holding or wearing your pet's home.

--- Lich: vanity-pet has exited.
```