### PR TITLE
workorders: add ;continue to resume an in-progress order from the logbook

### DIFF
--- a/craft.lic
+++ b/craft.lic
@@ -6,7 +6,8 @@ class Craft
   def initialize
     arg_definitions = [
       [
-        { name: 'craft', options: %w[forging outfitting engineering alchemy enchanting], description: 'What craft to train' }
+        { name: 'craft', options: %w[forging outfitting engineering alchemy enchanting], description: 'What craft to train' },
+        { name: 'debug', regex: /debug/i, optional: true, description: 'Enable debug logging' }
       ]
     ]
     args = parse_args(arg_definitions)
@@ -24,6 +25,7 @@ class Craft
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.enchanting_belt
     @overrides = @settings.craft_overrides
+    @debug = args.debug
 
     if args.craft == 'engineering'
       exit if DRSkill.getxp('Engineering') > @craft_max_mindstate
@@ -155,137 +157,46 @@ class Craft
   end
 
   def train_alchemy
-    crafting_data = get_data('crafting')
+    recipes = get_data('recipes').crafting_recipes
     rank = DRSkill.getrank('Alchemy')
+    echo("Craft: train_alchemy rank=#{rank} hometown=#{@hometown} bag=#{@bag}") if @debug
 
     if rank <= 25 # Tier 1  Extremely Easy
-      # Buy red flowers and nemoih root
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /some blister cream/ }
-      DRCM.ensure_copper_on_hand(2000, @settings, @hometown)
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb2_stock'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], recipe['herb2'], crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('cream', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 1 - some blister cream') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /some blister cream/ }, 2000)
     elsif rank <= 50 # Tier 2 - Very Easy
-      # Buy red flowers and plovik leaf
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /some moisturizing ointment/ }
-      DRCM.ensure_copper_on_hand(2000, @settings, @hometown)
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb2_stock'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], recipe['herb2'], crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('ointment', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 2 - some moisturizing ointment') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /some moisturizing ointment/ }, 2000)
     elsif rank <= 100 # Tier 3 - Easy
-      # Buy plovik leaves
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /some chest salve/ }
-      DRCM.ensure_copper_on_hand(2000, @settings, @hometown)
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], 'na', crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('salve', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 3 - some chest salve') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /some chest salve/ }, 2000, herb2: 'na')
     elsif rank <= 175 # Tier 4 - Simple
-      # Buy riolur leaves
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /a neck potion/ }
-      DRCM.ensure_copper_on_hand(2000, @settings, @hometown)
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], 'na', crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('potion', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 4 - a neck potion') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /a neck potion/ }, 2000, herb2: 'na')
     elsif rank <= 300 # Tier 5 - Basic
-      # Buy jadice flower
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /some limb salve/ }
-      DRCM.ensure_copper_on_hand(2000, @settings, @hometown)
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], 'na', crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('salve', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 5 - some limb salve') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /some limb salve/ }, 2000, herb2: 'na')
     elsif rank <= 425 # Tier 6 - Somewhat Challenging
-      # Buy plovik leaves
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /some chest unguent/ }
-      DRCM.ensure_copper_on_hand(4000, @settings, @hometown)
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], 'na', crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('unguent', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 6 - some chest unguent') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /some chest unguent/ }, 4000, herb2: 'na')
     elsif rank <= 550 # Tier 7 - Challenging
-      # Buy riolur leaves
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /some neck tonic/ }
-      DRCM.ensure_copper_on_hand(4000, @settings, @hometown)
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], 'na', crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('tonic', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 7 - some neck tonic') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /some neck tonic/ }, 4000, herb2: 'na')
     elsif rank <= 700 # Tier 8 - Complicated
-      # Buy aevaes leaves
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /some eye tonic/ }
-      DRCM.ensure_copper_on_hand(4000, @settings, @hometown)
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], 'na', crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('tonic', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 8 - some eye tonic') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /some eye tonic/ }, 4000, herb2: 'na')
     elsif rank <= 850 # Tier 9 - Intricate
-      # Buy ojhenik root
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /a body elixir/ }
-      DRCM.ensure_copper_on_hand(4000, @settings, @hometown)
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], 'na', crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('elixir', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 9 - a body elixir') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /a body elixir/ }, 4000, herb2: 'na')
     elsif rank <= 1175 # Tier 10 - Difficult
-      # Forage belradi moss
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /a general elixir/ }
-      DRCM.ensure_copper_on_hand(4000, @settings, @hometown)
-      DRC.wait_for_script_to_complete('alchemy', ['belradi', 'forage', '25'])
-      DRC.wait_for_script_to_complete('alchemy', ['belradi', 'prepare'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], 'na', crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('elixir', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 10 - a general elixir') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /a general elixir/ }, 4000, herb2: 'na', forage: { 'belradi' => 25 })
     elsif rank <= 1400 # Tier 11  Very Difficult
-      # Forage blue flowers and belradi moss
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /some refreshment elixir/ }
-      DRCM.ensure_copper_on_hand(4000, @settings, @hometown)
-      DRC.wait_for_script_to_complete('alchemy', ['blue', 'forage', '25'])
-      DRC.wait_for_script_to_complete('alchemy', ['belradi', 'forage', '5'])
-      DRC.wait_for_script_to_complete('alchemy', ['blue', 'prepare'])
-      DRC.wait_for_script_to_complete('alchemy', ['belradi', 'prepare'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], recipe['herb2'], crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('elixir', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 11 - some refreshment elixir') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /some refreshment elixir/ }, 4000, forage: { 'blue flower' => 25, 'belradi' => 5 })
     else # Tier 12 - Extremely Difficult
-      # Buy red flowers and forage dioica sap
-      recipe = get_data('recipes').crafting_recipes.find { |each_recipe| each_recipe['name'] =~ /some vigor poultices/ }
-      DRCM.ensure_copper_on_hand(4000, @settings, @hometown)
-      DRCT.order_item(crafting_data['remedies'][@hometown]['stock-room'], recipe['herb1_stock'])
-      DRC.wait_for_script_to_complete('alchemy', ['dioica', 'forage', '5'])
-      DRC.wait_for_script_to_complete('alchemy', ['dioica', 'prepare'])
-      DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt)
-      DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt)
-      DRCT.walk_to(@training_room)
-      DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], recipe['herb2'], crafting_data['remedies'][@hometown]['catalyst'], recipe['container'], recipe['noun']])
-      DRCI.dispose_trash('poultices', @worn_trashcan, @worn_trashcan_verb)
+      echo('Craft: alchemy tier 12 - some vigor poultices') if @debug
+      brew(recipes.find { |recipe| recipe['name'] =~ /some vigor poultices/ }, 4000, forage: { 'dioica' => 5 })
     end
   end
 
