### PR TITLE
Update combat-trainer.lic for App Pouch with empty pouch

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3078,7 +3078,7 @@ class TrainerProcess
       appraise(game_state, 'careful')
     when /^App Pouch$/i
       DRC.retreat
-      DRC.bput("app my #{@gem_pouch_adjective} #{@gem_pouch_noun} quick", 'You sort', 'Appraise what', 'You cannot appraise', 'You can\'t appraise', 'There doesn\'t appears to be anything')
+      DRC.bput("app my #{@gem_pouch_adjective} #{@gem_pouch_noun} quick", 'You sort', 'Appraise what', 'You cannot appraise', 'You can\'t appraise', 'There doesn\'t appear to be anything')
     when /^App Bundle$/i
       DRC.retreat
       DRC.bput("app my bundle quick", 'You scan', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3078,7 +3078,7 @@ class TrainerProcess
       appraise(game_state, 'careful')
     when /^App Pouch$/i
       DRC.retreat
-      DRC.bput("app my #{@gem_pouch_adjective} #{@gem_pouch_noun} quick", 'You sort', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')
+      DRC.bput("app my #{@gem_pouch_adjective} #{@gem_pouch_noun} quick", 'You sort', 'Appraise what', 'You cannot appraise', 'You can\'t appraise', 'There doesn\'t appears to be anything')
     when /^App Bundle$/i
       DRC.retreat
       DRC.bput("app my bundle quick", 'You scan', 'Appraise what', 'You cannot appraise', 'You can\'t appraise')


### PR DESCRIPTION
Updated match string for App Pouch for if the pouch is empty

log:
>
[combat-trainer]>app my soft pouch quick
The soft gem pouch is a container, and can be opened and closed. The soft gem pouch is fairly soft.
It appears that the soft gem pouch can be worn attached to a belt. The soft gem pouch feels pretty light.
There doesn't appear to be anything in the soft gem pouch. Roundtime: 3 seconds.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `combat-trainer.lic` to handle empty gem pouch during appraisal by adding a new match string.
> 
>   - **Behavior**:
>     - Update `combat-trainer.lic` to handle empty gem pouch during appraisal.
>     - Adds match string 'There doesn\'t appear to be anything' to `DRC.bput()` call for `App Pouch` case.
>   - **Misc**:
>     - No other changes or refactoring in the script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 2643995ac6ba553767d24a4deb0772dd7c18ba52. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->