### PR TITLE
[scripts][trade]Fix sew script start

### DIFF
--- a/trade.lic
+++ b/trade.lic
@@ -1873,7 +1873,7 @@ class Trade
       outfitting_type = should_knit? ? 'knitting' : 'sewing'
       outfitting_mat = should_knit? ? 'wool' : 'burlap'
       @current_materials[@outfitting_material_type] -= recipe['volume']
-      start_script('sew', ['stow', outfitting_type, recipe['chapter'].to_s, recipe['name'], outfitting_mat].map { |arg| arg =~ /\s/ ? "\"#{arg}\"" : arg }, recipe['noun'])
+      start_script('sew', ['stow', outfitting_type, recipe['chapter'].to_s, recipe['name'], outfitting_mat, recipe['noun']].map { |arg| arg =~ /\s/ ? "\"#{arg}\"" : arg })
     end
   end
 


### PR DESCRIPTION
Updating the outfitting routine to start sew correctly, aligning with changes made to the engineering routine a while back.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `start_script` call in `Trade` class to correctly include `recipe['noun']` for the `sew` script.
> 
>   - **Behavior**:
>     - Fixes `start_script` call in `Trade` class to correctly include `recipe['noun']` in the argument list for the `sew` script.
>   - **Misc**:
>     - Aligns outfitting routine with previous changes in the engineering routine.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for f7bd41f0f685be372a5fe2df8b5d3547f70dcc95. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->