### PR TITLE
combat-trainer: target necro rituals by corpse id, not noun

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -858,19 +858,20 @@ class LootProcess
   def check_rituals?(game_state)
     return true unless DRStats.necromancer?
 
-    mob_noun = DRRoom.dead_npcs.first
-    return true if game_state.construct?(mob_noun)
+    corpse = Lich::DragonRealms::Creature.in_room(:dead).first
+    return true if corpse.nil?
+    return true if game_state.construct?(corpse.noun)
 
     echo "  should_perform_ritual? #{should_perform_ritual?(game_state)}" if $debug_mode_ct
     if @last_ritual.nil?
       if @necro_corpse_priority == 'pet'
         echo "Prioritizing pet creation over healing" if $debug_mode_ct
-        check_necro_pet(mob_noun, game_state)
-        check_necro_heal(mob_noun, game_state)
+        check_necro_pet(corpse, game_state)
+        check_necro_heal(corpse, game_state)
       elsif @necro_corpse_priority == 'heal' || !@necro_corpse_priority
         echo "Prioritizing healing over pet creation" if $debug_mode_ct
-        check_necro_heal(mob_noun, game_state)
-        check_necro_pet(mob_noun, game_state)
+        check_necro_heal(corpse, game_state)
+        check_necro_pet(corpse, game_state)
       end
       ritual = if @redeemed
                  'dissect'
@@ -883,14 +884,14 @@ class LootProcess
                else
                  @ritual_type
                end
-      do_necro_ritual(mob_noun, ritual, game_state) if should_perform_ritual?(game_state)
+      do_necro_ritual(corpse, ritual, game_state) if should_perform_ritual?(game_state)
     end
     return false if %w[consume harvest dissect].include?(@last_ritual)
 
     true
   end
 
-  def check_necro_heal(mob_noun, game_state)
+  def check_necro_heal(corpse, game_state)
     if @necro_heal && !game_state.necro_casting?
       game_state.wounds = DRCH.check_health['wounds']
       echo "Severity to Wounds: #{game_state.wounds}" if $debug_mode_ct
@@ -900,22 +901,22 @@ class LootProcess
         # flag set but no CF/devour cast to clear hence blocking looting (and potentially other necro_casting defs)
         # the check for !devour will also disallow concurrent use of devour and CF but that is not currently supported in CT @ 2/2/2025
         if @wound_level_threshold <= game_state.wounds.keys.max && !DRSpells.active_spells['Devour']
-          do_necro_ritual(mob_noun, 'consume', game_state)
+          do_necro_ritual(corpse, 'consume', game_state)
           return false
         end
       end
     end
   end
 
-  def check_necro_pet(mob_noun, game_state)
+  def check_necro_pet(corpse, game_state)
     if @make_zombie && !game_state.necro_casting? && !game_state.cfb_active?
       echo 'Making zombie' if $debug_mode_ct
-      do_necro_ritual(mob_noun, 'arise', game_state)
+      do_necro_ritual(corpse, 'arise', game_state)
       return false
     end
     if @make_bonebug && !game_state.necro_casting? && !game_state.cfw_active?
       echo 'Making bone bug' if $debug_mode_ct
-      do_necro_ritual(mob_noun, 'arise', game_state)
+      do_necro_ritual(corpse, 'arise', game_state)
       return false
     end
   end
@@ -937,21 +938,21 @@ class LootProcess
     necro_wrong_corpse_matchers.any? { |msg| result.include?(msg) }
   end
 
-  def do_necro_ritual(mob_noun, ritual, game_state)
+  def do_necro_ritual(corpse, ritual, game_state)
     return unless DRStats.necromancer?
     return unless ritual
-    return if game_state.construct?(mob_noun)
+    return if game_state.construct?(corpse.noun)
 
-    echo "Attempting necromancer ritual #{ritual} on #{mob_noun}" if $debug_mode_ct
+    echo "Attempting necromancer ritual #{ritual} on #{corpse.name || corpse.noun} (##{corpse.id})" if $debug_mode_ct
 
     if ritual.eql?('butcher')
-      butcher_corpse(mob_noun, ritual, game_state)
+      butcher_corpse(corpse, ritual, game_state)
       echo "Last ritual performed: #{@last_ritual}" if $debug_mode_ct
       return
     end
 
-    do_necro_ritual(mob_noun, 'preserve', game_state) if %w[consume harvest arise].include?(ritual)
-    perform_message = "perform #{ritual} on #{mob_noun}"
+    do_necro_ritual(corpse, 'preserve', game_state) if %w[consume harvest arise].include?(ritual)
+    perform_message = "perform #{ritual} on ##{corpse.id}"
     result = DRC.bput(perform_message, @rituals['arise'], @rituals['preserve'], @rituals['dissect'], @rituals['harvest'], @rituals['consume'], @rituals['construct'], necro_wrong_corpse_matchers, @rituals['failures'])
     echo result if $debug_mode_ct
     case result
