### PR TITLE
combat-trainer: rework butcher/dissect flow with a butcher_count cap

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -513,6 +513,12 @@ class LootProcess
     @dissect_and_butcher = settings.dissect_and_butcher
     echo("  @dissect_and_butcher: #{@dissect_and_butcher}") if $debug_mode_ct
 
+    # Optional cap on butchers per corpse. nil = butcher until exhausted
+    # ("much too battered..."). Set to 1 for legacy one-butcher-then-dissect
+    # when dissect_and_butcher and ritual_type is not butcher.
+    @butcher_count = thanatology['butcher_count']
+    echo("  @butcher_count: #{@butcher_count}") if $debug_mode_ct
+
     @rituals = get_data('spells').rituals
     echo("  @rituals: #{@rituals}") if $debug_mode_ct
 
@@ -914,6 +920,23 @@ class LootProcess
     end
   end
 
+  # Matchers for ritual targeting that hit a missing noun or a living creature.
+  # Listed before @rituals['failures'] so "on a corpse" wins over the shorter
+  # "This ritual may only be performed on" failure substring.
+  def necro_wrong_corpse_matchers
+    [
+      'What were you referring to',
+      'I could not find what you were referring to',
+      'This ritual may only be performed on a corpse'
+    ]
+  end
+
+  def necro_wrong_corpse_target?(result)
+    return false if result.nil? || result.empty?
+
+    necro_wrong_corpse_matchers.any? { |msg| result.include?(msg) }
+  end
+
   def do_necro_ritual(mob_noun, ritual, game_state)
     return unless DRStats.necromancer?
     return unless ritual
@@ -929,7 +952,7 @@ class LootProcess
 
     do_necro_ritual(mob_noun, 'preserve', game_state) if %w[consume harvest arise].include?(ritual)
     perform_message = "perform #{ritual} on #{mob_noun}"
-    result = DRC.bput(perform_message, @rituals['arise'], @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], @rituals['failures'])
+    result = DRC.bput(perform_message, @rituals['arise'], @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], necro_wrong_corpse_matchers, @rituals['failures'])
     echo result if $debug_mode_ct
     case result
     when @rituals['arise']
@@ -953,6 +976,8 @@ class LootProcess
     when @rituals['construct']
       echo 'Detected an attempt to do ritual on a construct' if $debug_mode_ct
       game_state.construct(mob_noun)
+    when *necro_wrong_corpse_matchers
+      DRC.message("*** combat-trainer: #{ritual} failed - wrong/missing corpse target (tried '#{mob_noun}')")
     when *@rituals['failures']
       echo 'Failure detected' if $debug_mode_ct
     end
@@ -963,21 +988,72 @@ class LootProcess
     return unless ritual.eql?('butcher')
 
     echo "Butchering the #{mob_noun}'s corpse!" if $debug_mode_ct
-    echo ' Only butchering it once!' if $debug_mode_ct && @dissect_and_butcher && !@ritual_type.eql?('butcher')
+    # Order: preserve -> butcher until exhausted -> dissect (if dissect_and_butcher).
+    # Natural stop: "much too battered and beat up to extract any body parts from."
+    # Optional thanatology.butcher_count caps butchers before that. Legacy one-shot
+    # only when dissect_and_butcher, ritual_type != butcher, and butcher_count == 1.
+    single_butcher = @dissect_and_butcher && !@ritual_type.eql?('butcher') && @butcher_count == 1
+    echo ' Only butchering it once!' if $debug_mode_ct && single_butcher
+
+    # Butcher-exhausted: stop butchering but corpse may still accept dissection.
+    butcher_exhausted = [
+      'much too battered and beat up to extract any body parts from',
+      'renders it useless for butchering'
+    ]
+    # Corpse ruined for further rituals - skip dissect.
+    corpse_ruined_for_rituals = [
+      'You realize the unfortunate butchery ruins the body for any further attempts at rituals',
+      'A failed or completed ritual has rendered this corpse unusable for your purpose',
+      'prevents a meaningful dissection'
+    ]
 
     @equipment_manager.stow_weapon(game_state.weapon_name)
 
