### PR TITLE
[script][bescort]shard thief guild update

### DIFF
--- a/bescort.lic
+++ b/bescort.lic
@@ -2123,7 +2123,7 @@ class Bescort
 
   def enter_thief_guild
     password = @settings.shard_thief_password
-    case DRC.bput('knock',/^You wait, but nothing happens/, /^A moment later, a slit opens in the door at eye level/)
+    case DRC.bput('knock', /^You wait, but nothing happens/, /^A moment later, a slit opens in the door at eye level/)
     when /^A moment later, a slit opens in the door at eye level/
       DRC.bput("say #{password}", 'You lean towards the doorway')
     end

--- a/bescort.lic
+++ b/bescort.lic
@@ -2129,10 +2129,21 @@ class Bescort
       when /^You say/
         DRC.message("fix yer yaml ye grub! Yer password is wrong!")
         DRC.message("Set the correct value for shard_thief_password")
+        stop_script("go2") if Script.running?("go2")
         exit
       end
     end
-    move 'go door'
+    case DRC.bput('go door', /From behind the doorway you hear a faint chuckle/, /Obvious exits/)
+    when /From behind the doorway you hear a faint chuckle/
+      case DRC.bput("say #{password}", 'You lean towards the doorway', /^You say/)
+      when /^You say/
+        DRC.message("fix yer yaml ye grub! Yer password is wrong!")
+        DRC.message("Set the correct value for shard_thief_password")
+        stop_script("go2") if Script.running?("go2")
+        exit
+      end
+      move 'go door'
+    end
   end
 
   def use_shard_gates

--- a/bescort.lic
+++ b/bescort.lic
@@ -2123,9 +2123,14 @@ class Bescort
 
   def enter_thief_guild
     password = @settings.shard_thief_password
-    case DRC.bput('knock', /^You wait, but nothing happens/, /^A moment later, a slit opens in the door at eye level/)
+    case DRC.bput('knock',/^You wait, but nothing happens/, /^A moment later, a slit opens in the door at eye level/)
     when /^A moment later, a slit opens in the door at eye level/
-      DRC.bput("say #{password}", 'You lean towards the doorway')
+      case DRC.bput("say #{password}", 'You lean towards the doorway', /^You say/)
+      when /^You say/
+        DRC.message("fix yer yaml ye grub! Yer password is wrong!")
+        DRC.message("Set the correct value for shard_thief_password")
+        exit
+      end
     end
     move 'go door'
   end

--- a/bescort.lic
+++ b/bescort.lic
@@ -2123,7 +2123,7 @@ class Bescort
 
   def enter_thief_guild
     password = @settings.shard_thief_password
-    case DRC.bput('knock',/^You wait, but nothing happens/, /^A moment later, a slit opens in the door at eye level/)
+    case DRC.bput('knock', /^You wait, but nothing happens/, /^A moment later, a slit opens in the door at eye level/)
     when /^A moment later, a slit opens in the door at eye level/
       case DRC.bput("say #{password}", 'You lean towards the doorway', /^You say/)
       when /^You say/

--- a/bescort.lic
+++ b/bescort.lic
@@ -2123,8 +2123,10 @@ class Bescort
 
   def enter_thief_guild
     password = @settings.shard_thief_password
-    DRC.bput('knock', 'You knock on the door')
-    DRC.bput("say #{password}", 'You lean towards the doorway')
+    case DRC.bput('knock',/^You wait, but nothing happens/, /^A moment later, a slit opens in the door at eye level/)
+    when /^A moment later, a slit opens in the door at eye level/
+      DRC.bput("say #{password}", 'You lean towards the doorway')
+    end
     move 'go door'
   end
 


### PR DESCRIPTION
Handle the case where password is not required due to a recent visit
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `enter_thief_guild` in `Bescort` class to conditionally say password based on door response, handling cases where it's not needed.
> 
>   - **Behavior**:
>     - Update `enter_thief_guild` in `Bescort` class to handle cases where password is not required.
>     - Only say password if door slit opens after knocking, indicating a password is needed.
>   - **Misc**:
>     - Modify `enter_thief_guild` to use regex for response matching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 02f207afc241f62adb56c3b88b554a2ea7cbdca4. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->