@@ -700,6 +611,90 @@ class Craft
     DRCI.dispose_trash(DRC.left_hand, @worn_trashcan, @worn_trashcan_verb) if DRC.left_hand && full_name.sub("metal ", "").include?(DRC.left_hand)
   end
 
+  def brew(recipe, copper_needed, herb2: nil, forage: {})
+    unless recipe
+      echo('Craft: brew aborted - recipe not found') if @debug
+      return
+    end
+
+    crafting_data = get_data('crafting')
+    remedies = crafting_data['remedies'][@hometown]
+    catalyst = remedies['catalyst']
+    herb2_arg = herb2.nil? ? (recipe['herb2'] || 'na') : herb2
+    echo("Craft: brew recipe=#{recipe['name']} copper=#{copper_needed} herb1=#{recipe['herb1']} herb1_stock=#{recipe['herb1_stock']} herb2=#{herb2_arg} herb2_stock=#{recipe['herb2_stock']} catalyst=#{catalyst} forage=#{forage}") if @debug
+
+    # From base-recipes.yaml: herb1/herb2 = name, herb1_stock/herb2_stock = shop order #
+    # Count needed for one remedy craft is 25 (or forage override).
+    needs = { recipe['herb1'] => forage[recipe['herb1']] || 25 }
+    unless %w[na none].include?(herb2_arg.to_s)
+      needs[herb2_arg] = forage[herb2_arg] || 25
+    end
+    echo("Craft: brew needs=#{needs}") if @debug
+
+    short = check_alchemy_herbs(needs)
+    echo("Craft: brew short after check=#{short}") if @debug
+    buyable = short.select do |herb, _required|
+      stock = herb_stock_number(recipe, herb)
+      stock && !stock.to_s.empty?
+    end
+    catalyst_on_hand = DRCI.exists?(catalyst)
+    needs_funds = buyable.any? || !catalyst_on_hand
+    echo("Craft: brew buyable=#{buyable} catalyst_on_hand=#{catalyst_on_hand} needs_funds=#{needs_funds}") if @debug
+
+    if needs_funds
+      echo("Craft: brew ensuring #{copper_needed} copper for Alchemy") if @debug
+      unless money_for_training?(copper_needed, 'Alchemy')
+        echo('Craft: brew aborted - insufficient funds') if @debug
+        return
+      end
+    end
+
+    stock_room = remedies['stock-room']
+    short.each do |herb, required|
+      stock = herb_stock_number(recipe, herb)
+      if stock && !stock.to_s.empty?
+        echo("Craft: brew ordering herb=#{herb} stock=#{stock} room=#{stock_room}") if @debug
+        DRCT.order_item(stock_room, stock)
+        DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) if DRC.right_hand
+        DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) if DRC.left_hand
+      else
+        target = alchemy_forage_target(herb)
+        echo("Craft: brew foraging herb=#{herb} target=#{target} qty=#{required}") if @debug
+        DRC.wait_for_script_to_complete('alchemy', [target, 'forage', required.to_s])
+        DRC.wait_for_script_to_complete('alchemy', [target, 'prepare'])
+      end
+    end
+
+    missing = check_alchemy_herbs(needs)
+    echo("Craft: brew short after acquire=#{missing}") if @debug
+    if missing.any?
+      echo("Missing alchemy ingredients: #{missing.keys.join(', ')}. Skipping Alchemy training.")
+      @settings.crossing_training.delete('Alchemy') if @settings.crossing_training
+      return
+    end
+
+    DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) if DRC.right_hand
+    DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) if DRC.left_hand
+    echo("Craft: brew starting remedy chapter=#{recipe['chapter']} container=#{recipe['container']} noun=#{recipe['noun']} room=#{@training_room}") if @debug
+    DRCT.walk_to(@training_room)
+    DRC.wait_for_script_to_complete('remedy', ['remedies', recipe['chapter'], recipe['name'], recipe['herb1'], herb2_arg, catalyst, recipe['container'], recipe['noun']])
+    DRCI.dispose_trash(recipe['noun'], @worn_trashcan, @worn_trashcan_verb)
+    echo('Craft: brew complete') if @debug
+  end
+
+  def herb_stock_number(recipe, herb)
+    return recipe['herb1_stock'] if herb == recipe['herb1']
+    return recipe['herb2_stock'] if herb == recipe['herb2']
+
+    nil
+  end
+
+  def alchemy_forage_target(herb)
+    return 'blue' if herb == 'blue flower'
+
+    herb
+  end
+
   def buy_wood
     crafting_data = get_data('crafting')
     return unless money_for_training?(1000, 'Engineering')
@@ -781,6 +776,36 @@ class Craft
       buy_wood if count < 5
     end
     DRCC.stow_crafting_item('lumber', @bag, @belt)
+  end
+
+  # Herbs is a hash of Key/Value pairs (HerbName => Count)
+  def check_alchemy_herbs(herbs)
+    echo("Craft: check_alchemy_herbs herbs=#{herbs}") if @debug
+    short = {}
+    herbs.each do |herb, required|
+      names = [herb]
+      names << 'dried flower' if herb == 'red flower'
+      names << 'crushed flower' if herb == 'blue flower'
+
+      count = 0
+      held = nil
+      names.each do |name|
+        case DRC.bput("get my #{name}", 'You get', 'You are already', 'What were you')
+        when 'You get', 'You are already'
+          count = DRC.bput("count my #{name}", 'You count out \d+ pieces').scan(/\d+/).first.to_i
+          held = name
+          echo("Craft: check_alchemy_herbs found name=#{name} count=#{count} required=#{required}") if @debug
+          break
+        end
+      end
+      echo("Craft: check_alchemy_herbs missing herb=#{herb} required=#{required}") if @debug && held.nil?
+
+      short[herb] = required if count < required
+      DRCC.stow_crafting_item(held, @bag, @belt) if held
+    end
+    # Return all herbs where count is less than the required value.
+    echo("Craft: check_alchemy_herbs short=#{short}") if @debug
+    short
   end
 
   def check_teaching

