### PR TITLE
Pick.lic Update - Box Popper Mode

### DIFF
--- a/pick.lic
+++ b/pick.lic
@@ -4,10 +4,14 @@
 
 custom_require.call(%w[common common-arcana common-healing common-items common-money common-travel equipmanager events spellmonitor])
 
-### Added box popper mode April 2025 ##
-### This is added to handle whether to gear up on before_dying ###
-# @equipment_manager has been set to equal $gear, so we don't call redundent objects.
-$gear = EquipmentManager.new
+### Added 'box popper' mode April 2025 ###
+# This was added to handle whether to gear up in before_dying, since @equipment_manager won't pass through.
+# @equipment_manager has been set to equal GEAR, so we don't call two EquipmentManager needlessly.
+GEAR = EquipmentManager.new
+# $boxes_popped is reset every time ;pick is run
+# but the ;e echo $boxes_popped will continue to display most recent ;pick results,
+# even after ;pick has closed.
+$boxes_popped = nil
 
 class Pick
   def initialize
@@ -19,7 +23,7 @@ class Pick
         { name: 'all', regex: /all/, optional: true, description: 'Overwrite for @stop_pick_on_mindlock to keep picking' },
         { name: 'assume', regex: /(quick|normal|careful)/, optional: true, description: 'Skips identification - assumes given difficulty' },
         { name: 'stand', regex: /stand/i, optional: true, description: 'Stand to pop boxes. Default is sit.' },
-		    { name: 'popper', regex: /popper/i, optional: true, description: 'Sets to accept, pop, and return boxes.' }
+        { name: 'popper', regex: /popper/i, optional: true, description: 'Accept, pop, and return boxes.' }
       ]
     ]
 
@@ -145,12 +149,12 @@ class Pick
     elsif stop_picking?
       echo 'Exiting due to mindstate...'
     else
-      @equipment_manager = $gear
+      @equipment_manager = GEAR
       setup_flags
       open_containers
       check_for_boxes if !@popper
       remove_hindering_gear
-	  loop{box_popper}if @popper
+      loop {box_popper} if @popper
       crack_boxes
       stop_buffs
       wear_normal_gear
@@ -220,12 +224,12 @@ class Pick
       @equipment_manager.wear_items(@removed_items)
       exit
     end
-	$geared_up = false
+    $geared_up = false
   end
 
   def wear_normal_gear
     @equipment_manager.wear_equipment_set?('standard')
-	$geared_up = true
+    $geared_up = true
   end
 
   def setup_flags
@@ -414,6 +418,7 @@ class Pick
     end
 
     if holding_box?(current_box)
+      $boxes_popped += 1
       stow_hands_except(current_box['noun'])
       loot(current_box['noun']) unless @popper
       dispose_empty_box(current_box) unless @popper
@@ -868,54 +873,50 @@ class Pick
       DRCI.dispose_trash(DRC.left_hand, @worn_trashcan, @worn_trashcan_verb) if @trap_parts.include?(DRC.left_hand)
     end
   end
-  
+
   ### Box Popping! ###
   def box_popper
     Flags.add('box_offered', /offers you .* (box|caddy|case|casket|chest|coffer|crate|skippet|strongbox|trunk)/i)
-	fput("nod")
+    fput("nod")
     pause until Flags['box_offered']