@@ -975,19 +976,19 @@ class LootProcess
       necro_harvest_check
     when @rituals['construct']
       echo 'Detected an attempt to do ritual on a construct' if $debug_mode_ct
-      game_state.construct(mob_noun)
+      game_state.construct(corpse.noun)
     when *necro_wrong_corpse_matchers
-      DRC.message("*** combat-trainer: #{ritual} failed - wrong/missing corpse target (tried '#{mob_noun}')")
+      DRC.message("*** combat-trainer: #{ritual} failed - wrong/missing corpse target (tried '#{corpse.name || corpse.noun}' ##{corpse.id})")
     when *@rituals['failures']
       echo 'Failure detected' if $debug_mode_ct
     end
     echo "Last ritual performed: #{@last_ritual}" if $debug_mode_ct
   end
 
-  def butcher_corpse(mob_noun, ritual, game_state)
+  def butcher_corpse(corpse, ritual, game_state)
     return unless ritual.eql?('butcher')
 
-    echo "Butchering the #{mob_noun}'s corpse!" if $debug_mode_ct
+    echo "Butchering the #{corpse.name || corpse.noun}'s corpse! (##{corpse.id})" if $debug_mode_ct
     # Order: preserve -> butcher until exhausted -> dissect (if dissect_and_butcher).
     # Natural stop: "much too battered and beat up to extract any body parts from."
     # Optional thanatology.butcher_count caps butchers before that. Legacy one-shot
@@ -1010,13 +1011,13 @@ class LootProcess
     @equipment_manager.stow_weapon(game_state.weapon_name)
 
     # Preserve first - extends part decay and marks the corpse for butchery.
-    do_necro_ritual(mob_noun, 'preserve', game_state)
+    do_necro_ritual(corpse, 'preserve', game_state)
 
     butchers_done = 0
     skip_dissect = false
     loop do
-      result = DRC.bput("perform #{ritual} on #{mob_noun}", @rituals['butcher'], necro_wrong_corpse_matchers, @rituals['failures'], @rituals['construct'])
-      game_state.construct(mob_noun) if result.include?(@rituals['construct'])
+      result = DRC.bput("perform #{ritual} on ##{corpse.id}", @rituals['butcher'], necro_wrong_corpse_matchers, @rituals['failures'], @rituals['construct'])
+      game_state.construct(corpse.noun) if result.include?(@rituals['construct'])
       @last_ritual = 'butcher' if result.include?(@rituals['butcher'])
 
       if result.empty? || result.include?(@rituals['construct'])
@@ -1025,7 +1026,7 @@ class LootProcess
       end
 
       if necro_wrong_corpse_target?(result)
-        DRC.message("*** combat-trainer: #{ritual} failed - wrong/missing corpse target (tried '#{mob_noun}')")
+        DRC.message("*** combat-trainer: #{ritual} failed - wrong/missing corpse target (tried '#{corpse.name || corpse.noun}' ##{corpse.id})")
         skip_dissect = true
         break
       end
@@ -1053,7 +1054,7 @@ class LootProcess
     end
 
     # Dissect last when requested and the corpse is still usable.
-    do_necro_ritual(mob_noun, 'dissect', game_state) if @dissect_and_butcher && !skip_dissect
+    do_necro_ritual(corpse, 'dissect', game_state) if @dissect_and_butcher && !skip_dissect
     @equipment_manager.wield_weapon?(game_state.weapon_name, game_state.weapon_skill)
   end
 

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -5222,3 +5222,186 @@ RSpec.describe 'GameState action counter' do
     expect(gs.action_count).to eq(0)
   end
 end