--- a/spec/workorders_spec.rb
+++ b/spec/workorders_spec.rb
@@ -122,6 +122,26 @@ RSpec.describe WorkOrders do
       expect(match[:remaining]).to eq('3')
     end
 
+    it 'defines LOGBOOK_ITEM_PATTERN with named capture' do
+      pattern = described_class::LOGBOOK_ITEM_PATTERN
+      match = 'This logbook is tracking a work order requiring you to craft a curved metal shovel from any material.'.match(pattern)
+      expect(match).not_to be_nil
+      expect(match[:item]).to eq('a curved metal shovel')
+    end
+
+    it 'captures fabric items when remaining count is on the same line' do
+      line = 'This logbook is tracking a work order requiring you to craft a knitted napkin from any fabric.  You must bundle and deliver 1 more within the next 2 roisaen.'
+      match = line.match(described_class::LOGBOOK_ITEM_PATTERN)
+      expect(match).not_to be_nil
+      expect(match[:item]).to eq('a knitted napkin')
+      expect(line.match(described_class::LOGBOOK_REMAINING_PATTERN)[:remaining]).to eq('1')
+    end
+
+    it 'defines RESUME_LOGBOOK_PATTERNS as frozen array including LOGBOOK_ITEM_PATTERN' do
+      expect(described_class::RESUME_LOGBOOK_PATTERNS).to be_frozen
+      expect(described_class::RESUME_LOGBOOK_PATTERNS).to include(described_class::LOGBOOK_ITEM_PATTERN)
+    end
+
     it 'defines COUNT_PATTERN with named capture' do
       pattern = described_class::COUNT_PATTERN
       match = '42'.match(pattern)
@@ -169,7 +189,7 @@ RSpec.describe WorkOrders do
 
     it 'defines VERSION as frozen string' do
       expect(described_class::VERSION).to be_frozen
-      expect(described_class::VERSION).to eq('1.0.0')
+      expect(described_class::VERSION).to eq('1.0.2')
     end
   end
 
@@ -346,6 +366,73 @@ RSpec.describe WorkOrders do
       expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::READ_LOGBOOK_PATTERNS)
                                  .and_return('I could not find what you were referring to.')
       expect(workorders.send(:logbook_remaining, 'forging')).to be_nil
+    end
+  end
+
+  # ===========================================================================
+  # #resume_work_order - parse active order from logbook for continue
+  # ===========================================================================
+  describe '#resume_work_order' do
+    let(:recipes) do
+      [
+        { 'name' => 'a curved metal shovel', 'noun' => 'shovel', 'type' => 'blacksmithing' },
+        { 'name' => 'a metal razor', 'noun' => 'razor', 'type' => 'blacksmithing' }
+      ]
+    end
+
+    before do
+      allow(workorders).to receive(:stow_tool)
+    end
+
+    it 'returns recipe name and remaining count for an in-progress order' do
+      expect(DRCI).to receive(:get_item?).with('forging logbook').and_return(true)
+      # bput returns only the matched substring for the first matching pattern
+      expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::RESUME_LOGBOOK_PATTERNS)
+                                 .and_return('This logbook is tracking a work order requiring you to craft a curved metal shovel from any')
+      expect(workorders).to receive(:logbook_remaining).with('forging').and_return(2)
+      expect(Lich::Messaging).to receive(:msg).with('plain', 'WorkOrders: Continuing work order for 2 a curved metal shovel')
+
+      expect(workorders.send(:resume_work_order, 'forging', recipes)).to eq(['a curved metal shovel', 2])
+    end
+
+    it 'parses knitted fabric orders from the truncated bput match' do
+      recipes = [{ 'name' => 'a knitted napkin', 'noun' => 'napkin', 'type' => 'tailoring', 'chapter' => 5 }]
+      expect(DRCI).to receive(:get_item?).with('outfitting logbook').and_return(true)
+      expect(DRC).to receive(:bput).with('read my outfitting logbook', *described_class::RESUME_LOGBOOK_PATTERNS)
+                                 .and_return('This logbook is tracking a work order requiring you to craft a knitted napkin from any')
+      expect(workorders).to receive(:logbook_remaining).with('outfitting').and_return(1)
+      expect(Lich::Messaging).to receive(:msg).with('plain', 'WorkOrders: Continuing work order for 1 a knitted napkin')
+
+      expect(workorders.send(:resume_work_order, 'outfitting', recipes)).to eq(['a knitted napkin', 1])
+    end
+
+    it 'returns quantity 0 when logbook order appears complete' do
+      expect(DRCI).to receive(:get_item?).with('forging logbook').and_return(true)
+      expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::RESUME_LOGBOOK_PATTERNS)
+                                 .and_return('This work order appears to be complete.')
+      expect(Lich::Messaging).to receive(:msg).with('plain', 'WorkOrders: Logbook order complete — turning in')
+
+      expect(workorders.send(:resume_work_order, 'forging', recipes)).to eq([nil, 0])
+    end
+
+    it 'exits when logbook has no in-progress work order' do
+      expect(DRCI).to receive(:get_item?).with('forging logbook').and_return(true)
+      expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::RESUME_LOGBOOK_PATTERNS)
+                                 .and_return('This logbook is not currently tracking a work order.')
+      expect(Lich::Messaging).to receive(:msg).with('bold', 'WorkOrders: No in-progress work order in forging logbook')
+      expect(workorders).to receive(:exit).and_raise(SystemExit)
+
+      expect { workorders.send(:resume_work_order, 'forging', recipes) }.to raise_error(SystemExit)
+    end
+
+    it 'exits when logbook item does not match a recipe' do
+      expect(DRCI).to receive(:get_item?).with('forging logbook').and_return(true)
+      expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::RESUME_LOGBOOK_PATTERNS)
+                                 .and_return('This logbook is tracking a work order requiring you to craft a metal unknown widget from any')
+      expect(Lich::Messaging).to receive(:msg).with('bold', "WorkOrders: Could not match logbook item 'a metal unknown widget' to a recipe")
+      expect(workorders).to receive(:exit).and_raise(SystemExit)
+
+      expect { workorders.send(:resume_work_order, 'forging', recipes) }.to raise_error(SystemExit)
     end
   end
 

