### PR TITLE
[data][base-hunting] Fix dangling town refs and snarlvine_fox indentation

### DIFF
--- a/data/base-hunting.yaml
+++ b/data/base-hunting.yaml
@@ -198,9 +198,9 @@ hunting_areas_by_town:
   # https://elanthipedia.play.net/Mottled_westanuryn                     180-290
     - velaka_westanuryn
   # https://elanthipedia.play.net/Velakan_slaver                         225-360
-    - velaka_slaver
+    - velaka_slavers
   # https://elanthipedia.play.net/Zombie_nomad                           260-410
-    - zombie_nomad
+    - zombie_nomads
   # https://elanthipedia.play.net/Gam_chaga                              300-450
     - gam_chaga
   # https://elanthipedia.play.net/Isundjen_conjurer                      360-500
@@ -246,8 +246,6 @@ hunting_areas_by_town:
   # 19097 - Unmappable room
   # Hit or miss spawns, boxes and skins
     - orc_scouts
-  # https://elanthipedia.play.net/Hulking_black_barghest                 210-290
-    - hulking_black_barghest_riverhaven
   # https://elanthipedia.play.net/Orc_Bandit                             180-317
   # warcats calm, need 35 disc
   # Hit or miss spawn, boxes and skins
@@ -311,7 +309,7 @@ hunting_areas_by_town:
   # https://elanthipedia.play.net/Silver_leucro                           95-110
     - silver_leucros_ratha
   # https://elanthipedia.play.net/Adult_razortusk_boar                   100-130
-    - razortuzk_boars
+    - razortusk_boars
   # https://elanthipedia.play.net/Merrows                                120-150
     - crimson_merrows
   # https://elanthipedia.play.net/Bawdy_swain                            120-150
@@ -2616,9 +2614,9 @@ hunting_zones:
   - 10066
   - 10065
   - 10064
-  #https://elanthipedia.play.net/Snarlvine_fox                         550-700
-  #snarvine vixen spawn too, same mob different nount
-  - snarlvine_fox:
+  # https://elanthipedia.play.net/Snarlvine_fox                         550-700
+  # snarlvine vixen spawn too, same mob different noun
+  snarlvine_fox:
   - 51876
   - 51877
   - 51878

--- a/spec/base_hunting_spec.rb
+++ b/spec/base_hunting_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+require_relative 'spec_helper'
+
+# Structural-integrity specs for data/base-hunting.yaml, guarding the cleanup in
+# this PR and the two bug classes it fixes.
+#
+# 1. Dangling town references. `hunting_areas_by_town` is a per-town menu of zone
+#    NAMES; every name must resolve to a zone defined in `hunting_zones`
+#    (name -> [room_ids]) or `escort_zones` (name -> {base,area,enter}), or it
+#    silently resolves to nothing at runtime (hunting-buddy#find_hunting_room?).
+#    Four names had drifted: velaka_slaver/zombie_nomad/razortuzk_boars were
+#    singular/misspelled variants of real zones, and
+#    hulking_black_barghest_riverhaven was never defined (dead menu entry removed;
+#    tracked as a follow-up to map Ceceline's Meadow and re-add it).
+#
+# 2. A YAML indentation slip folded a whole zone into another zone's room list.
+#    `snarlvine_fox` was written as `- snarlvine_fox:` (a list ITEM whose value is
+#    a mapping) inside the `sky_giants` list instead of as its own sibling key, so
+#    Psych parsed sky_giants as [..ints.., {"snarlvine_fox"=>nil}, 51876..51879]:
+#    snarlvine_fox was undiscoverable and its four rooms were misattributed to
+#    sky_giants, and sky_giants held a Hash where room-id code expects Integers.
+#
+# These specs assert the file-wide invariants (all now hold) plus the specific
+# snarlvine_fox/sky_giants regression, so a future edit that reintroduces either
+# bug class fails loudly.
+#
+# YAML is loaded permissively (YAML.unsafe_load_file) to match how Lich loads it
+# at runtime -- base-hunting.yaml uses YAML aliases, which Psych 4+ rejects under
+# a safe load. Specs run from the repo root, so the relative path resolves.
+RSpec.describe 'data/base-hunting.yaml integrity' do
+  let(:data)          { YAML.unsafe_load_file('data/base-hunting.yaml') }
+  let(:escort_zones)  { data.fetch('escort_zones') }
+  let(:hunting_zones) { data.fetch('hunting_zones') }
+  let(:towns)         { data.fetch('hunting_areas_by_town') }
+  # Every zone the game can actually route to: escort (via bescort) or go2 rooms.
+  let(:defined_zones) { escort_zones.keys + hunting_zones.keys }
+
+  it 'parses as valid YAML' do
+    expect(data).to be_a(Hash)
+  end
+
+  describe 'town menus (hunting_areas_by_town)' do
+    it 'reference only zones defined in hunting_zones or escort_zones' do
+      referenced = towns.values.flatten.compact.uniq
+      unresolved = referenced.reject { |zone| defined_zones.include?(zone) }
+
+      expect(unresolved).to eq([]), "dangling town references (defined nowhere): #{unresolved.inspect}"
+    end
+  end
+
+  describe 'hunting_zones' do
+    it 'maps every zone to a non-empty list of positive integer room ids' do
+      malformed = hunting_zones.reject do |_name, rooms|
+        rooms.is_a?(Array) && !rooms.empty? && rooms.all? { |room| room.is_a?(Integer) && room.positive? }
+      end
+
+      expect(malformed.keys).to eq([]), "malformed hunting_zones room lists: #{malformed.keys.inspect}"
+    end
+
+    it 'never shares a name with escort_zones (escort takes precedence at runtime)' do
+      expect(escort_zones.keys & hunting_zones.keys).to eq([])
+    end
+  end
+
+  # Regression for the "- snarlvine_fox:" indentation fold into sky_giants.
+  describe 'snarlvine_fox' do
+    it 'is its own zone with exactly its four rooms' do
+      expect(hunting_zones['snarlvine_fox']).to eq([51876, 51877, 51878, 51879])
+    end
+
+    it 'is not swallowed into sky_giants, which stays pure room-id integers' do
+      expect(hunting_zones['sky_giants']).to all(be_a(Integer))
+      expect(hunting_zones['sky_giants']).not_to include(51876, 51877, 51878, 51879)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Two classes of latent data bug in `data/base-hunting.yaml`:

