### PR TITLE
[script] [registergear] add new script

### DIFF
--- a/registergear.lic
+++ b/registergear.lic
@@ -1,0 +1,113 @@
+def register_item(item_name, debug = false)
+  echo "[reggear: Tapping: #{item_name}]" if debug
+  fput("tap #{item_name}")
+  tap_output = waitfor(/^You tap .+?\./, /^What were you referring/i, /^The faces on your stick pause/i)
+
+  if tap_output =~ /^What were you referring/i
+    echo "[reggear: Could not identify item: #{item_name}]"
+    return
+  end
+
+  if tap_output =~ /^The faces on your stick pause/
+    echo "[reggear: Cannot tap #{item_name} — skipping (locked/animated)]"
+    return
+  end
+
+  if match = tap_output.match(/^You tap (.+)\./i)
+    description = match[1]
+    echo "[reggear: Matched item: #{description}]" if debug
+  else
+    echo "[reggear: Could not match description for #{item_name}]"
+    return
+  end
+
+  echo "[reggear: Removing #{item_name}...]"
+  remove_result = fput("remove #{item_name}")
+  if remove_result !~ /(remove|loosen|take off|unstrap|pull off|take .* off|detach|strip off|slide.*off)/i
+    echo "[reggear: Failed to remove #{item_name}.]" if debug
+
+    get_result = fput("get #{item_name}")
+    if get_result =~ /already holding/i
+      echo "[reggear: Already holding #{item_name} — skipping get.]" if debug
+    elsif get_result =~ /need a free hand/
+      echo "[Hands are full, cannot get #{item_name}. Skipping.]" if debug
+      return
+    else
+      echo "[reggear: getting #{item_name}.]" if debug
+    end
+  end
+
+  echo "[reggear: Registering #{item_name} (1st time)...]" if debug
+  reg_result = fput("register #{item_name}")
+
+  if reg_result =~ /do not have enough Kronars/i
+    echo "[reggear: Not enough Kronars to register #{item_name}. Skipping.]" if debug
+    return
+  end
+
+  if reg_result =~ /You cannot register, I am sorry/i
+    echo "[reggear: Cannot register items in this room.]" if debug
+    exit
+  end
+
+  if reg_result =~ /did the paperwork for that.+recently/i
+    echo "[reggear: #{item_name} is already registered. Skipping re-registration.]" if debug
+    fput("wear #{item_name}")
+    return
+  end
+
+  if reg_result =~ /There appears to be some problems with the item/i
+    echo "[reggear: Cannot register #{item_name} because it has attached or contained items. Skipping.]" if debug
+    return
+  end
+
+  echo "[reggear: Registering #{item_name} second time]" if debug
+  fput("register #{item_name}")
+
+  echo "[reggear: Rewearing #{item_name}...]" if debug
+  wear_result = fput("wear #{item_name}")
+  unless wear_result =~ /(You wear|You already)/i
+    echo "[WARNING: Failed to rewear #{item_name}.]" if debug
+    unless wear_result =~ /already in your inventory/
+      stow_item(item_name, debug)
+    end
+  end
+
+  echo "[reggear: #{item_name} registered successfully.]"
+end
+
+def get_item(item_name, debug = true)
+  echo "[reggear: getting #{item_name}.]" if debug
+  fput("get #{item_name}")
+end
+
+def stow_item(item_name, debug = true)
+  echo "[reggear: stowing #{item_name}.]" if debug
+  fput("stow #{item_name}")
+end
+
+settings = get_settings
+@gearsets = settings.gear_sets
+set_name = settings.set_name || "standard"
+
+unless @gearsets
+  echo "[reggear: No 'gear_sets' defined in yaml.]" if debug
+  exit
+end
+
+@items = @gearsets[set_name]
+
+unless @items
+  echo "[reggear: Gear set '#{set_name}' not found in yaml.]" if debug
+  exit
+end
+
+debug = true
+echo "[reggear: Walking to registrar...]" if debug
+DRCT.walk_to(14670)
+fput("go curtain")
+
+@items.each do |item|
+  register_item(item, debug)
+  pause 1  # prevent command flooding
+end


### PR DESCRIPTION
New script for registering gear listed in your `gear:`

All questions or concerns on this should be directed at @Algonem as they are the author.  I'm just adding the new file for him!


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `registergear.lic` script to automate gear registration with error handling and settings integration.
> 
>   - **New Script**:
>     - Adds `registergear.lic` to automate gear registration.
>     - Uses `register_item`, `get_item`, and `stow_item` functions.
>   - **Behavior**:
>     - Handles item tapping, removal, registration, and re-wearing.
>     - Checks for errors: item identification, locked items, insufficient funds, room restrictions, and item issues.
>   - **Settings**:
>     - Reads gear sets from settings and processes each item in the specified set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 29cd2342adb7c4edcd5837e9db2cc5837c1e81f0. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->