--- a/spec/workorders_spec.rb
+++ b/spec/workorders_spec.rb
@@ -410,7 +410,7 @@ RSpec.describe WorkOrders do
       expect(DRCI).to receive(:get_item?).with('forging logbook').and_return(true)
       expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::RESUME_LOGBOOK_PATTERNS)
                                  .and_return('This work order appears to be complete.')
-      expect(Lich::Messaging).to receive(:msg).with('plain', 'WorkOrders: Logbook order complete — turning in')
+      expect(Lich::Messaging).to receive(:msg).with('plain', 'WorkOrders: Logbook order complete - turning in')
 
       expect(workorders.send(:resume_work_order, 'forging', recipes)).to eq([nil, 0])
     end

--- a/spec/workorders_spec.rb
+++ b/spec/workorders_spec.rb
@@ -312,14 +312,40 @@ RSpec.describe WorkOrders do
     end
 
     context 'when work order is not complete' do
-      it 'handles incomplete work order response' do
+      it 'does not claim success when work order is incomplete' do
         allow(DRCI).to receive(:get_item?).and_return(true)
         allow(DRC).to receive(:release_invisibility)
         allow(DRC).to receive(:bput).and_return("The work order isn't yet complete")
+        allow(workorders).to receive(:logbook_remaining).and_return(1)
         expect(workorders).to receive(:stow_tool).with('logbook')
+        expect(Lich::Messaging).to receive(:msg).with('bold', /still needs 1 more.*not turned in/)
+        expect(Lich::Messaging).not_to receive(:msg).with('plain', 'WorkOrders: Work order completed and turned in')
 
         workorders.send(:complete_work_order, info)
       end
+    end
+  end
+
+  # ===========================================================================
+  # #logbook_remaining - read remaining item count from work order logbook
+  # ===========================================================================
+  describe '#logbook_remaining' do
+    it 'returns 0 when work order appears complete' do
+      expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::READ_LOGBOOK_PATTERNS)
+                                 .and_return('This work order appears to be complete.')
+      expect(workorders.send(:logbook_remaining, 'forging')).to eq(0)
+    end
+
+    it 'returns remaining count from logbook text' do
+      expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::READ_LOGBOOK_PATTERNS)
+                                 .and_return('You must bundle and deliver 1 more of the ordered item.')
+      expect(workorders.send(:logbook_remaining, 'forging')).to eq(1)
+    end
+
+    it 'returns nil when response is unreadable' do
+      expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::READ_LOGBOOK_PATTERNS)
+                                 .and_return('I could not find what you were referring to.')
+      expect(workorders.send(:logbook_remaining, 'forging')).to be_nil
     end
   end
 
@@ -962,7 +988,8 @@ RSpec.describe WorkOrders do
     let(:info) do
       {
         'stock-room' => 100,
-        'trash-room' => 200
+        'trash-room' => 200,
+        'logbook'    => 'forging'
       }
     end
     let(:materials_info) do
@@ -996,6 +1023,8 @@ RSpec.describe WorkOrders do
       allow(DRCT).to receive(:dispose)
       allow(DRC).to receive(:wait_for_script_to_complete)
       allow(workorders).to receive(:bundle_item)
+      # need one more -> craft once -> complete on next check (+ final status read)
+      allow(workorders).to receive(:logbook_remaining).and_return(1, 0, 0)
     end
 
     it 'stows ingot to crafting_container using DRCC.stow_crafting_item' do
@@ -1019,6 +1048,14 @@ RSpec.describe WorkOrders do
       allow(DRCC).to receive(:stow_crafting_item)
       expect(DRC).to receive(:wait_for_script_to_complete).with('smith', ['bronze', 'short sword'])
       workorders.send(:forge_items, info, materials_info, item, 1)
+    end
+
+    it 'crafts an extra item when logbook still needs one more after quantity' do
+      allow(DRCC).to receive(:stow_crafting_item)
+      # asked for 2; after two crafts still need 1; third craft completes
+      allow(workorders).to receive(:logbook_remaining).and_return(2, 1, 1, 0, 0)
+      expect(DRC).to receive(:wait_for_script_to_complete).with('smith', ['bronze', 'short sword']).exactly(3).times
+      workorders.send(:forge_items, info, materials_info, item, 2)
     end
   end
 

--- a/spec/workorders_spec.rb
+++ b/spec/workorders_spec.rb
@@ -122,6 +122,26 @@ RSpec.describe WorkOrders do
       expect(match[:remaining]).to eq('3')
     end
 
+    it 'defines LOGBOOK_ITEM_PATTERN with named capture' do
+      pattern = described_class::LOGBOOK_ITEM_PATTERN
+      match = 'This logbook is tracking a work order requiring you to craft a curved metal shovel from any material.'.match(pattern)
+      expect(match).not_to be_nil
+      expect(match[:item]).to eq('a curved metal shovel')
+    end
+
+    it 'captures fabric items when remaining count is on the same line' do
+      line = 'This logbook is tracking a work order requiring you to craft a knitted napkin from any fabric.  You must bundle and deliver 1 more within the next 2 roisaen.'
+      match = line.match(described_class::LOGBOOK_ITEM_PATTERN)
+      expect(match).not_to be_nil
+      expect(match[:item]).to eq('a knitted napkin')
+      expect(line.match(described_class::LOGBOOK_REMAINING_PATTERN)[:remaining]).to eq('1')
+    end
+
+    it 'defines RESUME_LOGBOOK_PATTERNS as frozen array including LOGBOOK_ITEM_PATTERN' do
+      expect(described_class::RESUME_LOGBOOK_PATTERNS).to be_frozen
+      expect(described_class::RESUME_LOGBOOK_PATTERNS).to include(described_class::LOGBOOK_ITEM_PATTERN)
+    end
+
     it 'defines COUNT_PATTERN with named capture' do
       pattern = described_class::COUNT_PATTERN
       match = '42'.match(pattern)
@@ -169,7 +189,7 @@ RSpec.describe WorkOrders do
 
     it 'defines VERSION as frozen string' do
       expect(described_class::VERSION).to be_frozen
-      expect(described_class::VERSION).to eq('1.0.0')
+      expect(described_class::VERSION).to eq('1.0.1')
     end
   end
 
