### PR TITLE
Update base-town.yaml

### DIFF
--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -44,8 +44,8 @@ Crossing:
     id: 8266
     name: Falken
   npc_empath:
-    # id: 6870 # This is the Crossing npc healer room.  Martyr Saedelthorp and Apprentice Kaiva.
-    id: 6218 # This is dokt, commented out for the wild magic event.
+    id: 6870 # This is the Crossing npc healer room.  Martyr Saedelthorp and Apprentice Kaiva.
+    # id: 6218 # This is Dokt.  Dokt is no longer a healer.  Leaving in for posterity
   locksmithing:
     id: 19125
     name: Ragge

--- a/data/base-town.yaml
+++ b/data/base-town.yaml
@@ -268,8 +268,8 @@ Knife Clan:
   nexus: # Crossing
     id: 19162
   deposit: *crossing_deposit
-  npc_empath:
-    id: 6218 # This is dokt
+  # npc_empath:
+    # id: 6218 # This is Dokt.  He no longer heals.  Leaving this here for Posterity
 Darkling Wood:
   currency: dokoras
   nexus: # Shard


### PR DESCRIPTION
update base-town to remove Dokt as he is no longer a healer.

Crossing now defaults to the Crossing auto healer
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `npc_empath` ID in `base-town.yaml` for Crossing to default to the Crossing auto healer, removing Dokt as a healer.
> 
>   - **Behavior**:
>     - Update `npc_empath` ID in `base-town.yaml` for Crossing to default to the Crossing auto healer (ID 6870).
>     - Remove Dokt (ID 6218) as a healer, as he is no longer serving that role.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for afec3869688bc8de01f658fd32549bfb8204aceb. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->