### PR TITLE
[scripts][inventory-manager] Fix a family vault issue and add support for urchin version command for inventory saves

### DIFF
--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -26,7 +26,8 @@ class InventoryManager
         { name: 'servant', regex: /servant/i, optional: true, description: "Save shadow servant inventory." },
         { name: 'shop', regex: /shop/i, optional: true, description: "Save your Trader shop inventory." },
         { name: 'pocket', regex: /pocket/i, optional: true, description: "Rummages your secret pocket container for list of items. NOTE: Must be wearing the container." },
-        { name: 'vault_standard', regex: /vault_standard/i, optional: true, description: "Uses VAULT STANDARD to get a list of items." }
+        { name: 'vault_standard', regex: /vault_standard/i, optional: true, description: "Uses VAULT STANDARD to get a list of items." },
+        { name: 'vault_family', regex: /vault_family/i, optional: true, description: "Uses VAULT FAMILY to get a list of items." }
       ],
       [
         { name: 'search', regex: /search/i, description: 'Start a search across all characters for specified item.' },
@@ -54,6 +55,8 @@ class InventoryManager
       add_vault_book
     elsif args.vault_standard
       add_vault_standard
+    elsif args.vault_family
+      add_vault_family
     elsif args.vault_regular
       add_vault_regular_inv
     elsif args.family_vault
@@ -293,6 +296,10 @@ class InventoryManager
     check_inventory("vault standard", /^Vault Inventory:/, 'vault')
   end
 
+  def add_vault_family
+    check_inventory("vault family", /^Vault Inventory:/, 'Family')
+  end
+
   def add_vault_book
     unless DRCI.get_item_if_not_held?("vault book")
       DRC.message("Unable to find your vault book, exiting!")
@@ -341,7 +348,7 @@ class InventoryManager
   end
 
   def add_family_vault
-    check_inventory("rummage vault", /^You rummage through a secure vault/, 'Family', 42)
+    check_inventory("rummage vault", /^You rummage through a vault/, 'Family', 42)
   end
 
   def add_vault_regular_inv


### PR DESCRIPTION
Was having trouble saving my family vault info via rummage, and there was no `;inv save vault_standard` equivalent for using urchins to go rummage for me. Apparently the rummage of family vault is not "secure" but just a vault :)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for family vault inventory saving and fixes regex for non-secure family vaults in `inventory-manager.lic`.
> 
>   - **Behavior**:
>     - Adds support for `vault_family` command in `InventoryManager` to save family vault inventories.
>     - Fixes regex in `add_family_vault` to match non-secure vaults.
>   - **Functions**:
>     - Adds `add_vault_family` function to handle family vault inventory saving.
>     - Updates `add_family_vault` to use correct regex for non-secure vaults.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=elanthia-online%2Fdr-scripts&utm_source=github&utm_medium=referral)<sup> for 1aef1d344acaf387fbf7b5cf05a549cc23a958f0. You can [customize](https://app.ellipsis.dev/elanthia-online/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->