@@ -346,6 +366,73 @@ RSpec.describe WorkOrders do
       expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::READ_LOGBOOK_PATTERNS)
                                  .and_return('I could not find what you were referring to.')
       expect(workorders.send(:logbook_remaining, 'forging')).to be_nil
+    end
+  end
+
+  # ===========================================================================
+  # #resume_work_order - parse active order from logbook for continue
+  # ===========================================================================
+  describe '#resume_work_order' do
+    let(:recipes) do
+      [
+        { 'name' => 'a curved metal shovel', 'noun' => 'shovel', 'type' => 'blacksmithing' },
+        { 'name' => 'a metal razor', 'noun' => 'razor', 'type' => 'blacksmithing' }
+      ]
+    end
+
+    before do
+      allow(workorders).to receive(:stow_tool)
+    end
+
+    it 'returns recipe name and remaining count for an in-progress order' do
+      expect(DRCI).to receive(:get_item?).with('forging logbook').and_return(true)
+      # bput returns only the matched substring for the first matching pattern
+      expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::RESUME_LOGBOOK_PATTERNS)
+                                 .and_return('This logbook is tracking a work order requiring you to craft a curved metal shovel from any')
+      expect(workorders).to receive(:logbook_remaining).with('forging').and_return(2)
+      expect(Lich::Messaging).to receive(:msg).with('plain', 'WorkOrders: Continuing work order for 2 a curved metal shovel')
+
+      expect(workorders.send(:resume_work_order, 'forging', recipes)).to eq(['a curved metal shovel', 2])
+    end
+
+    it 'parses knitted fabric orders from the truncated bput match' do
+      recipes = [{ 'name' => 'a knitted napkin', 'noun' => 'napkin', 'type' => 'tailoring', 'chapter' => 5 }]
+      expect(DRCI).to receive(:get_item?).with('outfitting logbook').and_return(true)
+      expect(DRC).to receive(:bput).with('read my outfitting logbook', *described_class::RESUME_LOGBOOK_PATTERNS)
+                                 .and_return('This logbook is tracking a work order requiring you to craft a knitted napkin from any')
+      expect(workorders).to receive(:logbook_remaining).with('outfitting').and_return(1)
+      expect(Lich::Messaging).to receive(:msg).with('plain', 'WorkOrders: Continuing work order for 1 a knitted napkin')
+
+      expect(workorders.send(:resume_work_order, 'outfitting', recipes)).to eq(['a knitted napkin', 1])
+    end
+
+    it 'returns quantity 0 when logbook order appears complete' do
+      expect(DRCI).to receive(:get_item?).with('forging logbook').and_return(true)
+      expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::RESUME_LOGBOOK_PATTERNS)
+                                 .and_return('This work order appears to be complete.')
+      expect(Lich::Messaging).to receive(:msg).with('plain', 'WorkOrders: Logbook order complete - turning in')
+
+      expect(workorders.send(:resume_work_order, 'forging', recipes)).to eq([nil, 0])
+    end
+
+    it 'exits when logbook has no in-progress work order' do
+      expect(DRCI).to receive(:get_item?).with('forging logbook').and_return(true)
+      expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::RESUME_LOGBOOK_PATTERNS)
+                                 .and_return('This logbook is not currently tracking a work order.')
+      expect(Lich::Messaging).to receive(:msg).with('bold', 'WorkOrders: No in-progress work order in forging logbook')
+      expect(workorders).to receive(:exit).and_raise(SystemExit)
+
+      expect { workorders.send(:resume_work_order, 'forging', recipes) }.to raise_error(SystemExit)
+    end
+
+    it 'exits when logbook item does not match a recipe' do
+      expect(DRCI).to receive(:get_item?).with('forging logbook').and_return(true)
+      expect(DRC).to receive(:bput).with('read my forging logbook', *described_class::RESUME_LOGBOOK_PATTERNS)
+                                 .and_return('This logbook is tracking a work order requiring you to craft a metal unknown widget from any')
+      expect(Lich::Messaging).to receive(:msg).with('bold', "WorkOrders: Could not match logbook item 'a metal unknown widget' to a recipe")
+      expect(workorders).to receive(:exit).and_raise(SystemExit)
+
+      expect { workorders.send(:resume_work_order, 'forging', recipes) }.to raise_error(SystemExit)
     end
   end
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -5,7 +5,7 @@
 =end
 
 class WorkOrders
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.2'.freeze
 
   # Pattern constants for game responses
   GIVE_LOGBOOK_SUCCESS_PATTERNS = [
@@ -78,7 +78,18 @@ class WorkOrders
     'You must bundle and deliver \d+ more'
   ].freeze
 
+  # Full item capture must be used in bput — a shorter prefix match returns only the
+  # matched substring and drops the item name (item + remaining are often one line).
+  LOGBOOK_ITEM_PATTERN = /This logbook is tracking a work order requiring you to craft (?<item>.+?) from any/i.freeze
   LOGBOOK_REMAINING_PATTERN = /You must bundle and deliver (?<remaining>\d+) more/.freeze
+
+  RESUME_LOGBOOK_PATTERNS = [
+    LOGBOOK_ITEM_PATTERN,
+    'This work order appears to be complete.',
+    'is not currently tracking',
+    'has expired',
+    LOGBOOK_REMAINING_PATTERN
+  ].freeze
 
   COUNT_PATTERN = /(?<count>\d+)/.freeze
   POLISH_COUNT_PATTERN = /The surface polish has (?<count>\d+) uses remaining/.freeze
@@ -95,15 +106,16 @@ class WorkOrders
       [
         { name: 'discipline', options: %w[blacksmithing weaponsmithing tailoring shaping carving remedies artificing], description: 'What type of workorder to do?' },
         { name: 'repair', regex: /repair/i, optional: true, description: 'repair tools instead of crafting' },
-        { name: 'turnin', regex: /turnin/i, optional: true, description: 'get work order and turn it in immediately with items already on hand' }
+        { name: 'turnin', regex: /turnin/i, optional: true, description: 'get work order and turn it in immediately with items already on hand' },
+        { name: 'continue', regex: /continue/i, optional: true, description: 'resume an in-progress workorder from the logbook' }
       ]
     ]
 
     args = parse_args(arg_definitions)
-    work_order(args.discipline, args.repair, args.turnin)
+    work_order(args.discipline, args.repair, args.turnin, args.continue)
   end
 