-	echo "An offer has been made." if @debug
-    # Once flagged, we should now accept. #
-	case DRC.bput('accept', /You accept (\w*)\'s offer and are now holding .* (box|caddy|case|casket|chest|coffer|crate|skippet|strongbox|trunk)/i, /be in the same place for that/i, /You have no offers to accept/i)
-	when /You accept (\w*)\'s offer and are now holding .* (box|caddy|case|casket|chest|coffer|crate|skippet|strongbox|trunk)/i
+    # Once flagged, we should now accept.
+    case DRC.bput('accept', /You accept (\w*)\'s offer and are now holding .* (box|caddy|case|casket|chest|coffer|crate|skippet|strongbox|trunk)/i, /be in the same place for that/i, /You have no offers to accept/i)
+    when /You accept (\w*)\'s offer and are now holding .* (box|caddy|case|casket|chest|coffer|crate|skippet|strongbox|trunk)/i
       @popper_box_belongs_to = $1
-	  @popper_box = $2
-	  DRC.message("#{@popper_box_belongs_to} has given you a #{@popper_box} to pop for them.")
-	  # Attempts to open the popped box. #
-	  attempt_open(@popper_box)
-	  # Double checks that the box has been returned in attempt_open. #
-	  popper_return_box until !@popper_box
-	  $boxes_popped += 1
-	end
+      @popper_box = $2
+      DRC.message("#{@popper_box_belongs_to} has given you a #{@popper_box} to pop for them.")
+      # Attempts to open the popped box.
+      attempt_open(@popper_box)
+      # Double checks that the box has been returned in attempt_open.
+      popper_return_box until !@popper_box
+    end
   end
   
   def popper_return_box
     case DRC.bput("Give my #{@popper_box} to #{@popper_box_belongs_to}", /has accepted your offer/i, /nothing in your right hand/i, /What is it you\'re trying to give/i)
     when /has accepted your offer/i
-	  Flags.delete('box_offered')
-      DRC.message("Box has been returned to #{@popper_box_belongs_to}.")
-	  @popper_box = nil
+      Flags.delete('box_offered')
+      DRC.message("The #{@popper_box} has been returned to #{@popper_box_belongs_to}.")
+      @popper_box = nil
     when /What is it you\'re trying to give/i
-	  DRC.message("#{@popper_box_belongs_to} doesn't seem to be there to receive the box...")
-	  pause 5
-	else
-	  echo "Something went wrong in popper_return_box method."
-	  exit
-	end
+      DRC.message("#{@popper_box_belongs_to} doesn't seem to be there to receive the box...")
+      pause 5
+    else
+      echo "Something went wrong in popper_return_box method."
+      exit
+    end
   end
-  # end of Box Popping! #
+  ### end of Box Popping! ###
+
 end
 
 before_dying do
   echo "geared_up: #{$geared_up}"
   if !$geared_up
-	$gear.wear_equipment_set?('standard')
+    GEAR.wear_equipment_set?('standard')
     $geared_up = true
   end
-  if $boxes_popped > 0
-    echo "Popper Boxes popped this session: #{$boxes_popped}" if $boxes_popped > 0
-    $boxes_popped = nil
-  end    
+  echo "Boxes handled this PICK: #{$boxes_popped}" if $boxes_popped
   Flags.delete('box_offered')
   Flags.delete('disarm-trap-type')
   Flags.delete('disarm-shift')
@@ -923,7 +924,6 @@ before_dying do
   Flags.delete('more-locks')
   Flags.delete('glance-no-traps')
   Flags.delete('glance-no-locks')
-  $gear = nil
 end
 
 Pick.new

--- a/pick.lic
+++ b/pick.lic
@@ -4,6 +4,11 @@
 
 custom_require.call(%w[common common-arcana common-healing common-items common-money common-travel equipmanager events spellmonitor])
 
+### Added box popper mode April 2025 ##
+### This is added to handle whether to gear up on before_dying ###
+# @equipment_manager has been set to equal $gear, so we don't call redundent objects.
+$gear = EquipmentManager.new
+
 class Pick
   def initialize
     arg_definitions = [
@@ -13,7 +18,8 @@ class Pick
         { name: 'source', regex: /(source=(\w+))/, optional: true, description: 'Container with boxes to pick.' },
         { name: 'all', regex: /all/, optional: true, description: 'Overwrite for @stop_pick_on_mindlock to keep picking' },
         { name: 'assume', regex: /(quick|normal|careful)/, optional: true, description: 'Skips identification - assumes given difficulty' },
-        { name: 'stand', regex: /stand/i, optional: true, description: 'Stand to pop boxes. Default is sit.' }
+        { name: 'stand', regex: /stand/i, optional: true, description: 'Stand to pop boxes. Default is sit.' },
+		    { name: 'popper', regex: /popper/i, optional: true, description: 'Sets to accept, pop, and return boxes.' }
       ]
     ]
 
@@ -38,7 +44,7 @@ class Pick
     check_deprecated_settings
 
     @stand = args.stand
-
+    @popper = args.popper
     @use_lockpick_ring = @settings.use_lockpick_ring
     @lockpick_container = @settings.lockpick_container
     @balance_lockpick_container = @settings.pick['balance_lockpick_container']
@@ -139,11 +145,12 @@ class Pick
     elsif stop_picking?
       echo 'Exiting due to mindstate...'
     else
-      @equipment_manager = EquipmentManager.new
+      @equipment_manager = $gear
       setup_flags
       open_containers
-      check_for_boxes
+      check_for_boxes if !@popper
       remove_hindering_gear
+	  loop{box_popper}if @popper
       crack_boxes
       stop_buffs
       wear_normal_gear
@@ -213,10 +220,12 @@ class Pick
       @equipment_manager.wear_items(@removed_items)
       exit
     end
+	$geared_up = false
   end
 
   def wear_normal_gear
     @equipment_manager.wear_equipment_set?('standard')
+	$geared_up = true
   end
 
   def setup_flags
@@ -406,8 +415,8 @@ class Pick
 
     if holding_box?(current_box)
       stow_hands_except(current_box['noun'])
-      loot(current_box['noun'])
-      dispose_empty_box(current_box)
+      loot(current_box['noun']) unless @popper
+      dispose_empty_box(current_box) unless @popper
     else
       echo "You lost your box somehow." if @debug
     end
@@ -859,15 +868,62 @@ class Pick
       DRCI.dispose_trash(DRC.left_hand, @worn_trashcan, @worn_trashcan_verb) if @trap_parts.include?(DRC.left_hand)
     end
   end
+  
+  ### Box Popping! ###
+  def box_popper
+    Flags.add('box_offered', /offers you .* (box|caddy|case|casket|chest|coffer|crate|skippet|strongbox|trunk)/i)
+	fput("nod")
+    pause until Flags['box_offered']
+	echo "An offer has been made." if @debug
+    # Once flagged, we should now accept. #
+	case DRC.bput('accept', /You accept (\w*)\'s offer and are now holding .* (box|caddy|case|casket|chest|coffer|crate|skippet|strongbox|trunk)/i, /be in the same place for that/i, /You have no offers to accept/i)
+	when /You accept (\w*)\'s offer and are now holding .* (box|caddy|case|casket|chest|coffer|crate|skippet|strongbox|trunk)/i
+      @popper_box_belongs_to = $1
+	  @popper_box = $2
+	  DRC.message("#{@popper_box_belongs_to} has given you a #{@popper_box} to pop for them.")
+	  # Attempts to open the popped box. #
+	  attempt_open(@popper_box)
+	  # Double checks that the box has been returned in attempt_open. #
+	  popper_return_box until !@popper_box
+	  $boxes_popped += 1
+	end
+  end
+  
+  def popper_return_box
+    case DRC.bput("Give my #{@popper_box} to #{@popper_box_belongs_to}", /has accepted your offer/i, /nothing in your right hand/i, /What is it you\'re trying to give/i)
+    when /has accepted your offer/i
+	  Flags.delete('box_offered')
+      DRC.message("Box has been returned to #{@popper_box_belongs_to}.")
+	  @popper_box = nil
+    when /What is it you\'re trying to give/i
+	  DRC.message("#{@popper_box_belongs_to} doesn't seem to be there to receive the box...")
+	  pause 5
+	else
+	  echo "Something went wrong in popper_return_box method."
+	  exit
+	end
+  end
+  # end of Box Popping! #
 end
 
 before_dying do
+  echo "geared_up: #{$geared_up}"
+  if !$geared_up
+	$gear.wear_equipment_set?('standard')
+    $geared_up = true
+  end
+  if $boxes_popped > 0
+    echo "Popper Boxes popped this session: #{$boxes_popped}" if $boxes_popped > 0
+    $boxes_popped = nil
+  end    
+  Flags.delete('box_offered')
   Flags.delete('disarm-trap-type')
   Flags.delete('disarm-shift')
   Flags.delete('more-traps')
   Flags.delete('more-locks')
   Flags.delete('glance-no-traps')
   Flags.delete('glance-no-locks')
+  $gear = nil
 end
 
 Pick.new

--- a/pick.lic
+++ b/pick.lic
@@ -154,7 +154,7 @@ class Pick
       open_containers
       check_for_boxes if !@popper
       remove_hindering_gear
-      loop {box_popper} if @popper
+      loop { box_popper } if @popper
       crack_boxes
       stop_buffs
       wear_normal_gear
@@ -891,7 +891,7 @@ class Pick
       popper_return_box until !@popper_box
     end
   end
-  
+
   def popper_return_box
     case DRC.bput("Give my #{@popper_box} to #{@popper_box_belongs_to}", /has accepted your offer/i, /nothing in your right hand/i, /What is it you\'re trying to give/i)
     when /has accepted your offer/i
@@ -907,7 +907,6 @@ class Pick
     end
   end
   ### end of Box Popping! ###
-
 end
 
 before_dying do


### PR DESCRIPTION
Added a new argument called 'popper'. 

**;pick popper**

Will set the executor of the the script to:

- receive box from other
- pop said box
- return the box
- wait for another box

Also added a check to ensure gear is worn at the close of the script.

Also added function to report how many popper boxes have been done at the end of the session.

This is phase 1 of my intended updates to pick. The next update will be a "poppee" mode, where executor finds and gives their boxes to the popper for popping.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds 'popper' mode to `pick.lic` for accepting, popping, and returning boxes, ensures gear is worn, and reports boxes popped.
> 
>   - **Behavior**:
>     - Adds 'popper' mode to `Pick` class in `pick.lic`, allowing the executor to accept, pop, and return boxes.
>     - Ensures gear is worn at the end of the script using `$gear`.
>     - Reports the number of boxes popped at the end of the session.
>   - **Functions**:
>     - Adds `box_popper` and `popper_return_box` methods to handle box popping and returning.
>     - Modifies `attempt_open` to skip looting and disposing of boxes in 'popper' mode.
>   - **Misc**:
>     - Introduces `$gear` and `$geared_up` variables to manage equipment state.
>     - Adds `popper` argument to `arg_definitions` in `initialize` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 32eae13a9ca454531e34194d97c999d487810721. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->