### PR TITLE
[script] [dependency] support waypoint overrides `timeto` as numbers or string procs

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -698,7 +698,8 @@ class ScriptManager
         new_wayto = StringProc.new("#{values['str_proc']}")
       end
       if values['travel_time']
-        new_timeto = values['travel_time'].to_f
+        new_timeto = Float(values['travel_time'], exception: false)
+        new_timeto ||= StringProc.new("#{values['travel_time']}")
       end
       start_room.wayto["#{end_room_id}"] = new_wayto
       start_room.timeto["#{end_room_id}"] = new_timeto

--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '2.0.11'
+$DEPENDENCY_VERSION = '2.0.12'
 $MIN_RUBY_VERSION = '3.3.1'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/KzSAUPnDHh'
 


### PR DESCRIPTION
### Background

In Lich's mapdb, the `timeto` property of a room can be either a number or a stringproc.

For example:
```json
  "timeto": {
    "2321": 0.2,
    "9400": ";e unless UserVars.athletics >= 260 then nil else 0.2 end"
  },
```

In a character's yaml config, player's can define a `personal_wayto_overrides` setting. Currently, only numeric `timeto` values are supported. For more advanced overrides, allowing string procs for `timeto` is necessary.

### Changes

- If a `timeto` value is defined then try to parse it as a number, if it doesn't parse then treat it as a string proc

### Example Usage

_This is a sneak peek at what https://github.com/elanthia-online/dr-scripts/pull/7169, https://github.com/elanthia-online/dr-scripts/pull/7170 and https://github.com/elanthia-online/dr-scripts/pull/7171 will enable_

```yaml
personal_wayto_overrides:
  gondola_bypass_north:
    start_room: 2904 # south platform
    end_room: 2249 # north platform
    str_proc: start_script('bescort', ['gondola_bypass', 'north']); wait_while{running?('bescort')};
    travel_time: unless UserVars.flying_mount then 240 else 0.2 end
  gondola_bypass_south:
    start_room: 2249 # north platform
    end_room: 2904 # south platform
    str_proc: start_script('bescort', ['gondola_bypass', 'south']); wait_while{running?('bescort')};
    travel_time: unless UserVars.flying_mount then 240 else 0.2 end

```