### PR TITLE
[script] [combat-trainer] fix: add matches when no enemy to attack

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -5255,6 +5255,8 @@ class GameState
     maneuver_failure_messages = [
       # You are not engaged with any enemies
       /^There is nothing else to face/,
+      /^What are you trying to attack/,
+      /^Face what/,
       # Your ranged weapon is unloaded
       /^You prepare the shot, but stop when you realize/,
       # Maneuver is still on cooldown


### PR DESCRIPTION
### Changes

- Add matches for `What are you trying to attack?` and `Face what?` when try to perform a combat maneuver and no enemies to engage

```
[combat-trainer]>maneuver rush

Face what?
What are you trying to attack?

...

[combat-trainer: *** No match was found after 15 seconds, dumping info]

```


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add regex patterns to handle cases where no enemy is available to attack in `combat-trainer.lic`.
> 
>   - **Behavior**:
>     - Add regex patterns to `maneuver_failure_messages` in `combat-trainer.lic` to handle cases where no enemy is available to attack.
>     - Specifically handles `What are you trying to attack?` and `Face what?` messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for e0d963102ee576990779316be1e9924c7cb7414c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->