### PR TITLE
base-crafting - fix Riverhaven carving stock room

### DIFF
--- a/data/base-crafting.yaml
+++ b/data/base-crafting.yaml
@@ -1272,7 +1272,7 @@ carving:
     polish-number: 4
     repair-room: 8856
     repair-npc: Valomenica
-    stock-room: 9110
+    stock-room: 8858
     pattern-book: carving
   Langenfirth:
     << : *theren_carving


### PR DESCRIPTION
Riverhaven's carving stock room number was incorrect.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects the `stock-room` number for Riverhaven's carving section in `data/base-crafting.yaml`.
> 
>   - **Fix**:
>     - Corrected `stock-room` number from `9110` to `8858` for Riverhaven's carving section in `data/base-crafting.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for dfd3b5da0077379939e7658ea84dcadc3cdbac5f. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->