### PR TITLE
Fix typo for Ushnish altar match

### DIFF
--- a/truffenyi-commune-quest.lic
+++ b/truffenyi-commune-quest.lic
@@ -128,7 +128,7 @@ class TruffenyiCommuneQuest
                              'trothfang'
                            when /a tithe box sitting outside of a small chapel, the tail of a snake disappearing into the slot/i
                              'huldah'
-                           when /a scene of wilted crops interspersed with livestock lying supine a rough texture to the carving is noticeable above each animal/i
+                           when /a scene of wilted crops interspersed with livestock lying supine; a rough texture to the carving is noticeable above each animal/i
                              'ushnish'
                            when /a simply dressed mage sleeping underneath an elm tree during a downpour. A spellbook sits open on a nearby picnic table/i
                              'drogor'


### PR DESCRIPTION
Script could not recognize the dark aspect Ushnish on my altar for the quest. There was a missing semicolon in the match text.

Here's the full text for my miniature altar: `A carving along the front of the miniature altar depicts a boar carrying a seashell.  On the back, another carving depicts a scene of wilted crops interspersed with livestock lying supine; a rough texture to the carving is noticeable above each animal.  Inside, three round indentations are carved along the bottom of the altar.`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes a typo in the 'ushnish' altar description regex pattern in `TruffenyiCommuneQuest`.
> 
>   - **Fix**:
>     - Corrects a typo in the regular expression pattern for matching the 'ushnish' altar description in `TruffenyiCommuneQuest` class, changing a comma to a semicolon.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 2236967f00ed6d912ff60c2fffbdd00d3e3d8236. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->