+
+# ===================================================================
+# LootProcess -- necromancer ritual corpse targeting
+#
+# Rituals used to be aimed at the bare noun from DRRoom.dead_npcs, which
+# is ambiguous the moment two same-noun corpses share a room. Unless an
+# example says otherwise the room below holds two 'rat' corpses that
+# differ only by id, so a command built from the noun could not tell
+# them apart:
+# every perform/butcher must address the selected corpse by '#<id>'.
+# Only the operator-facing diagnostics still name the corpse, falling
+# back to the noun when the creature has no name yet.
+# ===================================================================
+RSpec.describe LootProcess do
+  before(:each) do
+    ct_setup
+    DRStats.guild = 'Necromancer'
+    Lich::DragonRealms::Creature._set_room([selected_corpse, other_corpse])
+    allow(DRC).to receive(:bput) { |command, *_matchers| record_bput(command) }
+    allow(DRC).to receive(:message)
+  end
+
+  # Same noun, different ids -- the whole point of the id targeting.
+  let(:selected_corpse) { OpenStruct.new(id: 111, noun: 'rat', name: 'a giant rat') }
+  let(:other_corpse) { OpenStruct.new(id: 222, noun: 'rat', name: 'a giant rat') }
+
+  let(:rituals) do
+    {
+      'preserve'  => 'suspending the corpse in unnatural stasis',
+      'harvest'   => 'a few quick, precise motions with your ritual knife',
+      'dissect'   => 'Using your knife as a probe',
+      'consume'   => 'a few quick, precise cuts with your ritual knife',
+      'arise'     => 'carefully carve a ritual design across a handspan of its body',
+      'construct' => 'Rituals do not work upon constructs',
+      'butcher'   => 'Making several deep cuts with your knife',
+      'failures'  => ['You do not have the knowledge required to perform this ritual']
+    }
+  end
+
+  # Commands the script sent, in order, so each example can assert both
+  # what was targeted and that the noun never leaked into a command.
+  let(:sent_commands) { [] }
+  # Per-command canned game responses; anything unlisted answers with the
+  # matching ritual message so the happy path runs to completion.
+  let(:bput_responses) { {} }
+
+  def record_bput(command)
+    sent_commands << command
+    return bput_responses[command] if bput_responses.key?(command)
+
+    case command
+    when /^perform preserve/ then rituals['preserve']
+    when /^perform butcher/  then rituals['butcher']
+    when /^perform dissect/  then rituals['dissect']
+    when /^perform arise/    then rituals['arise']
+    else 'Roundtime'
+    end
+  end
+
+  def perform_commands
+    sent_commands.grep(/^perform /)
+  end
+
+  def build_necro_loot(**overrides)
+    lp = LootProcess.allocate
+    defaults = {
+      rituals: rituals, last_ritual: nil, ritual_type: 'butcher',
+      necro_corpse_priority: 'heal', necro_heal: false,
+      make_zombie: false, make_bonebug: false,
+      redeemed: false, cycle_rituals: false, force_rituals: false,
+      current_harvest_count: 0, necro_count: 0,
+      dissect_and_butcher: true, butcher_count: 2, necro_store: false,
+      equipment_manager: double('EquipmentManager', stow_weapon: nil, wield_weapon?: nil)
+    }
+    defaults.merge(overrides).each { |k, v| lp.instance_variable_set(:"@#{k}", v) }
+    lp
+  end
+
+  def necro_game_state(construct: false)
+    state = double('GameState', necro_casting?: false, cfb_active?: false, cfw_active?: false,
+                                weapon_name: 'javelin', weapon_skill: 'Polearms')
+    allow(state).to receive(:construct?).and_return(construct)
+    allow(state).to receive(:construct)
+    allow(state).to receive(:prepare_nr=)
+    allow(state).to receive(:prepare_cfb=)
+    allow(state).to receive(:prepare_cfw=)
+    allow(state).to receive(:prepare_consume=)
+    state
+  end
+
+  describe '#check_rituals? with two same-noun corpses in the room' do
+    it 'asks the creature registry for dead creatures' do
+      build_necro_loot.check_rituals?(necro_game_state)
+
+      expect(Lich::DragonRealms::Creature._in_room_filters).to include([:dead])
+    end
+
+    it 'targets preserve, every butcher and the final dissect at the selected corpse id' do
+      build_necro_loot(ritual_type: 'butcher', dissect_and_butcher: true, butcher_count: 2)
+        .check_rituals?(necro_game_state)
+
+      expect(perform_commands).to eq(
+        [
+          'perform preserve on #111',
+          'perform butcher on #111',
+          'perform butcher on #111',
+          'perform dissect on #111'
+        ]
+      )
+    end
+
+    it 'never addresses a corpse by noun, nor the other same-noun corpse' do
+      build_necro_loot(ritual_type: 'butcher', dissect_and_butcher: true, butcher_count: 2)
+        .check_rituals?(necro_game_state)
+
+      expect(sent_commands.grep(/rat/)).to be_empty
+      expect(sent_commands.grep(/#222/)).to be_empty
+    end
+
+    it 'targets the selected corpse id for a non-butcher ritual and its preserve' do
+      # Mindstates full, so the configured ritual is skipped and only the
+      # zombie-raising arise (with its preserve) runs. Stubbed per-example
+      # rather than seeded with DRSkill._set_xp: outdoorsmanship_spec swaps
+      # the harness xp store for one reset_data does not clear, so a seeded
+      # value leaks into later examples in a full-suite run.
+      allow(DRSkill).to receive(:getxp).and_return(34)
+
+      build_necro_loot(ritual_type: 'dissect', dissect_and_butcher: false, make_zombie: true)
+        .check_rituals?(necro_game_state)
+
+      expect(perform_commands).to eq(['perform preserve on #111', 'perform arise on #111'])
+    end
+
+    it 'sends nothing when the room holds no corpse' do
+      Lich::DragonRealms::Creature._set_room([])
+
+      expect(build_necro_loot.check_rituals?(necro_game_state)).to be true
+      expect(perform_commands).to be_empty
+    end
+
+    it 'skips a corpse the game state already knows is a construct' do
+      game_state = necro_game_state(construct: true)
+
+      expect(build_necro_loot.check_rituals?(game_state)).to be true
+      expect(game_state).to have_received(:construct?).with('rat')
+      expect(perform_commands).to be_empty
+    end
+  end
+
+  describe 'wrong/missing corpse diagnostics' do
+    it 'reports the corpse name and id when a perform misses its target' do
+      bput_responses['perform dissect on #111'] = 'What were you referring to'
+
+      build_necro_loot(ritual_type: 'dissect', dissect_and_butcher: false)
+        .check_rituals?(necro_game_state)
+
+      expect(DRC).to have_received(:message)
+        .with("*** combat-trainer: dissect failed - wrong/missing corpse target (tried 'a giant rat' #111)")
+    end
+
+    it 'falls back to the noun when the corpse has no name yet' do
+      selected_corpse.name = nil
+      bput_responses['perform dissect on #111'] = 'What were you referring to'
+
+      build_necro_loot(ritual_type: 'dissect', dissect_and_butcher: false)
+        .check_rituals?(necro_game_state)
+
+      expect(DRC).to have_received(:message)
+        .with("*** combat-trainer: dissect failed - wrong/missing corpse target (tried 'rat' #111)")
+    end
+
+    it 'reports the corpse and skips the dissect when a butcher misses its target' do
+      bput_responses['perform butcher on #111'] = 'I could not find what you were referring to'
+
+      build_necro_loot(ritual_type: 'butcher', dissect_and_butcher: true, butcher_count: 2)
+        .check_rituals?(necro_game_state)
+
+      expect(DRC).to have_received(:message)
+        .with("*** combat-trainer: butcher failed - wrong/missing corpse target (tried 'a giant rat' #111)")
+      expect(perform_commands).to eq(['perform preserve on #111', 'perform butcher on #111'])
+    end
+  end
+end

--- a/test/test_harness.rb
+++ b/test/test_harness.rb
@@ -835,6 +835,7 @@ module Harness
     Map._reset
     XMLData._reset
     UserVars._reset
+    Lich::DragonRealms::Creature._reset
   end
 
   def echo(message)
@@ -1380,6 +1381,41 @@ module Harness
 
     module Util
       def self.issue_command(*_args); []; end
+    end
+
+    module DragonRealms
+      # Stand-in for lich-5's creature registry (lib/dragonrealms/creature.rb).
+      # Real CreatureInstance objects expose id/noun/name plus status flags; a
+      # spec only needs to seed the room roster, so any object answering the
+      # attributes the script under test reads (an OpenStruct is plenty) works.
+      #
+      # in_room ignores its status filters (:dead, :undead, ...) and returns
+      # whatever was seeded -- seed the roster you want the filtered call to
+      # produce. The filters are still recorded in _in_room_filters so a spec
+      # can assert the script asked for the right ones.
+      module Creature
+        @@_room = []
+        @@_in_room_filters = []
+
+        def self._reset
+          @@_room = []
+          @@_in_room_filters = []
+        end
+
+        # Seed the roster with an array of creature-like objects.
+        def self._set_room(creatures)
+          @@_room = creatures
+        end
+
+        def self._in_room_filters
+          @@_in_room_filters
+        end
+
+        def self.in_room(*filters)
+          @@_in_room_filters << filters
+          @@_room
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Ritual targeting used `mob_noun` (a bare noun string from `DRRoom.dead_npcs`) for every perform/preserve/butcher command and error message
- When more than one same-noun corpse is in the room, that's ambiguous and can hit the wrong corpse
- Switch to `Lich::DragonRealms::Creature.in_room(:dead)` and target/echo by corpse id, falling back to noun only for display
- Added regression specs: two same-noun corpses in the room, differing only by id, so every `perform`/butcher command has to name `#<id>`

## Test plan
- [x] `rspec spec/combat_trainer_spec.rb`
- [x] `rspec` (full suite, and with `--order random`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved necromancer ritual handling for live dead-creature objects.
  * Rituals now reject missing corpses and correctly identify constructs.
  * Ritual commands, butchering, and follow-up dissection consistently target the correct creature.
  * Diagnostics now include creature names and IDs for clearer error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