-  def work_order(discipline, repair, turnin)
+  def work_order(discipline, repair, turnin, continue_order = nil)
     @settings = get_settings
     @worn_trashcan = @settings.worn_trashcan
     @worn_trashcan_verb = @settings.worn_trashcan_verb
@@ -148,7 +160,12 @@ class WorkOrders
       exit
     end
 
-    unless repair
+    item = nil
+    quantity = nil
+    if continue_order
+      item_name, quantity = resume_work_order(info['logbook'], recipes)
+      item = recipes.find { |r| r['name'] == item_name } if item_name
+    elsif !repair
       if @settings.workorder_diff.is_a?(Hash)
         item_name, quantity = request_work_order(recipes, info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], @settings.workorder_diff[discipline])
       else
@@ -176,16 +193,18 @@ class WorkOrders
       @outfitting_room = @settings.outfitting_room
       tools = @settings.outfitting_tools
       @belt = @settings.outfitting_belt
-      case item['chapter']
-      when 4, 2, 3
-        craft_method = :sew_items
-      when 5
-        materials_info = crafting_data['stock'][@workorders_materials['knit_type']]
-        craft_method = :knit_items
-      else
-        if item['chapter']
-          Lich::Messaging.msg('bold', "WorkOrders: Unknown chapter for tailoring item: #{item}")
-          exit
+      if item
+        case item['chapter']
+        when 4, 2, 3
+          craft_method = :sew_items
+        when 5
+          materials_info = crafting_data['stock'][@workorders_materials['knit_type']]
+          craft_method = :knit_items
+        else
+          if item['chapter']
+            Lich::Messaging.msg('bold', "WorkOrders: Unknown chapter for tailoring item: #{item}")
+            exit
+          end
         end
       end
     when 'shaping'
@@ -225,12 +244,18 @@ class WorkOrders
 
     return repair_items(info, tools) if repair
 
+    if continue_order && quantity.zero?
+      complete_work_order(info)
+      repair_items(info, tools) if @workorders_repair
+      return
+    end
+
     if DRSkill.getxp(skill) > @craft_max_mindstate
       Lich::Messaging.msg('bold', "WorkOrders: Exiting because your current mindstate for #{skill} (#{DRSkill.getxp(skill)}) is over the set maximum craft_max_mindstate: #{@craft_max_mindstate}")
       exit
     end
 
-    if turnin
+    if turnin && !continue_order
       quantity.times do
         DRCI.get_item(item['noun'], @settings.default_container)
         bundle_item(item['noun'], info['logbook'])
@@ -280,6 +305,60 @@ class WorkOrders
     return match[:remaining].to_i if match
 
     nil
+  end
+
+  # Resume an in-progress work order from the discipline logbook.
+  # @return [Array(String, Integer)] recipe name and remaining quantity (0 if complete)
+  def resume_work_order(logbook, recipes)
+    unless DRCI.get_item?("#{logbook} logbook")
+      Lich::Messaging.msg('bold', "WorkOrders: Failed to get #{logbook} logbook")
+      exit
+    end
+
+    result = DRC.bput("read my #{logbook} logbook", *RESUME_LOGBOOK_PATTERNS)
+
+    if result.include?('appears to be complete')
+      stow_tool('logbook')
+      Lich::Messaging.msg('plain', 'WorkOrders: Logbook order complete — turning in')
+      return [nil, 0]
+    end
+
+    if result.include?('not currently tracking') || result.include?('has expired')
+      stow_tool('logbook')
+      Lich::Messaging.msg('bold', "WorkOrders: No in-progress work order in #{logbook} logbook")
+      exit
+    end
+
+    match = result.match(LOGBOOK_ITEM_PATTERN)
+    unless match
+      stow_tool('logbook')
+      Lich::Messaging.msg('bold', "WorkOrders: Could not parse item from #{logbook} logbook")
+      exit
+    end
+
+    item_desc = match[:item]
+    recipe = recipes.find { |r| r['name'] == item_desc }
+    unless recipe
+      stow_tool('logbook')
+      Lich::Messaging.msg('bold', "WorkOrders: Could not match logbook item '#{item_desc}' to a recipe")
+      exit
+    end
+
+    remaining = logbook_remaining(logbook)
+    stow_tool('logbook')
+
+    if remaining.nil?
+      Lich::Messaging.msg('bold', "WorkOrders: Could not read remaining count from #{logbook} logbook")
+      exit
+    end
+
+    if remaining.zero?
+      Lich::Messaging.msg('plain', 'WorkOrders: Logbook order complete — turning in')
+      return [recipe['name'], 0]
+    end
+
+    Lich::Messaging.msg('plain', "WorkOrders: Continuing work order for #{remaining} #{recipe['name']}")
+    [recipe['name'], remaining]
   end
 
   def get_tool(name)

--- a/workorders.lic
+++ b/workorders.lic
@@ -260,7 +260,7 @@ class WorkOrders
       if result.include?(GIVE_LOGBOOK_INCOMPLETE_PATTERN)
         remaining = logbook_remaining(info['logbook'])
         detail = remaining ? "still needs #{remaining} more" : 'is not complete'
-        Lich::Messaging.msg('bold', "WorkOrders: Work order #{detail} — not turned in")
+        Lich::Messaging.msg('bold', "WorkOrders: Work order #{detail} - not turned in")
         stow_tool('logbook')
         return
       end

--- a/workorders.lic
+++ b/workorders.lic
@@ -22,6 +22,8 @@ class WorkOrders
     "What is it you're trying to give"
   ].freeze
 
+  GIVE_LOGBOOK_INCOMPLETE_PATTERN = "The work order isn't yet complete".freeze
+
   NPC_NOT_FOUND_PATTERN = "What is it you're trying to give".freeze
 
   # The clerk's repair quote, e.g. "That will cost 4,447 Kronars to repair.
@@ -34,6 +36,9 @@ class WorkOrders
 
   # Clerk's response when we lack the coin to pay for a repair.
   REPAIR_NEED_COIN_PATTERN = 'more coin'
