### PR TITLE
[validate.lic] Add check for dual_load/bow powershot coexisting

### DIFF
--- a/validate.lic
+++ b/validate.lic
@@ -105,6 +105,12 @@ class DRYamlValidator
     warn('You have no weapons configured in weapon_training: this will likely cause problems.')
   end
 
+  def assert_that_dual_load_and_charged_maneuvers_bows_do_not_coexist(settings)
+    return unless settings.dual_load && settings.charged_maneuvers.has_key?('Bow')
+
+    error('dual_load: true is not compatible with using charged_maneuvers with Bows!  Set dual_load to false or configure charged_maneuvers without Bows')
+  end
+
   def assert_that_cyclic_no_release_spell_is_invalid_unless_listed_in_base_spells(settings)
     return if !settings.cyclic_no_release
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a validation in `validate.lic` to ensure `dual_load` and `charged_maneuvers` with `Bows` do not coexist in settings.
> 
>   - **Behavior**:
>     - Adds `assert_that_dual_load_and_charged_maneuvers_bows_do_not_coexist(settings)` to `DRYamlValidator` in `validate.lic`.
>     - Raises an error if `dual_load` is true and `charged_maneuvers` includes `Bow`.
>   - **Misc**:
>     - No changes to existing functions or other files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for da9c738018065e2cd2e0fb9041892b4d46aeedcc. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->