### PR TITLE
[script] [dependency] fix: mute all exp output

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,7 +10,7 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '2.0.12'
+$DEPENDENCY_VERSION = '2.0.13'
 $MIN_RUBY_VERSION = '3.3.1'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/KzSAUPnDHh'
 
@@ -1823,7 +1823,7 @@ unless $DRINFOMON_IN_CORE_LICH
 
   echo("DRinfomon ready.")
 else
-  Lich::Util.issue_command("exp all 0", /^Circle: \d+/, /^Rested EXP Stored|type: AWAKEN|Unlock Rested Experience/, quiet: true, timeout: 1)
+  Lich::Util.issue_command("exp all 0", /^Circle: \d+/, /^EXP HELP/, quiet: true, timeout: 1)
   Lich::Util.issue_command("info", /^Name/, /^<output class=""/, quiet: true, timeout: 1)
   Lich::Util.issue_command("played", /^Account Info for/, quiet: true, timeout: 1)
   Lich::Util.issue_command("ability", /^You (?:know the Berserks|recall the spells you have learned from your training)|^From (?:your apprenticeship you remember practicing|the \w+ tree)/, /^You (?:recall that you have \d+ training sessions|can use SPELL STANCE \[HELP\]|have \d+ available slot)/, quiet: true, timeout: 1)


### PR DESCRIPTION
### Background

When `dependency.lic` starts it runs `exp all 0` command, squelching _most_ of the output.

_While awake_
```
[dependency]>exp all 0

Overall state of mind: clear
EXP HELP for more information

[dependency]>info
```

_While asleep_
```
[dependency]>exp all 0

Overall state of mind: clear

You are relaxed and your mind has entered a light state of rest.  To wake up and start learning again, type: AWAKEN.  To enter a deep state of rest, enter the SLEEP command again.
EXP HELP for more information

[dependency]>info
```

### Changes

- Mute output until `EXP HELP` line is seen

```
[dependency]>exp all 0

[dependency]>info
```


### Tests

- As a Premium character, both while asleep and awake
- As a F2P character, both while asleep and awake

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `dependency.lic` to mute `exp all 0` output until `EXP HELP` is seen, affecting both asleep and awake states, and increment version to `2.0.13`.
> 
>   - **Behavior**:
>     - Modify `Lich::Util.issue_command` in `dependency.lic` to mute output until `EXP HELP` is seen.
>     - Affects both asleep and awake states for characters.
>   - **Version**:
>     - Increment version from `2.0.12` to `2.0.13` in `dependency.lic`.
>   - **Testing**:
>     - Tested with Premium and F2P characters, both asleep and awake.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for c09df6bca199edd119206ce5730bb50e6e2af336. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->