### PR TITLE
Correct a silverfish room in base-hunting.yaml

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -431,10 +431,10 @@ hunting_zones:
   - 6088
   - 6090
   - 6089
+  - 6087
   elder_silverfish:
   # Beyond the jagged opening elder hardened silverfish (~14 relative level) spawn.
   # Premie Only
-  - 6087
   - 6086
   - 6085
   - 6084


### PR DESCRIPTION
Room 6087 is right outside of the entrance to the elder silverfish and spawns hardened silverfish
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reclassify room `6087` to spawn hardened silverfish instead of elder silverfish in `base-hunting.yaml`.
> 
>   - **Behavior**:
>     - Moves room `6087` from `elder_silverfish` to `hardened_silverfish` in `base-hunting.yaml`.
>     - Room `6087` now spawns hardened silverfish instead of elder silverfish.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for fde11f6187f493556405f323168f81c472081612. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->