### PR TITLE
[script] [combat-trainer] add match for "You need two hands" when fail to attack

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3707,7 +3707,7 @@ class AttackProcess
         end
       end
 
-      DRC.bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
+      DRC.bput(command, 'Wouldn\'t it be better if you used a melee weapon?', 'You need two hands to wield this weapon', 'You turn to face', 'Face What?', 'Roundtime', "You aren't close enough to attack", 'It would help if you were closer', 'There is nothing else to face!', 'You must be hidden', 'flying too high for you to attack', 'You can\'t coldcock', 'while it is flying', 'Novel idea, but it\'s a ghost!', 'Bumbling, you slip', 'You can not slam with that', 'You must be hidden or invisible to ambush', 'You don\'t have enough focus', 'You don\'t think you have enough focus', 'is already out cold')
     end
 
     pause


### PR DESCRIPTION
### Issue

When trying to attack with a two-handed weapon and your offhand is holding something unexpectedly, then combat-trainer hangs because it is missing a match string.

```log
[combat-trainer: message: You need two hands to wield this weapon!]

[combat-trainer: checked against [/Wouldn't it be better if you used a melee weapon?/i, /You turn to face/i, /Face What?/i, /Roundtime/i, /You aren't close enough to attack/i, /It would help if you were closer/i, /There is nothing else to face!/i, /You must be hidden/i, /flying too high for you to attack/i, /You can't coldcock/i, /while it is flying/i, /Novel idea, but it's a ghost!/i, /Bumbling, you slip/i, /You can not slam with that/i, /You must be hidden or invisible to ambush/i, /You don't have enough focus/i, /You don't think you have enough focus/i, /is already out cold/i]]

[combat-trainer: for command feint]
```

### Changes

- Add missing match string `'You need two hands to wield this weapon'`
- No other changes necessary as a few lines later in the script it has logic to handle this scenario, it was just missing the match string to get there 😉 

### Test

```log
> glance

You glance down to see a diacan marauder blade with a grip wrapped in morgawr leather in your right hand and a chamois cloth in your left hand.

[combat-trainer]>feint

You need two hands to wield this weapon!

[combat-trainer]>stow left

You put your cloth in your wyvern skull.

[combat-trainer]>feint

< With the precision and elegance of a plunging goshawk, you feint...  The blade lands a strong hit (6/22) to the rat's left arm.
[You're mighty, solidly balanced with no advantage.]
[Roundtime 2 sec.]
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add match string to handle error when a two-handed weapon cannot be wielded due to the offhand being occupied in `AttackProcess`.
> 
>   - **Behavior**:
>     - Add match string `'You need two hands to wield this weapon'` to `DRC.bput` in `AttackProcess` to handle cases where a two-handed weapon cannot be wielded due to the offhand being occupied.
>   - **Misc**:
>     - No other changes necessary as existing logic handles this scenario once the match string is recognized.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 3b51d10f44b36b9b118801976de7d56b0d9ad58e. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->