### PR TITLE
Update base-spells.yaml

### DIFF
--- a/data/base-spells.yaml
+++ b/data/base-spells.yaml
@@ -3007,7 +3007,7 @@ spell_data:
     metamagic: true
   River in the Sky:
     skill: Warding
-    abbrev: rits
+    abbrev: RITS
     mana: 15
     guild: Ranger
     mana_type: life


### PR DESCRIPTION
Updated abbreviation for River in the Sky from rits to RITS to align with other spell abbreviations.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Changed abbreviation for `River in the Sky` from `rits` to `RITS` in `base-spells.yaml` for consistency.
> 
>   - **Abbreviation Update**:
>     - Changed abbreviation for `River in the Sky` from `rits` to `RITS` in `base-spells.yaml` to align with other spell abbreviations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for e44e6968b79b962347a1b74b125a08f6d4de76b5. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->