### PR TITLE
[scripts][sell-loot] Handle bundle change TT

### DIFF
--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -121,7 +121,12 @@ class SellLoot
 
     DRC.release_invisibility
     DRC.bput('sell my bundle', 'ponders over the bundle', 'sorts through it', 'gives it a close inspection', 'takes the bundle')
-    DRC.bput('stow rope', 'You put')
+    case DRC.left_hand+" "+DRC.right_hand
+    when /rope/
+      DRCI.put_away_item('rope')
+    when /bundle/
+      DRCI.put_away_item('bundle') unless DRCI.wear_item?('bundle')
+    end
   end
 
   def check_spare_pouch(container, adj)

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -121,7 +121,7 @@ class SellLoot
 
     DRC.release_invisibility
     DRC.bput('sell my bundle', 'ponders over the bundle', 'sorts through it', 'gives it a close inspection', 'takes the bundle')
-    case DRC.left_hand+" "+DRC.right_hand
+    case DRC.left_hand + " " + DRC.right_hand
     when /rope/
       DRCI.put_away_item('rope')
     when /bundle/
@@ -237,7 +237,7 @@ class SellLoot
                     "What is it you're trying to give",               # no container or no npc
                     "not interested in",                              # non-traps in container
                     "doesn't appear to be interested in your offer",  # not a thief
-                    "I don't have that in stock right now")            # players in room, try again later
+                    "I don't have that in stock right now")           # players in room, try again later
       when "not interested in"
         DRC.message("Remove non-trap components from #{container} then try again.")
       when "doesn't appear to be interested in your offer"

--- a/sell-loot.lic
+++ b/sell-loot.lic
@@ -123,9 +123,9 @@ class SellLoot
     DRC.bput('sell my bundle', 'ponders over the bundle', 'sorts through it', 'gives it a close inspection', 'takes the bundle')
     case DRC.left_hand + " " + DRC.right_hand
     when /rope/
-      DRCI.put_away_item('rope')
+      DRCI.put_away_item?('rope')
     when /bundle/
-      DRCI.put_away_item('bundle') unless DRCI.wear_item?('bundle')
+      DRCI.put_away_item?('bundle') unless DRCI.wear_item?('bundle')
     end
   end
 


### PR DESCRIPTION
Accounts for TT276 where bundles stay as bundles indefinitely even when sold.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes issue TT276 in `sell-loot.lic` by ensuring bundles are put away after being sold in `sell_bundle` method.
> 
>   - **Behavior**:
>     - Fixes issue TT276 where bundles remain as bundles after being sold in `sell_bundle` method of `SellLoot` class.
>     - Adds logic to check if the item in hand is a bundle and puts it away unless worn.
>   - **Misc**:
>     - Minor whitespace change in `sell_traps` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 8c683dcb60269861b7767e6c8b5542fc8b821703. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->