### PR TITLE
[data][base-recipes] remove simple gwethsmashers from being used for workorders

### DIFF
--- a/data/base-recipes.yaml
+++ b/data/base-recipes.yaml
@@ -9100,7 +9100,7 @@ crafting_recipes:
   noun: bone totem
   type: artificing
   chapter: 2
-  work_order: true
+  work_order: false
   enchant_stock1_name: abolition
   enchant_stock1: 2
   enchant_stock2_name: metamorphosis


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `simple gwethsmasher` work order status to false in `base-recipes.yaml`.
> 
>   - **Behavior**:
>     - Change `work_order` from `true` to `false` for `simple gwethsmasher` in `base-recipes.yaml`.
>     - Affects `artificing` type, chapter 2.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for faf82ce8154269999afd30877d3d836ba065222c. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->