+    # Preserve first - extends part decay and marks the corpse for butchery.
+    do_necro_ritual(mob_noun, 'preserve', game_state)
+
+    butchers_done = 0
+    skip_dissect = false
     loop do
-      result = DRC.bput("perform #{ritual} on #{mob_noun}", @rituals['butcher'], @rituals['failures'], @rituals['construct'])
+      result = DRC.bput("perform #{ritual} on #{mob_noun}", @rituals['butcher'], necro_wrong_corpse_matchers, @rituals['failures'], @rituals['construct'])
       game_state.construct(mob_noun) if result.include?(@rituals['construct'])
       @last_ritual = 'butcher' if result.include?(@rituals['butcher'])
-      break if result.empty? || @rituals['failures'].any? { |msg| result.include?(msg) || result.include?(@rituals['construct']) }
 
-      DRC.bput("drop my #{DRC.right_hand}", 'You drop', 'You discard', 'Please rephrase')
-      break if @dissect_and_butcher && !@ritual_type.eql?('butcher')
+      if result.empty? || result.include?(@rituals['construct'])
+        skip_dissect = true
+        break
+      end
+
+      if necro_wrong_corpse_target?(result)
+        DRC.message("*** combat-trainer: #{ritual} failed - wrong/missing corpse target (tried '#{mob_noun}')")
+        skip_dissect = true
+        break
+      end
+
+      if butcher_exhausted.any? { |msg| result.include?(msg) }
+        echo "  Butcher exhausted (#{result}); continuing to dissect" if $debug_mode_ct
+        break
+      end
+
+      if corpse_ruined_for_rituals.any? { |msg| result.include?(msg) }
+        echo "  Corpse ruined for rituals (#{result}); skipping dissect" if $debug_mode_ct
+        skip_dissect = true
+        break
+      end
+
+      if @rituals['failures'].any? { |msg| result.include?(msg) }
+        skip_dissect = true
+        break
+      end
+
+      DRC.bput("drop my #{DRC.right_hand}", 'You drop', 'You discard', 'Please rephrase', 'What were you referring to') if DRC.right_hand
+      butchers_done += 1
+      break if single_butcher
+      break if @butcher_count && butchers_done >= @butcher_count
     end
 
-    do_necro_ritual(mob_noun, 'dissect', game_state) if @dissect_and_butcher && !@ritual_type.eql?('butcher')
+    # Dissect last when requested and the corpse is still usable.
+    do_necro_ritual(mob_noun, 'dissect', game_state) if @dissect_and_butcher && !skip_dissect
     @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
   end
 

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -379,7 +379,13 @@ thanatology:
   store: false
   harvest_container:
   harvest_count: 0
+  # Optional butcher cap per corpse. Unset = butcher until exhausted
+  # ("much too battered and beat up to extract any body parts from"), then dissect
+  # when dissect_and_butcher. Set to 1 for legacy one-butcher-then-dissect.
+  # Multi-butcher + preserve/dissect order requires patched combat-trainer.
+  butcher_count:
 # attempts to necromancer dissect after butchering a mob.  This often works.
+# With patched CT: preserve → multi-butcher → dissect when dissect_and_butcher.
 dissect_and_butcher: false
 # redeemed tag only allows dissect ritual
 necro_redeemed: false


### PR DESCRIPTION
## Summary
- Preserves the corpse before butchering, then keeps butchering until it's naturally exhausted ("too battered and beat up...") or ruined for further rituals, instead of stopping after a single attempt. Dissect (when `dissect_and_butcher` is set) now only runs afterward if the corpse wasn't mistargeted or ruined.
- Adds an optional `thanatology:butcher_count` setting to cap the number of butcher attempts. Unset reproduces the old butcher-until-exhausted loop; `1` reproduces the old butcher-once-then-dissect behavior.
- Detects a wrong/missing corpse target response ("What were you referring to", "I could not find...", "This ritual may only be performed on a corpse") as its own case rather than lumping it into the generic ritual-failure branch, and messages the player when it happens during butchering.

## Test plan
- [x] Full `rspec` suite passes (2810 examples, 0 failures)
- [x] `ruby -c combat-trainer.lic` syntax check clean
- [x] `rubocop combat-trainer.lic` clean