+
+  # Extra forge attempts beyond asked quantity to cover quality rejects / failed crafts
+  FORGE_ATTEMPT_BUFFER = 5
 
   REPAIR_GIVE_PATTERNS = [
     "I don't repair those here",
@@ -252,10 +257,29 @@ class WorkOrders
       end
       DRC.release_invisibility
       result = DRC.bput("give logbook to #{info['npc']}", *GIVE_LOGBOOK_SUCCESS_PATTERNS, NPC_NOT_FOUND_PATTERN)
+      if result.include?(GIVE_LOGBOOK_INCOMPLETE_PATTERN)
+        remaining = logbook_remaining(info['logbook'])
+        detail = remaining ? "still needs #{remaining} more" : 'is not complete'
+        Lich::Messaging.msg('bold', "WorkOrders: Work order #{detail} — not turned in")
+        stow_tool('logbook')
+        return
+      end
       break unless GIVE_LOGBOOK_RETRY_PATTERNS.any? { |pattern| pattern.is_a?(Regexp) ? pattern.match?(result) : result.include?(pattern) }
     end
     stow_tool('logbook')
     Lich::Messaging.msg('plain', 'WorkOrders: Work order completed and turned in')
+  end
+
+  # Read work-order logbook and return items still needed.
+  # @return [Integer, nil] remaining count, 0 if complete, nil if unreadable
+  def logbook_remaining(logbook)
+    result = DRC.bput("read my #{logbook} logbook", *READ_LOGBOOK_PATTERNS)
+    return 0 if result.include?('appears to be complete')
+
+    match = result.match(LOGBOOK_REMAINING_PATTERN)
+    return match[:remaining].to_i if match
+
+    nil
   end
 
   def get_tool(name)
@@ -748,7 +772,16 @@ class WorkOrders
 
     DRCM.ensure_copper_on_hand(@cash_on_hand || 5000, @settings, @hometown)
 
-    quantity.times do
+    max_attempts = quantity + FORGE_ATTEMPT_BUFFER
+    attempts = 0
+    while attempts < max_attempts
+      remaining = logbook_remaining(info['logbook'])
+      if remaining.nil?
+        Lich::Messaging.msg('bold', 'WorkOrders: Could not read forging logbook remaining count')
+        break
+      end
+      break if remaining.zero?
+
       if remaining_volume < recipe['volume']
         DRCT.dispose("#{materials_info['stock-name']} ingot", info['trash-room'], @worn_trashcan, @worn_trashcan_verb) if remaining_volume.positive?
         DRCT.order_item(info['stock-room'], materials_info['stock-number'])
@@ -760,7 +793,14 @@ class WorkOrders
       bundle_item(recipe['noun'], info['logbook'])
 
       remaining_volume -= recipe['volume']
+      attempts += 1
     end
+
+    remaining = logbook_remaining(info['logbook'])
+    if remaining&.positive?
+      Lich::Messaging.msg('bold', "WorkOrders: Forging finished but logbook still needs #{remaining} more")
+    end
+
     DRCT.dispose("#{materials_info['stock-name']} ingot", info['trash-room'], @worn_trashcan, @worn_trashcan_verb) if remaining_volume.positive?
   end
 
@@ -814,9 +854,24 @@ class WorkOrders
       exit
     end
 
-    quantity.times do
+    max_attempts = quantity + FORGE_ATTEMPT_BUFFER
+    attempts = 0
+    while attempts < max_attempts
+      remaining = logbook_remaining(info['logbook'])
+      if remaining.nil?
+        Lich::Messaging.msg('bold', 'WorkOrders: Could not read forging logbook remaining count')
+        break
+      end
+      break if remaining.zero?
+
       DRC.wait_for_script_to_complete('smith', [@use_own_ingot_type, item['name']])
       bundle_item(recipe['noun'], info['logbook'])
+      attempts += 1
+    end
+
+    remaining = logbook_remaining(info['logbook'])
+    if remaining&.positive?
+      Lich::Messaging.msg('bold', "WorkOrders: Forging finished but logbook still needs #{remaining} more")
     end
 
     if smelt

--- a/workorders.lic
+++ b/workorders.lic
@@ -78,7 +78,7 @@ class WorkOrders
     'You must bundle and deliver \d+ more'
   ].freeze
 
-  # Full item capture must be used in bput — a shorter prefix match returns only the
+  # Full item capture must be used in bput - a shorter prefix match returns only the
   # matched substring and drops the item name (item + remaining are often one line).
   LOGBOOK_ITEM_PATTERN = /This logbook is tracking a work order requiring you to craft (?<item>.+?) from any/i.freeze
   LOGBOOK_REMAINING_PATTERN = /You must bundle and deliver (?<remaining>\d+) more/.freeze
@@ -319,7 +319,7 @@ class WorkOrders
 
     if result.include?('appears to be complete')
       stow_tool('logbook')
-      Lich::Messaging.msg('plain', 'WorkOrders: Logbook order complete — turning in')
+      Lich::Messaging.msg('plain', 'WorkOrders: Logbook order complete - turning in')
       return [nil, 0]
     end
 
@@ -353,7 +353,7 @@ class WorkOrders
     end
 
     if remaining.zero?
-      Lich::Messaging.msg('plain', 'WorkOrders: Logbook order complete — turning in')
+      Lich::Messaging.msg('plain', 'WorkOrders: Logbook order complete - turning in')
       return [recipe['name'], 0]
     end
 

--- a/workorders.lic
+++ b/workorders.lic
@@ -5,7 +5,7 @@
 =end
 
 class WorkOrders
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 
   # Pattern constants for game responses
   GIVE_LOGBOOK_SUCCESS_PATTERNS = [
@@ -78,7 +78,18 @@ class WorkOrders
     'You must bundle and deliver \d+ more'
   ].freeze
 
+  # Full item capture must be used in bput - a shorter prefix match returns only the
+  # matched substring and drops the item name (item + remaining are often one line).
+  LOGBOOK_ITEM_PATTERN = /This logbook is tracking a work order requiring you to craft (?<item>.+?) from any/i.freeze
   LOGBOOK_REMAINING_PATTERN = /You must bundle and deliver (?<remaining>\d+) more/.freeze
+
+  RESUME_LOGBOOK_PATTERNS = [
+    LOGBOOK_ITEM_PATTERN,
+    'This work order appears to be complete.',
+    'is not currently tracking',
+    'has expired',
+    LOGBOOK_REMAINING_PATTERN
+  ].freeze
 
   COUNT_PATTERN = /(?<count>\d+)/.freeze
   POLISH_COUNT_PATTERN = /The surface polish has (?<count>\d+) uses remaining/.freeze
