### PR TITLE
fix(horse-trainer): Add match for when lacking knowledge

### DIFF
--- a/horse-trainer.lic
+++ b/horse-trainer.lic
@@ -18,7 +18,7 @@ class TeachHorse
 
   def instruct(skill)
     @start = Time.now
-    case DRC.bput("instruct horse #{skill}", 'You begin', 'horse is already')
+    case DRC.bput("instruct horse #{skill}", 'You begin', 'horse is already', /^You don't know enough about that to instruct a horse/)
     when 'horse is already'
       return
     end


### PR DESCRIPTION
Resolves https://github.com/elanthia-online/dr-scripts/issues/7176
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds error handling for lacking knowledge in `instruct(skill)` in `horse-trainer.lic`.
> 
>   - **Behavior**:
>     - Adds a new match pattern `/^You don't know enough about that to instruct a horse/` to `DRC.bput` in `instruct(skill)` method in `horse-trainer.lic`.
>     - Handles cases where the user lacks knowledge to instruct a horse, preventing script errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for a652a29a1da26c68eb4a32264ad51f421a4e5b92. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->