### PR TITLE
[script][combat-trainer] Add support for rush ACM

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4658,6 +4658,9 @@ class GameState
     @cambrinth_invoke_exact_amount = settings.cambrinth_invoke_exact_amount
     echo("  @cambrinth_invoke_exact_amount: #{@cambrinth_invoke_exact_amount}") if $debug_mode_ct
 
+    @rush_shield = settings.rush_shield
+    echo("  @rush_shield: #{@rush_shield}") if $debug_mode_ct
+
     if @use_analyze_combos && DRStats.barbarian?
       Flags.add('ct-accuracy-ready', 'You sense your combat accuracy decrease')
       Flags['ct-accuracy-ready'] = true
@@ -4830,11 +4833,50 @@ class GameState
     return unless can_engage?
     return if stomp
     return if pounce
+    return if rush
 
     case DRC.bput("engage", /^You (are already|begin to) (stealthily )?(advanc(e|ing)|at melee)/, /^There is nothing else/, /is already quite dead/, /^What do you want to advance towards/)
     when /You are already advancing/, /You begin to advance/, /You begin to stealthily advance/
       pause 2
     end
+  end
+
+  def rush
+    return if retreating?
+    return false if DRC.left_hand
+    return false unless @rush_shield
+    return false unless npcs.any?
+    return false unless charged_maneuver_off_cooldown?(@charged_maneuvers['Shield Usage'])
+
+    wield_specific_weapon(@rush_shield, nil, false)
+    maneuver_success = case DRC.bput("maneuver rush",
+                                     /^You angle your .* towards .* and charge forwards/,
+                                     /^You are already engaged/,
+                                     /^You are unable to focus on performing a maneuver while aiming at an enemy/,
+                                     /^There is nothing else to face/,
+                                     /^You must rest a bit longer before attempting/)
+                       when /You must rest a bit longer before attempting/ # ability not actually off cooldown
+                         @cooldown_timers['rush'] += 15
+                         false
+                       when /There is nothing else to face/ # nothing to rush
+                         false
+                       when /You are unable to focus on performing a maneuver while aiming at an enemy/
+                         @cooldown_timers['rush'] += 15 # If we happen to try to engage while aiming, don't retry immediately
+                         false
+                       when /You are already engaged/ # already at melee
+                         true
+                       when /^You angle your .* towards .* and charge forwards/
+                         if Flags['ct-maneuver-cooldown-reduced'] && DRStats.paladin?
+                           @cooldown_timers['rush'] = Time.now + 45 # Paladins can get a shortened timer (similar to Barbarians for all other maneuvers)
+                           Flags.reset('ct-maneuver-cooldown-reduced')
+                         else
+                           @cooldown_timers['rush'] = Time.now + 90
+                         end
+                         true
+                       end
+
+    DRCI.wear_item?(@rush_shield)
+    return maneuver_success
   end
 
   def stomp

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -177,6 +177,7 @@ charged_maneuvers:
   Staves: twirl
   Polearms: impale
   Dual Wield: doublestrike
+  Shield Usage: rush
 
 # If "Charged Maneuver" is set in your training_abilities, this setting
 # will attempt doublestrikes by temporarily wielding a "doublestrike trainable"
@@ -234,6 +235,9 @@ stomp_to_engage: false
 pounce_on_cooldown: false
 # Toggle use of Pounce to engage (when it is available)
 pounce_to_engage: false
+
+# Define a worn shield to Rush to engage. It should match the name provided in your gear.
+rush_shield:
 
 # Defines the number of monsters you will keep in combat with you by performing 'dance actions' or attacking with only 'harmless: true' spells. 0 means kill everything.
 dance_threshold: 0


### PR DESCRIPTION
Adds the option to use the `rush` ACM to engage, when possible.

There are 2 new YAML settings. Specifying a `rush_shield` is mandatory. The shield must match your gear (similar to how you specify items in weapon_training):


```
rush_shield: triangular sipar

charged_maneuvers:
  Shield Usage: rush
```

(I wanted to incorporate this into `use_charged_maneuver`, but it doesn't seem possible with the way the game_state is managed. If anyone has a better implementation of this, I of course welcome it.)