### PR TITLE
TT - more mech mice.

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -389,6 +389,7 @@ hunting_zones:
   - 665
   # https://elanthipedia.play.net/Giant_mechanical_mouse                  0-2000
   # Flex creatures, require special weapon material to hit
+  # 51715, 51716, and 132 are outdoors, rest are indoors.
   mechanical_mice:
   - 134
   - 13468
@@ -400,6 +401,8 @@ hunting_zones:
   - 6873
   - 132
   - 133
+  - 51716
+  - 51715
   # https://elanthipedia.play.net/Musk_Hog                                 10-35
   hogs:
   - 1438


### PR DESCRIPTION
Add two rooms to support TT expansion.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add two new room IDs to `mechanical_mice` in `base-hunting.yaml` for TT expansion, marking them as outdoors.
> 
>   - **Hunting Zones**:
>     - Add two new room IDs `51715` and `51716` to `mechanical_mice` in `base-hunting.yaml` to support TT expansion.
>     - These rooms are noted as outdoors, along with room `132`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 5e3f21c747f69e2521eec33a220767c4bcd0302a. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->