### PR TITLE
[help-me.lic] add file modification time to output

### DIFF
--- a/help-me.lic
+++ b/help-me.lic
@@ -42,7 +42,7 @@ class HelpMe
 
     Dir[File.join(SCRIPT_DIR, 'profiles/*.yaml')].map { |item| File.path(item) }.select { |path| path.include?("#{checkname}-") }.each do |path|
       message_body += "\n****" * 3
-      message_body += path.to_s
+      message_body += "#{path.to_s}  -  Modified: #{File.mtime(path)}"
       message_body += "\n"
       message_body += File.read(path)
     end

--- a/help-me.lic
+++ b/help-me.lic
@@ -42,7 +42,7 @@ class HelpMe
 
     Dir[File.join(SCRIPT_DIR, 'profiles/*.yaml')].map { |item| File.path(item) }.select { |path| path.include?("#{checkname}-") }.each do |path|
       message_body += "\n****" * 3
-      message_body += "#{path.to_s}  -  Modified: #{File.mtime(path)}"
+      message_body += "#{path}  -  Modified: #{File.mtime(path)}"
       message_body += "\n"
       message_body += File.read(path)
     end


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds file modification time to YAML profile output in `help-me.lic`.
> 
>   - **Behavior**:
>     - Adds file modification time to the output in `help-me.lic` for each YAML profile file.
>     - Affects the loop in `submit_help_pastebin` where profile paths are processed.
>   - **Misc**:
>     - Concatenates file path and modification time in the message body.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for dd6a258a7454ad4efc5ceaf26014b55b38314847. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->