### PR TITLE
[script] [skill-recorder] refactor as class and check if have a flying mount for athletics based travel

### DIFF
--- a/skill-recorder.lic
+++ b/skill-recorder.lic
@@ -7,22 +7,22 @@ no_kill_all
 
 silence_me
 
-skill_recorder_passive_delay = get_settings.skill_recorder_passive_delay
-skill_recorder_check_exp_mods = get_settings.skill_recorder_check_exp_mods
+class SkillRecorder
+  def initialize
+    settings = get_settings
 
-before_dying do
-  # We won't be checking `exp mods` regularly so
-  # revert values to their non-modified ranks.
-  DRSkill.exp_modifiers.clear
-  UserVars.athletics = DRSkill.getrank('Athletics')
-  UserVars.instinct = DRSkill.getrank('Instinct')
-end
+    @skill_recorder_passive_delay = settings.skill_recorder_passive_delay
+    @skill_recorder_check_exp_mods = settings.skill_recorder_check_exp_mods
 
+    passive_loop
+  end
+
+  def passive_loop
 loop do
   # If enabled, then check your actual effective skill ranks
   # rather than assume the base 10% from any buffs you may have active.
   # This also detects curses where your effective ranks are reduced.
-  if skill_recorder_check_exp_mods
+      if @skill_recorder_check_exp_mods
     check_exp_mods # drinfomon method
   end
 
@@ -53,5 +53,17 @@ loop do
 
   UserVars.know_rezz = (DRStats.guild == 'Cleric' && DRSpells.known_spells['Resurrection'])
 
-  pause skill_recorder_passive_delay
+      pause @skill_recorder_passive_delay
 end
+  end
+end
+
+before_dying do
+  # We won't be checking `exp mods` regularly so
+  # revert values to their non-modified ranks.
+  DRSkill.exp_modifiers.clear
+  UserVars.athletics = DRSkill.getrank('Athletics')
+  UserVars.instinct = DRSkill.getrank('Instinct')
+end
+
+SkillRecorder.new

--- a/skill-recorder.lic
+++ b/skill-recorder.lic
@@ -14,47 +14,52 @@ class SkillRecorder
     @skill_recorder_passive_delay = settings.skill_recorder_passive_delay
     @skill_recorder_check_exp_mods = settings.skill_recorder_check_exp_mods
 
+    # Also save this setting in UserVars so that it is
+    # available in stringprocs in the map db and wayto overrides.
+    # Flying mounts allow you to skip athletics checks when moving.
+    UserVars.flying_mount = settings.flying_mount
+
     passive_loop
   end
 
   def passive_loop
-loop do
-  # If enabled, then check your actual effective skill ranks
-  # rather than assume the base 10% from any buffs you may have active.
-  # This also detects curses where your effective ranks are reduced.
+    loop do
+      # If enabled, then check your actual effective skill ranks
+      # rather than assume the base 10% from any buffs you may have active.
+      # This also detects curses where your effective ranks are reduced.
       if @skill_recorder_check_exp_mods
-    check_exp_mods # drinfomon method
-  end
+        check_exp_mods # drinfomon method
+      end
 
-  UserVars.athletics = DRSkill.getmodrank('Athletics')
+      UserVars.athletics = DRSkill.getmodrank('Athletics')
 
-  if DRSpells.active_spells['Athleticism'] || DRSpells.active_spells['Khri Flight'] || DRSpells.active_spells['Unyielding']
-    # If these buffs are active but we don't see a change in `exp mods`
-    # then assume the minimum modifier amount of 10%
-    if DRSkill.getrank('Athletics') == DRSkill.getmodrank('Athletics')
-      UserVars.athletics = UserVars.athletics * 1.1
-    end
-  end
+      if DRSpells.active_spells['Athleticism'] || DRSpells.active_spells['Khri Flight'] || DRSpells.active_spells['Unyielding']
+        # If these buffs are active but we don't see a change in `exp mods`
+        # then assume the minimum modifier amount of 10%
+        if DRSkill.getrank('Athletics') == DRSkill.getmodrank('Athletics')
+          UserVars.athletics = UserVars.athletics * 1.1
+        end
+      end
 
