### PR TITLE
[script][task-forage] handle full containers, resume tasks, reuse stored items

### DIFF
--- a/task-forage.lic
+++ b/task-forage.lic
@@ -3,7 +3,9 @@ class TaskForage
     arg_definitions = [
       [
         { name: 'town', optional: true, options: %w[crossing shard], variable: true,
-          description: 'Which town you want to run tasks in. If none provided, your hometown is used.' }
+          description: 'Which town you want to run tasks in. If none provided, your hometown is used.' },
+        { name: 'resume', optional: true, regex: /^resume$/i,
+          description: 'Pick up a task that is already in progress instead of canceling it.' }
       ]
     ]
 
@@ -128,6 +130,9 @@ class TaskForage
               'begins to advance on you!')
     Flags.add('giver-move', *@move_regex)
     Flags.add('cluttered', 'The room is too cluttered to find anything here', 'tries to forage for something, but can\'t find it with all the clutter here')
+    # Both messages mean the forage container has no room left for the item in hand
+    Flags.add('container-full', 'There isn\'t any more room in',
+              /You just can't get .+ to fit in .+ no matter how you arrange it/)
 
     @task_givers = { 'shard'    => { 'npc' => 'peddler', 'location' => @shard_path },
                      'crossing' => { 'npc' => 'Mags', 'location' => '954' } }
@@ -156,19 +161,87 @@ class TaskForage
     @tasks_completed = 0
     @tasks_failed = 0
     @item_count = 0
+    @delivered = 0
 
     echo 'UserVars:' if @debug
     echo UserVars.task_forage.to_yaml if @debug
     echo 'forage_settings:' if @debug
     echo @forage_settings.to_yaml if @debug
 
+    # Resuming reads the task journal, so it needs no trip to the giver first
+    resumed = @args.resume ? resume_task : false
+
     while determine_task_necessary
-      find_giver
-      get_task
+      unless resumed
+        find_giver
+        get_task
+      end
+      resumed = false
       gather_items
       find_giver
       complete_task
     end
+  end
+
+  # Adopt a task that's already in progress rather than canceling it. Returns false if
+  # there's nothing usable to resume, leaving the normal flow to cancel whatever is there.
+  def resume_task
+    echo 'resume_task' if @debug
+    # Match the "turn in" line, which the journal prints last, so the entry above it is
+    # already in the buffer by the time bput returns. Other task types have no such line,
+    # so they fall through to the timeout and are left alone.
+    remaining_regex = /You need to turn in (?<remaining>\d+) more/
+    no_task_regex = /You are not currently on a task/
+    result = DRC.bput('task', { 'suppress_no_match' => true, 'timeout' => 3 },
+                      remaining_regex, no_task_regex)
+    remaining_match = result.match(remaining_regex)
+    unless remaining_match
+      if result =~ no_task_regex
+        DRC.message('You are not on a task, so there is nothing to resume.')
+      else
+        DRC.message('Your in-progress task is not a foraging task. Not resuming it.')
+      end
+      return false
+    end
+    remaining = remaining_match[:remaining].to_i
+
+    # Match objects rather than Regexp.last_match -- the sub below would reset it
+    # Leading .* forces the last " in " before the verb, so a descriptor like
+    # "the peddler in red" can't be mistaken for the town
+    entry_regex = /.*\bin (?<town>.+?) wants you to retrieve (?<number>\d+) (?<item>.+?)\./
+    entry = reget(20).reverse.find { |line| line =~ entry_regex }
+    unless entry
+      DRC.message('Unable to read the task entry from your journal.')
+      return false
+    end
+
+    entry_match = entry.match(entry_regex)
+    entry_town = entry_match[:town].downcase.sub(/^the /, '')
+    entry_number = entry_match[:number].to_i
+    entry_item = entry_match[:item]
+    echo "journal entry: #{entry_number} #{entry_item} for #{entry_town}, #{remaining} remaining" if @debug
+
+    unless entry_town == @task_town
+      DRC.message("Your in-progress task is for #{entry_town}, not #{@task_town}. Not resuming it.")
+      return false
+    end
+
+    @number = entry_number
+    @item = entry_item
+    @delivered = [@number - remaining, 0].max
+    @item_count = @delivered # Items already turned in still count toward the total
+
+    # Deliberately not evaluate_item -- that declines the offer, which is the wrong verb
+    # for a task already accepted. Returning false lets the caller cancel it instead.
+    unless known_item? && mapped_item? && ready_item? && closeby_item?
+      DRC.message("Unable to resume the in-progress task for #{@item}.")
+      return false
+    end
+
+    DRC.message("Resuming task: #{@number} #{@item}, #{remaining} still to turn in.")
+    DRCI.stow_hands
+    use_stored_items
+    true
   end
 
   def follow_wanderer
@@ -304,6 +377,7 @@ class TaskForage
       case result
       when /I need (\d+) ([^.]+)/
         @item_count = 0
+        @delivered = 0
         @number = Regexp.last_match(1).to_i
         @item = Regexp.last_match(2)
         echo "Gathering #{@number} of #{@item}" if @debug
@@ -341,7 +415,20 @@ class TaskForage
     when /Remember, I need/
       echo 'Task received' if @debug
       DRCI.stow_hands
+      use_stored_items
     end
+  end
+
+  # Leftovers from an earlier task or a previous run can already be sitting in the forage
+  # container. Count those toward the task rather than foraging duplicates.
+  def use_stored_items
+    echo 'use_stored_items' if @debug
+    stored = @item_variants.sum { |noun| DRCI.count_items_in_container(noun, @forage_container) }
+    echo "stored #{@item_variants.join('/')}: #{stored}" if @debug
+    return unless stored.positive?
+
+    @item_count = [@item_count + stored, @number].min
+    DRC.message("Found #{stored} #{@item} in your #{@forage_container}. Using #{@item_count} of the #{@number} needed.")
   end
 
   def decline_task
@@ -452,6 +539,7 @@ class TaskForage
   # Check to make sure we have data on this item, and know the correct name.
   def known_item?
     echo 'known_item?' if @debug
+    @item_variants = nil
     if @foraging_data.any? { |item| item['item'] == @item }
       # no change necessary
     elsif @foraging_data.any? { |item| item['item'] == @item.chomp('s') }
@@ -471,6 +559,9 @@ class TaskForage
     elsif @item == 'pieces of wild corn'
       @item = 'corn'
     elsif @item == 'sticks, branches or limbs'
+      # Mags takes any of the three, so all three count in the container and at turn-in.
+      # Foraging still uses @item, the first entry.
+      @item_variants = %w[stick branch limb]
       @item = 'stick'
     elsif @item == 'some chamomile'
       @item = 'chamomile'
@@ -484,8 +575,15 @@ class TaskForage
       DRC.message("I don't know where to find #{@item}")
       return false
     end
-    echo 'known = true' if @debug
+    @item_variants ||= [@item]
+    echo "known = true, variants: #{@item_variants}" if @debug
     true
+  end
+
+  # Pull any of the nouns this task accepts out of the forage container.
+  # Returns the noun actually taken, or nil if none were there.
+  def get_task_item
+    @item_variants.find { |noun| DRCI.get_item?(noun, @forage_container) }
   end
 
   # Check if we have a location for the item
@@ -569,23 +667,53 @@ class TaskForage
     end
   end
 
+  # Pile up the foragables in the current room, moving on if the room is cluttered
+  def collect_pile
+    echo 'collect_pile' if @debug
+    DRC.collect(@item, false)
+    return unless Flags['cluttered']
+
+    cluttered_gathering_room
+    DRC.collect(@item, false)
+  end
+
+  # The forage container filled up mid-task. Hand over everything gathered so far so
+  # that the container has room again, then head back out for the rest.
+  def deliver_gathered_items
+    echo 'deliver_gathered_items' if @debug
+    Flags.reset('container-full')
+    DRC.message("Your #{@forage_container} is full. Turning in #{@item_count - @delivered} #{@item} before gathering more.")
+    find_giver
+    give_item # The item still in hand is the one that wouldn't fit
+    while @delivered < @item_count
+      noun = get_task_item
+      break unless noun
+
+      give_item(noun)
+    end
+    DRCT.walk_to(@item_location) if @item_count < @number
+  end
+
   # Travel to the nearest foraging spot and start to gather them
   def gather_items
     echo 'gather_items' if @debug
+    return if @item_count >= @number # Already covered by what's in the container
+
     DRCT.walk_to(@item_location)
     Flags.reset('cluttered')
     Flags.reset('combat')
+    Flags.reset('container-full')
 
     if @collect
-      DRC.collect(@item, false)
-      if Flags['cluttered']
-        cluttered_gathering_room
-        DRC.collect(@item, false)
-      end
+      collect_pile
       while @item_count < @number
         DRCI.get_item_unsafe(@item)
         if DRCI.put_away_item?(@item, @forage_container)
           @item_count += 1
+        elsif Flags['container-full']
+          @item_count += 1
+          deliver_gathered_items
+          collect_pile if @item_count < @number
         else
           DRC.message('Unable to store item.')
           cancel_task
@@ -600,6 +728,10 @@ class TaskForage
         if DRC.forage?(@item, 5)
           @item_count += 1
           unless DRCI.put_away_item?(@item, @forage_container)
+            if Flags['container-full']
+              deliver_gathered_items
+              next
+            end
             DRC.message("You need to make more room in your #{@forage_container}")
             cancel_task
             safe_exit
@@ -621,7 +753,7 @@ class TaskForage
             @tasks_failed += 1
             determine_task_necessary
             get_task
-            DRCT.walk_to(@item_location)
+            DRCT.walk_to(@item_location) if @item_count < @number # The new task may already be covered
           end
         end
       end
@@ -641,14 +773,17 @@ class TaskForage
     false
   end
 
-  def give_item
-    echo 'give_item' if @debug
-    case DRC.bput("give #{@item} to #{@task_giver}", 'and says, "Thanks,', '^What is it you\'re trying to give?',
+  def give_item(noun = @item)
+    echo "give_item: #{noun}" if @debug
+    case DRC.bput("give #{noun} to #{@task_giver}", 'and says, "Thanks,', '^What is it you\'re trying to give?',
                   ' I have a few things here for you, thank you so much for your help', 'Mags sighs and says')
     when /^What is it you're trying to give?/
       find_giver
-      give_item
+      give_item(noun)
+    when /and says, "Thanks,/
+      @delivered += 1
     when /I have a few things here for you, thank you so much for your help/
+      @delivered += 1
       @tasks_completed += 1
       @item = nil
       kill_time(2) if determine_task_necessary
@@ -661,12 +796,14 @@ class TaskForage
   def complete_task
     echo 'complete_task' if @debug
     UserVars.task_forage['item_failures'].delete(@item) unless UserVars.task_forage['item_failures'][@item].nil?
-    @number.times do
-      if !DRCI.get_item?(@item, @forage_container)
+    # Items already handed over during a mid-task container emptying don't need giving again
+    (@number - @delivered).times do
+      noun = get_task_item
+      if noun.nil?
         DRC.message('ERROR: Task item not found.')
         safe_exit
       else
-        give_item
+        give_item(noun)
       end
     end
   end
@@ -681,6 +818,7 @@ end
 before_dying do
   Flags.delete('combat')
   Flags.delete('giver-move')
+  Flags.delete('container-full')
 end
 
 TaskForage.new

--- a/task-forage.lic
+++ b/task-forage.lic
@@ -130,9 +130,12 @@ class TaskForage
               'begins to advance on you!')
     Flags.add('giver-move', *@move_regex)
     Flags.add('cluttered', 'The room is too cluttered to find anything here', 'tries to forage for something, but can\'t find it with all the clutter here')
-    # Both messages mean the forage container has no room left for the item in hand
+    # All three mean the item in hand won't go into the forage container. The weight
+    # message is a capacity limit rather than a count limit, but emptying the container
+    # is the same remedy.
     Flags.add('container-full', 'There isn\'t any more room in',
-              /You just can't get .+ to fit in .+ no matter how you arrange it/)
+              /You just can't get .+ to fit in .+ no matter how you arrange it/,
+              'too heavy to go in there')
 
     @task_givers = { 'shard'    => { 'npc' => 'peddler', 'location' => @shard_path },
                      'crossing' => { 'npc' => 'Mags', 'location' => '954' } }
@@ -685,12 +688,23 @@ class TaskForage
     DRC.message("Your #{@forage_container} is full. Turning in #{@item_count - @delivered} #{@item} before gathering more.")
     find_giver
     give_item # The item still in hand is the one that wouldn't fit
+    from_container = 0
     while @delivered < @item_count
       noun = get_task_item
       break unless noun
 
       give_item(noun)
+      from_container += 1
     end
+
+    # Nothing came out of the container, so emptying it didn't actually free anything.
+    # We still make progress (one item per trip), but the user should know why it's slow.
+    if from_container.zero? && !@warned_no_room && @item_count < @number
+      @warned_no_room = true
+      DRC.message("Your #{@forage_container} had no #{@item} to turn in, so it may be too small or too heavily loaded for this task.")
+      DRC.message('Foraging will continue one item per trip. Use a roomier container to speed this up.')
+    end
+
     DRCT.walk_to(@item_location) if @item_count < @number
   end
 

--- a/task-forage.lic
+++ b/task-forage.lic
@@ -450,7 +450,7 @@ class TaskForage
       find_giver
       cancel_task
     when /I see that you no longer wish to assist me/
-      true
+      echo 'Task canceled' if @debug
     when /wish to end your current/
       echo 'Cancel step 1' if @debug
       case DRC.bput("ask #{@task_giver} for task cancel", 'I see that you no longer wish to assist',


### PR DESCRIPTION
## What this changes

Four related fixes to `task-forage`, all from cases that ended the script early or wasted foraging trips.

### Full forage container no longer aborts the task

A failed `PUT` used to message `You need to make more room in your <container>`, cancel the task and exit. All three full-container responses now set a flag instead:

- `There isn't any more room in the <container> for that.`
- `You just can't get the <item> to fit in the <container>, no matter how you arrange it.`
- `That's too heavy to go in there!` (also `The <item> is too heavy to go in there!`)

When any of them fires, the script turns in everything gathered so far — the item still in hand plus the container's contents — and heads back out for the rest. Partial turn-ins are tracked in `@delivered` so the final hand-in gives `@number - @delivered` rather than blindly re-giving the full count.

The weight message is a capacity limit rather than a count limit, so emptying the container may not help — the item can simply be heavier than that container will ever take. The run still progresses, handing over the item in hand each trip, but it degrades to one round trip per item. It warns once when a turn-in trip pulls nothing out of the container, which is the signal that the container is too small or too heavily loaded rather than merely full.

### New `resume` argument

`;task-forage resume` adopts an in-progress task instead of canceling it. It reads the task journal rather than the giver, so it needs no trip to Mags first:

```
The firewood peddler Mags in The Crossing wants you to retrieve 14 shoe tacks.
You need to turn in 14 more.
```

It recovers the item, the total, and how many are already turned in. It declines to resume — falling back to today's cancel-and-retry — when there's no task, when the in-progress task isn't a foraging task, or when the journal names a different town than the one being run. That last guard matters: without it a Shard task resumed under `crossing` would send you to the wrong giver indefinitely.

### Items already in the container count toward the task

Checked on task acceptance, so leftovers from an earlier task or a previous run aren't foraged again. A fully covered task skips the trip to the foraging spot entirely.

### Tasks accepting several nouns now use all of them

`sticks, branches or limbs` mapped to `stick` alone, but `branch`, `limb` and `stick` are three separate foragables and Mags takes any of them. Branches and limbs sitting in the container were invisible to both the count and the turn-in — a backpack holding 3 limbs and 2 sticks counted as 2.

They're now tracked as a variant set that the container count, the mid-task turn-in and the final hand-in all draw from. Foraging still uses the primary noun. This is the only multi-noun phrasing in `known_item?`; every other item keeps a single-element set and is unaffected.

## Test plan

- [x] Fill the forage container mid-task; confirm the run turns in what it has and resumes foraging rather than exiting
- [ ] Same, for the `no matter how you arrange it` phrasing
- [ ] Same, for the `too heavy to go in there` phrasing
- [x] `;task-forage resume` partway through a task; confirm it picks up the right item and remaining count without visiting the giver first
- [ ] `;task-forage resume` with no task, and while on a non-foraging task; confirm both decline cleanly
- [ ] `;task-forage resume` while on a task for the other town; confirm it declines
- [x] Start a task with matching items already in the container; confirm they count and aren't re-foraged
- [x] Run a `sticks, branches or limbs` task with limbs in the container; confirm they count and are accepted at turn-in
- [ ] Regression: an ordinary task start-to-finish with an empty container

## Notes

Parsing is verified against captured game text for the fresh-task journal entry, the no-task response, a non-foraging journal entry, and a multi-word item (`sticks, branches or limbs`). The partial-progress wording (`You need to turn in 9 more.`) is inferred from the fresh-task line — if it differs in play, `resume` declines and falls back to existing behavior rather than misparsing.

`use_stored_items` issues one `RUMMAGE` per accepted noun, so a sticks task costs 3 rather than 1. Only multi-noun tasks are affected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resuming in-progress foraging tasks with `--resume`, restoring progress without repeating the initial interaction.
  * Foraging continues automatically after gathered items are delivered when container capacity is reached.
  * Improved handling of item variants and collection or turn-in names.

* **Bug Fixes**
  * Prevented previously delivered items from being requested or delivered again.
  * Improved tracking of stored items and remaining delivery quantities.
  * Added clearer cancellation and task-progress feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->