@@ -95,15 +106,16 @@ class WorkOrders
       [
         { name: 'discipline', options: %w[blacksmithing weaponsmithing tailoring shaping carving remedies artificing tinkering], description: 'What type of workorder to do?' },
         { name: 'repair', regex: /repair/i, optional: true, description: 'repair tools instead of crafting' },
-        { name: 'turnin', regex: /turnin/i, optional: true, description: 'get work order and turn it in immediately with items already on hand' }
+        { name: 'turnin', regex: /turnin/i, optional: true, description: 'get work order and turn it in immediately with items already on hand' },
+        { name: 'continue', regex: /continue/i, optional: true, description: 'resume an in-progress workorder from the logbook' }
       ]
     ]
 
     args = parse_args(arg_definitions)
-    work_order(args.discipline, args.repair, args.turnin)
+    work_order(args.discipline, args.repair, args.turnin, args.continue)
   end
 
-  def work_order(discipline, repair, turnin)
+  def work_order(discipline, repair, turnin, continue_order = nil)
     @settings = get_settings
     @worn_trashcan = @settings.worn_trashcan
     @worn_trashcan_verb = @settings.worn_trashcan_verb
@@ -150,7 +162,12 @@ class WorkOrders
       exit
     end
 
-    unless repair
+    item = nil
+    quantity = nil
+    if continue_order
+      item_name, quantity = resume_work_order(info['logbook'], recipes)
+      item = recipes.find { |r| r['name'] == item_name } if item_name
+    elsif !repair
       if @settings.workorder_diff.is_a?(Hash)
         item_name, quantity = request_work_order(recipes, info['npc-rooms'], info['npc'], info['npc_last_name'], discipline, info['logbook'], @settings.workorder_diff[discipline])
       else
@@ -178,16 +195,18 @@ class WorkOrders
       @outfitting_room = @settings.outfitting_room
       tools = @settings.outfitting_tools
       @belt = @settings.outfitting_belt
-      case item['chapter']
-      when 4, 2, 3
-        craft_method = :sew_items
-      when 5
-        materials_info = crafting_data['stock'][@workorders_materials['knit_type']]
-        craft_method = :knit_items
-      else
-        if item['chapter']
-          Lich::Messaging.msg('bold', "WorkOrders: Unknown chapter for tailoring item: #{item}")
-          exit
+      if item
+        case item['chapter']
+        when 4, 2, 3
+          craft_method = :sew_items
+        when 5
+          materials_info = crafting_data['stock'][@workorders_materials['knit_type']]
+          craft_method = :knit_items
+        else
+          if item['chapter']
+            Lich::Messaging.msg('bold', "WorkOrders: Unknown chapter for tailoring item: #{item}")
+            exit
+          end
         end
       end
     when 'shaping'
@@ -234,12 +253,18 @@ class WorkOrders
 
     return repair_items(info, tools) if repair
 
+    if continue_order && quantity.zero?
+      complete_work_order(info)
+      repair_items(info, tools) if @workorders_repair
+      return
+    end
+
     if DRSkill.getxp(skill) > @craft_max_mindstate
       Lich::Messaging.msg('bold', "WorkOrders: Exiting because your current mindstate for #{skill} (#{DRSkill.getxp(skill)}) is over the set maximum craft_max_mindstate: #{@craft_max_mindstate}")
       exit
     end
 
-    if turnin
+    if turnin && !continue_order
       quantity.times do
         DRCI.get_item(item['noun'], @settings.default_container)
         bundle_item(item['noun'], info['logbook'])
@@ -289,6 +314,60 @@ class WorkOrders
     return match[:remaining].to_i if match
 
     nil
+  end
+
+  # Resume an in-progress work order from the discipline logbook.
+  # @return [Array(String, Integer)] recipe name and remaining quantity (0 if complete)
+  def resume_work_order(logbook, recipes)
+    unless DRCI.get_item?("#{logbook} logbook")
+      Lich::Messaging.msg('bold', "WorkOrders: Failed to get #{logbook} logbook")
+      exit
+    end
+
+    result = DRC.bput("read my #{logbook} logbook", *RESUME_LOGBOOK_PATTERNS)
+
+    if result.include?('appears to be complete')
+      stow_tool('logbook')
+      Lich::Messaging.msg('plain', 'WorkOrders: Logbook order complete - turning in')
+      return [nil, 0]
+    end
+
+    if result.include?('not currently tracking') || result.include?('has expired')
+      stow_tool('logbook')
+      Lich::Messaging.msg('bold', "WorkOrders: No in-progress work order in #{logbook} logbook")
+      exit
+    end
+
+    match = result.match(LOGBOOK_ITEM_PATTERN)
+    unless match
+      stow_tool('logbook')
+      Lich::Messaging.msg('bold', "WorkOrders: Could not parse item from #{logbook} logbook")
+      exit
+    end
+
+    item_desc = match[:item]
+    recipe = recipes.find { |r| r['name'] == item_desc }
+    unless recipe
+      stow_tool('logbook')
+      Lich::Messaging.msg('bold', "WorkOrders: Could not match logbook item '#{item_desc}' to a recipe")
+      exit
+    end
+
+    remaining = logbook_remaining(logbook)
+    stow_tool('logbook')
+
+    if remaining.nil?
+      Lich::Messaging.msg('bold', "WorkOrders: Could not read remaining count from #{logbook} logbook")
+      exit
+    end
+
+    if remaining.zero?
+      Lich::Messaging.msg('plain', 'WorkOrders: Logbook order complete - turning in')
+      return [recipe['name'], 0]
+    end
+
+    Lich::Messaging.msg('plain', "WorkOrders: Continuing work order for #{remaining} #{recipe['name']}")
+    [recipe['name'], remaining]
   end
 
   def get_tool(name)


### PR DESCRIPTION
## Summary
- Adds `;workorders <discipline> continue` to resume an in-progress work order by reading the discipline logbook, instead of canceling and re-requesting one (e.g. after a disconnect). Recovers the recipe and remaining quantity from the logbook text, and skips straight to turn-in when the logbook reports the order already complete.

Rebased on current `main` now that #7514 (which added `logbook_remaining`, relied on here) has merged, so the diff is just this feature.

## Test plan
- [x] `rspec spec/workorders_spec.rb` passes (106 examples, 0 failures)
- [x] `ruby -c workorders.lic` syntax check clean