-  if DRStats.guild == 'Ranger'
-    UserVars.scouting = nil unless UserVars.scouting.nil?
-    UserVars.instinct = DRSkill.getmodrank('Instinct')
-  end
+      if DRStats.guild == 'Ranger'
+        UserVars.scouting = nil unless UserVars.scouting.nil?
+        UserVars.instinct = DRSkill.getmodrank('Instinct')
+      end
 
-  UserVars.thief_tunnels = {}
-  if DRStats.guild == 'Thief' && DRStats.circle > 5
-    UserVars.thief_tunnels['crossing_passages'] = true
-    UserVars.thief_tunnels['shard_passages'] = true
+      UserVars.thief_tunnels = {}
+      if DRStats.guild == 'Thief' && DRStats.circle > 5
+        UserVars.thief_tunnels['crossing_passages'] = true
+        UserVars.thief_tunnels['shard_passages'] = true
 
-    if UserVars.athletics >= 25
-      UserVars.thief_tunnels['crossing_leth'] = true
-    end
-  end
+        if UserVars.athletics >= 25
+          UserVars.thief_tunnels['crossing_leth'] = true
+        end
+      end
 
-  UserVars.know_rezz = (DRStats.guild == 'Cleric' && DRSpells.known_spells['Resurrection'])
+      UserVars.know_rezz = (DRStats.guild == 'Cleric' && DRSpells.known_spells['Resurrection'])
 
       pause @skill_recorder_passive_delay
-end
+    end
   end
 end
 


### PR DESCRIPTION
### Background

To take advantage of string procs in `travel_time` props of personal waypoint overrides introduced in https://github.com/elanthia-online/dr-scripts/pull/7169 to check if a character has a flying mount to bypass athletics-based travel then we need an efficient way to know if the character has `flying_mount:` set in their settings.

For performance, we don't want the mapdb loading settings multiple times each time it's calculating routes that include waypoints that need to check `get_settings.flying_mount`.

Therefore, by convention of `UserVars.athletics` and other variables that `skill-recorder` tracks, this PR proposes that it set `UserVars.flying_mount = settings.flying_mount` after loading the settings only once.

### Changes

- Refactor logic into a class per convention with most other Lich scripts
- Load settings once then set instance variables as needed
- On init, set `UserVars.flying_mount = settings.flying_mount` so that the variable can be referenced in `travel_time` prop of personal waypoint overrides

### Example Usage

_This is a sneak peek at what https://github.com/elanthia-online/dr-scripts/pull/7169, https://github.com/elanthia-online/dr-scripts/pull/7170 and https://github.com/elanthia-online/dr-scripts/pull/7171 will enable_

```yaml
personal_wayto_overrides:
  gondola_bypass_north:
    start_room: 2904 # south platform
    end_room: 2249 # north platform
    str_proc: start_script('bescort', ['gondola_bypass', 'north']); wait_while{running?('bescort')};
    travel_time: unless UserVars.flying_mount then 240 else 0.2 end
  gondola_bypass_south:
    start_room: 2249 # north platform
    end_room: 2904 # south platform
    str_proc: start_script('bescort', ['gondola_bypass', 'south']); wait_while{running?('bescort')};
    travel_time: unless UserVars.flying_mount then 240 else 0.2 end
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `skill-recorder.lic` into `SkillRecorder` class to optimize settings initialization and manage skill-related variables efficiently.
> 
>   - **Refactor**:
>     - Convert `skill-recorder.lic` into `SkillRecorder` class.
>     - Initialize settings once in `initialize` method and set `UserVars.flying_mount`.
>   - **Functionality**:
>     - `passive_loop` method updates `UserVars` based on skill ranks and active spells.
>     - `before_dying` block clears `DRSkill.exp_modifiers` and resets `UserVars.athletics` and `UserVars.instinct`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 8cd8eae3cc11eaff859970292e92bad4736a142d. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->