### PR TITLE
spec: opt-in line coverage for .lic scripts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 group :development do
+  gem "simplecov"
   gem "rspec"
   gem "rubocop"
   gem "guard"

--- a/spec/automap_spec.rb
+++ b/spec/automap_spec.rb
@@ -21,26 +21,6 @@ require 'ostruct'
 
 # Eval only the `module AutoMap ... end` slice so the top-level hook, config read,
 # and mapping loop at the bottom of the .lic never run.
-#
-# @param filename [String] path to the .lic relative to this spec's parent dir
-# @param module_name [String] the module to extract
-# @return [void]
-def load_lic_module(filename, module_name)
-  return if Object.const_defined?(module_name)
-
-  path = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(path)
-
-  start_idx = lines.index { |l| l =~ /^module\s+#{module_name}\b/ }
-  raise "Could not find 'module #{module_name}' in #{filename}" unless start_idx
-
-  end_offset = lines[start_idx + 1..].index { |l| l =~ /^end\s*$/ }
-  raise "Could not find matching end for 'module #{module_name}'" unless end_offset
-
-  source = lines[start_idx..start_idx + 1 + end_offset].join
-  eval(source, TOPLEVEL_BINDING, path, start_idx + 1)
-end
-
 load_lic_module('automap.lic', 'AutoMap')
 
 # Build a room stand-in with only the accessors AutoMap touches.

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -22,8 +22,9 @@ LICH_DIR = Dir.mktmpdir('lich-test') unless defined?(LICH_DIR)
 $clean_lich_char = ';'
 
 # --- Extract methods from dependency.lic ---
-dep_path = File.join(File.dirname(__FILE__), '..', 'dependency.lic')
+dep_path = lic_path('dependency.lic')
 dep_lines = File.readlines(dep_path)
+prime_lic_coverage(dep_path, dep_lines.size)
 
 DEP_SOURCE = File.read(dep_path)
 

--- a/spec/moonwatch_spec.rb
+++ b/spec/moonwatch_spec.rb
@@ -28,21 +28,7 @@ require_relative 'spec_helper'
 # `include`s Harness exactly once (it is auto-required via .rspec). We must NOT
 # re-`load` the harness here -- doing so re-executes its class bodies and would
 # clobber other specs' harness reopenings (e.g. combat-trainer's DRSpells
-# _reset). load_lic_class comes from spec_helper; we only add a `module` variant.
-def load_lic_module(filename, module_name)
-  return if Object.const_defined?(module_name)
-
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
-  lines = File.readlines(filepath)
-
-  start_idx = lines.index { |l| l =~ /^module\s+#{module_name}\b/ }
-  raise "Could not find 'module #{module_name}' in #{filename}" unless start_idx
-
-  end_idx = (start_idx + 1...lines.size).find { |i| lines[i] =~ /^end\s*$/ }
-  raise "Could not find matching end for 'module #{module_name}' in #{filename}" unless end_idx
-
-  eval(lines[start_idx..end_idx].join, TOPLEVEL_BINDING, filepath, start_idx + 1)
-end
+# _reset). load_lic_class and load_lic_module both come from spec_helper.
 
 # --- collaborators (contamination-proof) ----------------------------------
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,20 @@
 #     other file). Put spec-specific world setup in a describe-scoped before
 #     instead.
 
+# Coverage (opt-in): COVERAGE=1 bundle exec rspec, report in coverage/index.html.
+#
+# This has to run before anything else here, and it needs `enable_coverage :eval`
+# -- the .lic files are never required, they are eval'd by load_lic_class below,
+# and Ruby only measures eval'd source when Coverage is set up with eval: true.
+# Starting here is early enough: RSpec requires spec_helper (via .rspec) before
+# it loads any *_spec.rb, so every load_lic_class call still lies ahead of us.
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.enable_coverage :eval
+  SimpleCov.enable_coverage :branch
+  SimpleCov.start
+end
+
 require 'ostruct'
 
 # Load the test harness, which provides the mock game objects and commons
@@ -81,6 +95,31 @@ require 'ostruct'
 load File.join(File.dirname(__FILE__), '..', 'test', 'test_harness.rb')
 
 include Harness
+
+# Absolute, symlink-free path to a .lic in the repo root. Expanded rather than
+# left as "<root>/spec/../foo.lic" so eval attributes the source to the file's
+# real path -- backtraces point at it, and coverage tooling does not mistake it
+# for something under spec/.
+def lic_path(filename)
+  File.expand_path(File.join(__dir__, '..', filename))
+end
+
+# Ruby allocates a file's eval-coverage line array on the FIRST eval attributed
+# to that filename and never grows it. A .lic holding several classes is eval'd
+# once per class, so any class starting past the end of the first-eval'd one
+# would be silently dropped from coverage -- not counted as missed, just absent
+# (combat-trainer.lic reported 2 of its 11 classes). Priming with a blank eval
+# spanning the whole file sizes the array once so every later eval lands inside.
+# No-op when coverage is not running.
+def prime_lic_coverage(filepath, line_count)
+  return unless defined?(Coverage) && Coverage.running?
+
+  @primed_lic_files ||= {}
+  return if @primed_lic_files[filepath]
+
+  @primed_lic_files[filepath] = true
+  eval(("\n" * (line_count - 1)) + 'nil', TOPLEVEL_BINDING, filepath, 1)
+end
 
 # Extract and eval a class from a .lic file without executing the top-level code
 # (before_dying blocks, Klass.new, etc.) that sits outside the class body.
@@ -91,8 +130,9 @@ include Harness
 def load_lic_class(filename, class_name)
   return if Object.const_defined?(class_name)
 
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
+  filepath = lic_path(filename)
   lines = File.readlines(filepath)
+  prime_lic_coverage(filepath, lines.size)
 
   start_idx = lines.index { |l| l =~ /^class\s+#{class_name}\b/ }
   raise "Could not find 'class #{class_name}' in #{filename}" unless start_idx
@@ -110,19 +150,42 @@ def load_lic_class(filename, class_name)
   eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
 end
 
+# Module counterpart to load_lic_class, with the same strategy and guard.
+# Lived as a duplicated top-level def in automap_spec and moonwatch_spec, which
+# is the exact "a duplicate top-level definition wins for the entire process by
+# load order" hazard described above -- it belongs here, defined once.
+def load_lic_module(filename, module_name)
+  return if Object.const_defined?(module_name)
+
+  filepath = lic_path(filename)
+  lines = File.readlines(filepath)
+  prime_lic_coverage(filepath, lines.size)
+
+  start_idx = lines.index { |l| l =~ /^module\s+#{module_name}\b/ }
+  raise "Could not find 'module #{module_name}' in #{filename}" unless start_idx
+
+  end_idx = (start_idx + 1...lines.size).find { |i| lines[i] =~ /^end\s*$/ }
+  raise "Could not find matching end for 'module #{module_name}' in #{filename}" unless end_idx
+
+  eval(lines[start_idx..end_idx].join, TOPLEVEL_BINDING, filepath, start_idx + 1)
+end
+
 # Extract and eval a single top-level constant assignment (CONST = ...) from a
 # .lic file without executing the rest of the file. The const_defined? guard
 # makes repeated calls (across co-running specs) idempotent.
 def load_lic_constant(filename, const_name)
   return if Object.const_defined?(const_name)
 
-  filepath = File.join(File.dirname(__FILE__), '..', filename)
+  filepath = lic_path(filename)
   lines = File.readlines(filepath)
+  prime_lic_coverage(filepath, lines.size)
 
-  line = lines.find { |l| l =~ /^#{const_name}\s*=/ }
-  raise "Could not find '#{const_name}' in #{filename}" unless line
+  idx = lines.index { |l| l =~ /^#{const_name}\s*=/ }
+  raise "Could not find '#{const_name}' in #{filename}" unless idx
 
-  eval(line, TOPLEVEL_BINDING, filepath)
+  # Pass the real line number so the eval'd assignment is attributed to where it
+  # actually lives, rather than to line 1 of the file.
+  eval(lines[idx], TOPLEVEL_BINDING, filepath, idx + 1)
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,6 +85,32 @@ if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.enable_coverage :eval
   SimpleCov.enable_coverage :branch
+
+  # Only the class/module bodies a spec extracts are ever eval'd, so a script's
+  # remaining code -- the before_dying block, the `Klass.new` entry point, a
+  # top-level def, a multi-line constant -- is invisible to Coverage rather than
+  # counted as missed, which quietly flatters the percentage. Backfill those
+  # lines from SimpleCov's own static line classifier (the same one it uses for
+  # files that were never loaded at all) so they land in the denominator as
+  # uncovered. Real measurements always win; this only fills nil holes.
+  SimpleCov.at_exit do
+    result = SimpleCov.result
+    raw = result.original_result
+
+    raw.each do |filename, data|
+      next unless filename.end_with?('.lic')
+
+      static = SimpleCov::SimulateCoverage.call(filename)
+      static = static['lines'] || static[:lines] if static.is_a?(Hash)
+      next unless static
+
+      measured = data['lines'] || data[:lines]
+      static.each_index { |i| measured[i] = 0 if measured[i].nil? && !static[i].nil? }
+    end
+
+    SimpleCov::Result.new(raw, command_name: SimpleCov.command_name).format!
+  end
+
   SimpleCov.start
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,12 @@
 #     other file). Put spec-specific world setup in a describe-scoped before
 #     instead.
 
+# Line ranges (0-based, inclusive) each extractor actually eval'd out of a .lic,
+# keyed by absolute path. Lets the coverage backfill below distinguish "no spec
+# ever eval'd this line" from "eval'd, but Ruby attributed the statement to a
+# neighbouring line". Harmless and cheap when coverage is off.
+LIC_EVAL_RANGES = Hash.new { |h, k| h[k] = [] }
+
 # Coverage (opt-in): COVERAGE=1 bundle exec rspec, report in coverage/index.html.
 #
 # This has to run before anything else here, and it needs `enable_coverage :eval`
@@ -88,14 +94,19 @@ if ENV['COVERAGE']
 
   # Only the class/module bodies a spec extracts are ever eval'd, so a script's
   # remaining code -- the before_dying block, the `Klass.new` entry point, a
-  # top-level def, a multi-line constant -- is invisible to Coverage rather than
-  # counted as missed, which quietly flatters the percentage. Backfill those
-  # lines from SimpleCov's own static line classifier (the same one it uses for
-  # files that were never loaded at all) so they land in the denominator as
-  # uncovered. Real measurements always win; this only fills nil holes.
+  # top-level def -- is invisible to Coverage rather than counted as missed,
+  # which quietly flatters the percentage. Backfill those lines from SimpleCov's
+  # own static line classifier (the same one it uses for files that were never
+  # loaded at all) so they land in the denominator as uncovered.
+  #
+  # Restricted to lines OUTSIDE every range an extractor eval'd. Inside an eval'd
+  # range Ruby is authoritative and the static classifier is not: it calls each
+  # element line of a multi-line literal relevant, while Ruby attributes the
+  # whole literal to one line. Backfilling there invents missed lines for code
+  # that demonstrably ran (astrology.lic's OBSERVE_SUCCESS_PATTERNS is the
+  # example -- line 73 opens the array, but Ruby records the hit on line 74).
   SimpleCov.at_exit do
-    result = SimpleCov.result
-    raw = result.original_result
+    raw = SimpleCov.result.original_result
 
     raw.each do |filename, data|
       next unless filename.end_with?('.lic')
@@ -104,8 +115,14 @@ if ENV['COVERAGE']
       static = static['lines'] || static[:lines] if static.is_a?(Hash)
       next unless static
 
+      evaled = LIC_EVAL_RANGES[filename]
       measured = data['lines'] || data[:lines]
-      static.each_index { |i| measured[i] = 0 if measured[i].nil? && !static[i].nil? }
+      static.each_index do |i|
+        next unless measured[i].nil? && !static[i].nil?
+        next if evaled.any? { |range| range.cover?(i) }
+
+        measured[i] = 0
+      end
     end
 
     SimpleCov::Result.new(raw, command_name: SimpleCov.command_name).format!
@@ -173,6 +190,7 @@ def load_lic_class(filename, class_name)
   raise "Could not find matching end for 'class #{class_name}' in #{filename}" unless end_idx
 
   class_source = lines[start_idx..end_idx].join
+  LIC_EVAL_RANGES[filepath] << (start_idx..end_idx)
   eval(class_source, TOPLEVEL_BINDING, filepath, start_idx + 1)
 end
 
@@ -193,6 +211,7 @@ def load_lic_module(filename, module_name)
   end_idx = (start_idx + 1...lines.size).find { |i| lines[i] =~ /^end\s*$/ }
   raise "Could not find matching end for 'module #{module_name}' in #{filename}" unless end_idx
 
+  LIC_EVAL_RANGES[filepath] << (start_idx..end_idx)
   eval(lines[start_idx..end_idx].join, TOPLEVEL_BINDING, filepath, start_idx + 1)
 end
 
@@ -211,6 +230,7 @@ def load_lic_constant(filename, const_name)
 
   # Pass the real line number so the eval'd assignment is attributed to where it
   # actually lives, rather than to line 1 of the file.
+  LIC_EVAL_RANGES[filepath] << (idx..idx)
   eval(lines[idx], TOPLEVEL_BINDING, filepath, idx + 1)
 end
 


### PR DESCRIPTION
Adds opt-in line/branch coverage for the `.lic` scripts:

```sh
COVERAGE=1 bundle exec rspec     # report in coverage/ (already gitignored)
```

Default runs are untouched — without `COVERAGE` set, nothing here loads simplecov or does any extra work.

Current picture across the 39 specced scripts: **6391 / 16401 lines (39.0%)**, branch 27.3%. The other 183 scripts have no spec at all.

## Why this needed more than `SimpleCov.start`

I tried the obvious thing first and got a report claiming 0 covered lines. Three separate problems, each of which silently produces a wrong number rather than an error:

**1. The specs never `require` the scripts.** `load_lic_class` evals a line-slice of the `.lic`, and Ruby only measures eval'd source when Coverage is set up with `eval: true`. Without `enable_coverage :eval` the report is empty. Starting simplecov at the top of `spec_helper.rb` is early enough — `.rspec`'s `--require spec_helper` runs before any `*_spec.rb` loads, so every extractor call still lies ahead of it.

**2. The extractors built the path as `<root>/spec/../foo.lic`.** Its project-relative form is `spec/../foo.lic`, which simplecov's default test-directory filter discards — so the scripts were being thrown out of their own coverage report. The new `lic_path` helper expands the path, after which the *default* filters are correct and no filter configuration is needed. It also means backtraces from eval'd code point at the file's real path.

**3. Ruby sizes a file's eval-coverage line array on the first eval attributed to that filename and never grows it.** A multi-class `.lic` is eval'd once per class, so any class starting past the end of the first-eval'd one was dropped — not counted as missed, just absent. `combat-trainer.lic` was reporting 2 of its 11 classes. `prime_lic_coverage` sizes the array once per file up front; it is a no-op unless `Coverage.running?`.

## Un-eval'd code is now counted as missed

Only the class/module bodies a spec extracts ever run, so the rest of a script — the `before_dying` block, the `Klass.new` entry point, a top-level `def` — had no coverage entry at all. That is not the same as being uncovered: those lines were dropped from the denominator, which flattered every percentage. They are now backfilled from simplecov's static line classifier (the same one it uses for files that were never loaded) at ~390 lines across the suite.

The backfill is deliberately restricted to lines *outside* every range an extractor eval'd, recorded in `LIC_EVAL_RANGES`. Inside an eval'd range Ruby is authoritative and the static classifier is not: it calls each element line of a multi-line literal relevant, while Ruby attributes the whole literal to one line. Without the restriction, `astrology.lic`'s `OBSERVE_SUCCESS_PATTERNS` had its opening line reported missed while the next line showed a hit — 23 invented missed lines across the suite.

## Extractor consolidation

`automap_spec` and `moonwatch_spec` each defined their own top-level `load_lic_module`, and `dependency_spec` built its own path. Two identical top-level defs in different spec files is exactly the load-order hazard `spec_helper.rb`'s own header warns about, so `load_lic_module` moves into spec_helper and the three specs use the shared extractors.

That was not only tidiness — it was also why `automap.lic` and `dependency.lic` were missing from the report entirely and `moonwatch.lic` was losing its five modules.

Two smaller fixes while in here:

- `load_lic_constant` passes the constant's real line number to `eval` instead of defaulting to line 1.
- `load_lic_constant` uses `index` rather than `find`, so the line number is available.

## Note on the dependency

`simplecov` is added to the `:development` group. It is only loaded when `COVERAGE` is set, but it does become a bundle dependency. If that is unwelcome I am happy to move the whole thing behind an optional group instead — say the word.

## Test plan

- [ ] `bundle exec rspec` — 2977 examples, 0 failures (unchanged from main)
- [ ] `COVERAGE=1 bundle exec rspec` — same 2977 examples, plus `coverage/index.html`
- [ ] `bundle exec rubocop spec/` — clean
- [ ] Spot-check `coverage/index.html`: `combat-trainer.lic` shows all 11 classes, and its `before_dying` block reads as missed rather than being absent
