### PR TITLE
[scripts][dependency] Spam version warning and autostarts

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -10,16 +10,19 @@ require 'ostruct'
 require 'digest/sha1'
 require 'monitor'
 
-$DEPENDENCY_VERSION = '2.0.13'
+$DEPENDENCY_VERSION = '2.0.14'
 $MIN_RUBY_VERSION = '3.3.1'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/KzSAUPnDHh'
 
 unless Gem::Version.new(LICH_VERSION) >= Gem::Version.new('5.11.0')
-  _respond("<pushBold/>*****************************************************************************<popBold/>")
-  _respond("<pushBold/>* Lich versions prior to 5.11.0 were deprecated on Thursday 27 March 2025.  *<popBold/>")
-  _respond("<pushBold/>* See https://github.com/elanthia-online/dr-scripts/wiki/First-Time-Setup   *<popBold/>")
-  _respond("<pushBold/>* For update instructions.                                                  *<popBold/>")
-  _respond("<pushBold/>*****************************************************************************<popBold/>")
+  100.times do
+    _respond("<pushBold/>*****************************************************************************<popBold/>")
+    _respond("<pushBold/>* Lich versions prior to 5.11.0 were deprecated on Thursday 27 March 2025.  *<popBold/>")
+    _respond("<pushBold/>* See https://github.com/elanthia-online/dr-scripts/wiki/First-Time-Setup   *<popBold/>")
+    _respond("<pushBold/>* For update instructions.                                                  *<popBold/>")
+    _respond("<pushBold/>*****************************************************************************<popBold/>")
+    pause 15
+  end
   exit
 end
 
@@ -250,7 +253,7 @@ class ScriptManager
 
     UserVars.autostart_scripts ||= []
     UserVars.autostart_scripts.uniq!
-    UserVars.autostart_scripts = UserVars.autostart_scripts - ['dependency']
+    UserVars.autostart_scripts -= ['dependency']
     Settings['autostart'] ||= Array.new
 
     unless Settings['autostart'] == Settings['autostart'].uniq
@@ -287,7 +290,7 @@ class ScriptManager
   end
 
   def update_autostarts
-    @autostarts = (UserVars.autostart_scripts + Settings['autostart']).uniq
+    @autostarts = (UserVars.autostart_scripts.to_a + SetupFiles.new.get_settings.autostarts.to_a + Settings['autostart']).uniq
   end
 
   def add_global_auto(script)
@@ -861,7 +864,6 @@ class SlackbotManager
     return unless @slackbot.nil?
 
     echo("Registering Slackbot")
-    custom_require.call('slackbot')
     @slackbot = SlackBot.new
   end
 

--- a/dependency.lic
+++ b/dependency.lic
@@ -15,13 +15,14 @@ $MIN_RUBY_VERSION = '3.3.1'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/KzSAUPnDHh'
 
 unless Gem::Version.new(LICH_VERSION) >= Gem::Version.new('5.11.0')
-  100.times do
+  10.times do
     _respond("<pushBold/>*****************************************************************************<popBold/>")
     _respond("<pushBold/>* Lich versions prior to 5.11.0 were deprecated on Thursday 27 March 2025.  *<popBold/>")
     _respond("<pushBold/>* See https://github.com/elanthia-online/dr-scripts/wiki/First-Time-Setup   *<popBold/>")
     _respond("<pushBold/>* For update instructions.                                                  *<popBold/>")
+    _respond("<pushBold/>* Exiting Dependency now. Nothing much will work from here...               *<popBold/>")
     _respond("<pushBold/>*****************************************************************************<popBold/>")
-    pause 15
+    pause 10
   end
   exit
 end


### PR DESCRIPTION
Spams the version warning now.

Also allows for yaml-based autostarts.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances version warning repetition and adds YAML-based autostart support in `dependency.lic`.
> 
>   - **Behavior**:
>     - Version warning for Lich versions prior to 5.11.0 now repeats 100 times with a 15-second pause between each in `dependency.lic`.
>     - Adds support for YAML-based autostarts in `update_autostarts` method of `ScriptManager` class.
>   - **Misc**:
>     - Updates `$DEPENDENCY_VERSION` to '2.0.14'.
>     - Simplifies subtraction operation in `ScriptManager` by using `-=` operator.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for c7232fe4a831ce338396295457459f85b0263971. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->