**1. Dangling town references.** `hunting_areas_by_town` is a per-town menu of zone *names*; each must resolve to a zone in `hunting_zones` or `escort_zones`, or it silently resolves to nothing at runtime (`hunting-buddy.lic#find_hunting_room?`). Four had drifted:

| Town menu listed | Real zone | Issue |
|---|---|---|
| `velaka_slaver` | `velaka_slavers` | singular typo |
| `zombie_nomad` | `zombie_nomads` | singular typo |
| `razortuzk_boars` | `razortusk_boars` | `z`->`s` typo |
| `hulking_black_barghest_riverhaven` | *(none)* | never defined (no rooms) |

**2. YAML indentation fold.** `snarlvine_fox` was written as `- snarlvine_fox:` (a list item whose value is a mapping) *inside* the `sky_giants` room list instead of as its own sibling key, so Psych parsed:

```ruby
sky_giants => [10072, ..., 10064, {"snarlvine_fox"=>nil}, 51876, 51877, 51878, 51879]
```

So `snarlvine_fox` was undiscoverable, its four rooms were misattributed to `sky_giants`, and `sky_giants` held a `Hash` where room-id code expects `Integer`s.

## Fix

- Correct the three typo'd town refs to their real zone names.
- Remove the dead `hulking_black_barghest_riverhaven` menu entry (nothing to resolve to). The mob is real (Hulking black barghest, ~210-290, in Ceceline's Meadow) but was never mapped; it's tracked as a follow-up to map that area and re-add the zone with real rooms.
- Dedent `snarlvine_fox` to its own `hunting_zones` key (rooms 51876-51879). `sky_giants` is now a clean list of room-id integers.

No behavior change for any working zone: the renamed refs now reach zones that already existed, and the removed ref did nothing before.

## Tests

New `spec/base_hunting_spec.rb` (DAMP) asserts the file-wide invariants and the specific regression:

- every `hunting_areas_by_town` reference resolves to a defined zone (guards dangling refs)
- every `hunting_zones` value is a non-empty array of positive integer room ids (guards the fold)
- no zone name is defined in both `escort_zones` and `hunting_zones`
- `snarlvine_fox` is its own zone `[51876, 51877, 51878, 51879]` and is not present in `sky_giants`

Results: new spec 6 examples 0 failures; **full suite 2983 examples, 0 failures**; `rubocop` clean.

Note: the separate brocket-conversion PR (#7549) also introduces `spec/base_hunting_spec.rb`; whichever merges second needs a trivial union of the two `RSpec.describe` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)