### PR TITLE
[script] [bescort] add gondola bypass support for flying mounts

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -152,6 +152,10 @@ class Bescort
         { name: 'mode', options: %w[north south], description: 'Which direction are you going?' }
       ],
       [
+        { name: 'fly_under_gondola', regex: /fly_under_gondola/i, description: 'Fly over the obstacles under the gondola between Shard and Leth Deriel' },
+        { name: 'mode', options: %w[north south], description: 'Which direction are you going?' }
+      ],
+      [
         { name: 'sandbarge', regex: /sandbarge/i, description: 'The sand barge between Hvaral, Oasis, and Muspari' },
         { name: 'start_location', options: %w[hvaral oasis muspari], description: 'Where are you coming from?' },
         { name: 'end_location', options: %w[hvaral oasis muspari], description: 'Where do you need to get to?' }
@@ -278,6 +282,8 @@ class Bescort
       take_theren_rope_bridge(args.mode)
     elsif args.gondola
       ride_gondola(args.mode)
+    elsif args.fly_under_gondola
+      fly_under_gondola(args.mode)
     elsif args.sandbarge
       take_sandbarge(args.start_location, args.end_location)
     elsif args.desert
@@ -1839,7 +1845,24 @@ class Bescort
     fput('rel mana')
   end
 
+  # Waits for and rides the gondola to the other platform.
   def ride_gondola(mode)
+    north_platform_room_id = 2249
+    south_platform_room_id = 2904
+
+    case mode.downcase
+    when /north/
+      unless Room.current.id == south_platform_room_id
+        echo("Must start at the south platform, room number #{south_platform_room_id}, to ride the gondola north")
+        exit
+      end
+    when /south/
+      unless Room.current.id == north_platform_room_id
+        echo("Must start at the north platform, room number #{north_platform_room_id}, to ride the gondola south")
+        exit
+      end
+    end
+
     case DRC.bput('go gondola', 'There is no wooden gondola here', 'Gondola, Cab')
     when /no wooden gondola here/i
       DRC.bput('look gondola', 'The wooden gondola')
@@ -1852,6 +1875,54 @@ class Bescort
       waitfor 'With a soft bump, the gondola comes to a stop at its destination'
       move 'out'
     end
+  end
+
+  # Uses a flying mount to bypass the athletics checks so you
+  # can take the shortcut under the gondola to the other side.
+  def fly_under_gondola(mode)
+    north_start_room_id = 2245  # on road north of gondola at branch
+    south_start_room_id = 19466 # under gondola at southside of the log
+
+    case mode.downcase
+    when /north/
+      unless Room.current.id == south_start_room_id
+        echo("Must start under gondola at southside of the log, room number #{south_start_room_id}, to fly under the gondola north")
+        exit
+      end
+      moveset = [
+        'go log',
+        'go embankment',
+        'southwest',
+        'south',
+        'down',
+        'go wall',
+        'go ledge',
+        'go niche',
+        'go branch'
+      ]
+    when /south/
+      unless Room.current.id == north_start_room_id
+        echo("Must start on road north of gondola at the branch, room number #{north_start_room_id}, to fly under the gondola south")
+        exit
+      end
+      moveset = [
+        'go branch',
+        'go niche',
+        'go ledge',
+        'go wall',
+        'up',
+        'north',
+        'northeast',
+        'go embankment',
+        'go log'
+      ]
+    end
+
+    # Set speed to slow so that we go one room at a time
+    # and don't mistakenly run down other paths.
+    use_flying_mount(@flying_mount, 'mount', 'slow')
+    moveset.each { |dir| move(dir) }
+    use_flying_mount(@flying_mount, 'dismount')
   end
 
   def take_xing_ferry(mode)

--- a/bescort.lic
+++ b/bescort.lic
@@ -148,11 +148,11 @@ class Bescort
         { name: 'mode', options: %w[totheren torossman], description: 'Where do you need to get to?' }
       ],
       [
-        { name: 'gondola', regex: /gondola/i, description: 'Gondola between Shard and Leth Deriel' },
+        { name: 'gondola', regex: /^gondola$/i, description: 'Gondola between Shard and Leth Deriel' },
         { name: 'mode', options: %w[north south], description: 'Which direction are you going?' }
       ],
       [
-        { name: 'fly_under_gondola', regex: /fly_under_gondola/i, description: 'Fly over the obstacles under the gondola between Shard and Leth Deriel' },
+        { name: 'fly_under_gondola', regex: /^fly_under_gondola$/i, description: 'Fly over the obstacles under the gondola between Shard and Leth Deriel' },
         { name: 'mode', options: %w[north south], description: 'Which direction are you going?' }
       ],
       [


### PR DESCRIPTION
### Background

It would be nice if `bescort` would take into consideration if a user has a flying mount to bypass athletics checks when traveling. For my specific use case, when wanting to go under the gondola (instead of riding it or climbing around it) to go between Leth and Shard.

### Changes

- Add a `fly_under_gondola` function to use your flying mount to use the under gondola shortcut
- Validate you are in the correct starting room to ride (or fly under) the gondola

### Example Usage

```yaml
flying_mount: barkcloth rug

personal_wayto_overrides:
  fly_under_gondola_north:
    start_room: 19466 # under gondola at southside of the log
    end_room: 2245 # on road north of gondola at branch
    str_proc: "start_script('bescort', ['fly_under_gondola', 'north']); wait_while{running?('bescort')};"
    travel_time: "unless UserVars.flying_mount then nil else 0.2 end"
  fly_under_gondola_south:
    start_room: 2245 # on road north of gondola at branch
    end_room: 19466 # under gondola at southside of the log
    str_proc: "start_script('bescort', ['fly_under_gondola', 'south']); wait_while{running?('bescort')};"
    travel_time: "unless UserVars.flying_mount then nil else 0.2 end"
```

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `fly_under_gondola` function to `bescort.lic` for bypassing gondola athletics checks using flying mounts, with new argument parsing for this feature.
> 
>   - **Behavior**:
>     - Adds `fly_under_gondola` function in `bescort.lic` to bypass gondola athletics checks using flying mounts.
>     - Validates starting room for `fly_under_gondola` and `ride_gondola` functions to ensure correct initiation.
>   - **Argument Parsing**:
>     - Adds `fly_under_gondola` option with `north` and `south` modes to argument definitions in `Bescort` class.
>   - **Misc**:
>     - Adjusts regex for `gondola` argument to ensure exact match.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 91af13ee8ce20c4f9d337a9635c6a6bce1ad3761. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->