### PR TITLE
enchant: study sigils out of sigil books

### DIFF
--- a/enchant.lic
+++ b/enchant.lic
@@ -172,8 +172,7 @@ class Enchant
     result = DRC.bput("analyze #{@item} on #{@brazier_ref}", *analyze_patterns)
 
     if ANALYZE_READY_PATTERNS.any? { |pat| pat.match?(result) }
-      DRCC.get_crafting_item(@burin, @bag, @bag_items, @belt)
-      scribe
+      scribe_with_burin
     elsif ANALYZE_IMBUE_PATTERN.match?(result)
       handle_imbue_resume
     else
@@ -183,14 +182,16 @@ class Enchant
 
   def handle_imbue_resume
     result = DRC.bput("look on #{@brazier_ref}", BRAZIER_HAS_FOUNT_PATTERN, 'There is nothing')
-    if BRAZIER_HAS_FOUNT_PATTERN.match?(result)
-      imbue
-    else
+    unless BRAZIER_HAS_FOUNT_PATTERN.match?(result)
       DRCC.get_crafting_item(@fount, @bag, @bag_items, @belt)
       wave_result = DRC.bput("wave my #{@fount} at #{@item} on #{@brazier_ref}", WAVE_FOUNT_SUCCESS, WAVE_FOUNT_NOT_NEEDED)
       DRCC.stow_crafting_item(@fount, @bag, @belt) if wave_result == WAVE_FOUNT_NOT_NEEDED
-      imbue
     end
+    imbue
+    # An imbue is never the last step - the item still needs scribing, and the
+    # sigil prompt only arrives after the imbue roundtime. Without this the
+    # script exits before the scribe loop ever sees it.
+    scribe_with_burin
   end
 
   def handle_new_enchant
@@ -212,6 +213,14 @@ class Enchant
     DRC.bput("touch my #{@cube}", *TOUCH_CUBE_PATTERNS) if @cube
     imbue
 
+    scribe_with_burin
+  end
+
+  # Picks the burin back up and enters the scribe loop. Every path that leaves
+  # the item ready for scribing ends here.
+  #
+  # @return [void]
+  def scribe_with_burin
     DRCC.get_crafting_item(@burin, @bag, @bag_items, @belt)
     scribe
   end

--- a/enchant.lic
+++ b/enchant.lic
@@ -54,6 +54,33 @@ class Enchant
   SIGIL_STUDY_SUCCESS = /^You study the sigil-scroll and commit the design to memory/.freeze
   SIGIL_TRACE_SUCCESS = /^Recalling the intricacies of the sigil, you trace its form/.freeze
 
+  # Sigil book (holds sigil-scrolls in numbered pages, grouped into sections by
+  # sigil type). TURN selects a section or a page, READ lists the pages of the
+  # current view, and STUDY memorizes the sigil on the selected page - the same
+  # memorization the loose-scroll path gets, so TRACE is unchanged afterwards.
+  #
+  # The book must be HELD for any of these ("But you're not holding it."), and
+  # the item reference must NOT contain the word "sigil": the parser reads it as
+  # the sigil-type argument, so "turn my sigil book to sigil congruence" answers
+  # "Which sigil did you wish to turn the a small sigil book to?". The bare noun
+  # is used for TURN/READ/STUDY for that reason - which also means the artificing
+  # instruction book must be stowed while the sigil book is in hand.
+  SIGIL_BOOK_TURN_SECTION = /^You turn the .+ to the (?<section>[a-z\-']+) section\./i.freeze
+  SIGIL_BOOK_TURN_PAGE = /^You turn the .+ to page (?<page>\d+)\./i.freeze
+  SIGIL_BOOK_READ_HEADER = /^You page through the .+ to see what scrolls it contains\./.freeze
+  SIGIL_BOOK_READ_FOOTER = /^\[You can turn the book TO PAGE/.freeze
+  # "      3 -- nurture, rough (26), broad (21)"
+  SIGIL_BOOK_PAGE_ROW = /^\s*(?<page>\d+) -- (?<type>[a-z\-']+),/i.freeze
+  SIGIL_BOOK_PAGE_HEADER = /^On this page you see /.freeze
+  SIGIL_BOOK_PAGE_FOOTER = /^\[You can now STUDY the book to memorize the sigil\.\]/.freeze
+  # "   --=== Congruence sigil ===--"
+  SIGIL_BOOK_PAGE_TYPE = /--===\s*(?<type>.+?)\s+sigil\s*===--/i.freeze
+  SIGIL_BOOK_STUDY_SUCCESS = /^You commit the sigil's design to memory/.freeze
+  # STUDY with the book at the contents (no page selected) appraises the book
+  # instead of memorizing anything, so it must be treated as a failure.
+  SIGIL_BOOK_STUDY_APPRAISE = /^You study the book and determine it is well-suited for holding sigil-scrolls/.freeze
+  SIGIL_BOOK_NOT_HELD = "But you're not holding it."
+
   # Scribe patterns
   SCRIBE_RT_PATTERN = /^Roundtime/.freeze
   SCRIBE_SIGIL_NEEDED = /^You need another .* sigil to continue the enchanting process/.freeze
@@ -86,6 +113,10 @@ class Enchant
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.enchanting_belt
     @stamp = @settings.mark_crafted_goods
+    # Optional: sigil books holding your sigil-scrolls, tried in order. A book
+    # only holds 20 scrolls, so several are usually needed. When unset, sigils
+    # are retrieved loose, as before.
+    @sigil_books = @settings.sigil_books
     @worn_trashcan = @settings.worn_trashcan
     @worn_trashcan_verb = @settings.worn_trashcan_verb
 
@@ -339,13 +370,146 @@ class Enchant
   end
 
   def trace_sigil(sigil)
+    return unless study_sigil(sigil)
+
+    DRC.bput("trace #{@item} on #{@brazier_ref}", SIGIL_TRACE_SUCCESS)
+  end
+
+  # Memorizes a sigil, from the sigil book when one is configured and holds the
+  # type, otherwise from a loose sigil-scroll.
+  #
+  # @param sigil [String] sigil type, e.g. 'congruence'
+  # @return [Boolean] true once the sigil is committed to memory
+  def study_sigil(sigil)
+    return true if study_sigil_from_book(sigil)
+
     unless DRCI.get_item?("#{sigil} sigil")
       Lich::Messaging.msg("bold", "Enchant: Failed to get #{sigil} sigil.")
-      return
+      return false
     end
     DRC.bput("study my #{sigil} sigil", SIGIL_STUDY_SUCCESS)
     waitrt?
-    DRC.bput("trace #{@item} on #{@brazier_ref}", SIGIL_TRACE_SUCCESS)
+    true
+  end
+
+  # The configured sigil books, in the order they should be searched. A bare
+  # string is accepted as a single book.
+  #
+  # @return [Array<String>] configured sigil book names
+  def sigil_books
+    Array(@sigil_books)
+  end
+
+  # Studies a sigil out of the configured sigil books, taking the first book
+  # that holds the type. A book only holds 20 scrolls, so a run usually spans
+  # several of them.
+  #
+  # @param sigil [String] sigil type, e.g. 'congruence'
+  # @return [Boolean] true when the sigil was memorized from a book
+  def study_sigil_from_book(sigil)
+    return false if sigil_books.empty?
+
+    return true if sigil_books.any? { |book| study_sigil_from_this_book(book, sigil) }
+
+    Lich::Messaging.msg("bold", "Enchant: No #{sigil} sigil in your sigil books.")
+    false
+  end
+
+  # Studies a sigil out of one book: turn to the type's section, read it for a
+  # page holding that type, turn to that page, confirm the page before studying
+  # it. The book is stowed again before returning, so the caller's hands are
+  # free for the burin and the trace - and so the next book can be picked up
+  # without two same-nouned books being in reach at once.
+  #
+  # Every step is verified by a READ rather than trusted, because studying a
+  # page blanks it and RENUMBERS the remaining pages - a page number is only
+  # valid until the next study, so nothing about a book can be cached.
+  #
+  # @param book [String] the sigil book to search
+  # @param sigil [String] sigil type, e.g. 'congruence'
+  # @return [Boolean] true when the sigil was memorized from this book
+  def study_sigil_from_this_book(book, sigil)
+    return false unless get_sigil_book(book)
+
+    begin
+      page = find_sigil_page(book, sigil)
+      return false unless page
+      return false unless turn_to_sigil_page(book, page, sigil)
+
+      result = DRC.bput("study my #{sigil_book_noun(book)}", SIGIL_BOOK_STUDY_SUCCESS, SIGIL_BOOK_STUDY_APPRAISE, SIGIL_BOOK_NOT_HELD)
+      unless SIGIL_BOOK_STUDY_SUCCESS.match?(result.to_s)
+        Lich::Messaging.msg("bold", "Enchant: Failed to study #{sigil} sigil from #{book}.")
+        return false
+      end
+      waitrt?
+      true
+    ensure
+      DRCC.stow_crafting_item(book, @bag, @belt)
+    end
+  end
+
+  # The reference used for TURN/READ/STUDY. Always the bare noun - see the
+  # SIGIL_BOOK_* constants for why a "sigil ..." reference cannot be used.
+  #
+  # @param book [String] the sigil book name
+  # @return [String] noun of that sigil book
+  def sigil_book_noun(book)
+    DRC.get_noun(book)
+  end
+
+  # Gets a sigil book in hand, which every book command requires.
+  #
+  # Always fetches rather than short-circuiting on a book already held: sigil
+  # books commonly share the noun "book", so a held book is not proof that the
+  # right one is in hand.
+  #
+  # @param book [String] the sigil book to pick up
+  # @return [Boolean] true when the book is held
+  def get_sigil_book(book)
+    DRCC.get_crafting_item(book, @bag, @bag_items, @belt, true)
+    return true if DRCI.in_hands?(sigil_book_noun(book))
+
+    Lich::Messaging.msg("bold", "Enchant: Failed to get #{book}.")
+    false
+  end
+
+  # Finds the first page of a book holding the requested sigil type.
+  #
+  # Turning to a section that holds nothing still succeeds and simply reads
+  # empty, so presence is decided by the READ, not the TURN.
+  #
+  # @param book [String] the sigil book to read
+  # @param sigil [String] sigil type, e.g. 'congruence'
+  # @return [Integer, nil] page number, or nil when this book has none
+  def find_sigil_page(book, sigil)
+    noun = sigil_book_noun(book)
+    DRC.bput("turn my #{noun} to sigil #{sigil}", { 'timeout' => 3, 'suppress_no_match' => true }, SIGIL_BOOK_TURN_SECTION)
+    lines = Lich::Util.issue_command("read my #{noun}", SIGIL_BOOK_READ_HEADER, SIGIL_BOOK_READ_FOOTER, silent: true, quiet: true, timeout: 3)
+    match = lines
+            .map { |line| SIGIL_BOOK_PAGE_ROW.match(line) }
+            .compact
+            .find { |row| row[:type].casecmp(sigil).zero? }
+    match ? match[:page].to_i : nil
+  end
+
+  # Turns to a page and confirms it holds the expected sigil type.
+  #
+  # @param book [String] the sigil book being read
+  # @param page [Integer] page number to turn to
+  # @param sigil [String] sigil type the page is expected to hold
+  # @return [Boolean] true when the page is selected and ready to study
+  def turn_to_sigil_page(book, page, sigil)
+    noun = sigil_book_noun(book)
+    DRC.bput("turn my #{noun} to page #{page}", { 'timeout' => 3, 'suppress_no_match' => true }, SIGIL_BOOK_TURN_PAGE)
+    lines = Lich::Util.issue_command("read my #{noun}", SIGIL_BOOK_PAGE_HEADER, SIGIL_BOOK_PAGE_FOOTER, silent: true, quiet: true, timeout: 3)
+    match = lines
+            .map { |line| SIGIL_BOOK_PAGE_TYPE.match(line) }
+            .compact
+            .first
+    return true if match && match[:type].casecmp(sigil).zero?
+
+    Lich::Messaging.msg("bold", "Enchant: Page #{page} of #{book} does not hold a #{sigil} sigil.")
+    false
   end
 
   def scribe

--- a/enchant.lic
+++ b/enchant.lic
@@ -54,31 +54,42 @@ class Enchant
   SIGIL_STUDY_SUCCESS = /^You study the sigil-scroll and commit the design to memory/.freeze
   SIGIL_TRACE_SUCCESS = /^Recalling the intricacies of the sigil, you trace its form/.freeze
 
-  # Sigil book (holds sigil-scrolls in numbered pages, grouped into sections by
-  # sigil type). TURN selects a section or a page, READ lists the pages of the
-  # current view, and STUDY memorizes the sigil on the selected page - the same
-  # memorization the loose-scroll path gets, so TRACE is unchanged afterwards.
+  # Sigil book (holds sigil-scrolls in numbered pages). Configured as a sigil
+  # type -> book map: one book per type, because a book's contents cannot be
+  # reorganized once filled and there are far more sigil types than a book can
+  # usefully mix. TURN selects a page and STUDY memorizes the sigil on it - the
+  # same memorization the loose-scroll path gets, so TRACE is unchanged after.
+  #
+  # A dedicated book never has to be searched for a sigil: every page holds the
+  # type the book is dedicated to, and studying a page blanks it and RENUMBERS
+  # the rest, so the next scroll of that type is page 1 again. Page 1 is always
+  # the right answer, so no contents listing is ever read or cached.
+  #
+  # STUDY refuses a page that has not been read ("You must read the current page
+  # before you study the book."), so the sequence is TURN, READ, STUDY. The READ
+  # is not wasted: its banner names the sigil on the page, which is checked
+  # against the type asked for - free protection against a mis-filed scroll.
   #
   # The book must be HELD for any of these ("But you're not holding it."), and
   # the item reference must NOT contain the word "sigil": the parser reads it as
-  # the sigil-type argument, so "turn my sigil book to sigil congruence" answers
-  # "Which sigil did you wish to turn the a small sigil book to?". The bare noun
-  # is used for TURN/READ/STUDY for that reason - which also means the artificing
-  # instruction book must be stowed while the sigil book is in hand.
-  SIGIL_BOOK_TURN_SECTION = /^You turn the .+ to the (?<section>[a-z\-']+) section\./i.freeze
+  # a sigil-type argument, so "turn my sigil book to ..." answers "Which sigil
+  # did you wish to turn the a small sigil book to?". The bare noun is used for
+  # TURN/READ/STUDY for that reason - which also means the artificing instruction
+  # book must be stowed while a sigil book is in hand.
   SIGIL_BOOK_TURN_PAGE = /^You turn the .+ to page (?<page>\d+)\./i.freeze
-  SIGIL_BOOK_READ_HEADER = /^You page through the .+ to see what scrolls it contains\./.freeze
-  SIGIL_BOOK_READ_FOOTER = /^\[You can turn the book TO PAGE/.freeze
-  # "      3 -- nurture, rough (26), broad (21)"
-  SIGIL_BOOK_PAGE_ROW = /^\s*(?<page>\d+) -- (?<type>[a-z\-']+),/i.freeze
-  SIGIL_BOOK_PAGE_HEADER = /^On this page you see /.freeze
-  SIGIL_BOOK_PAGE_FOOTER = /^\[You can now STUDY the book to memorize the sigil\.\]/.freeze
-  # "   --=== Congruence sigil ===--"
+  # A book left on a page by an interrupted study answers this instead. It means
+  # the same thing here: a page is selected and ready to READ.
+  SIGIL_BOOK_ALREADY_AT_PAGE = /^You are already on page (?<page>\d+)\./i.freeze
+  # No page 1 means no scrolls left: "The book does not have that many sigils in
+  # it." This is how an emptied book is detected - its contents are never read.
+  SIGIL_BOOK_PAGE_MISSING = /does not have that many sigils in it\./i.freeze
+  # Page banner from READ: "   --=== Congruence sigil ===--"
   SIGIL_BOOK_PAGE_TYPE = /--===\s*(?<type>.+?)\s+sigil\s*===--/i.freeze
   SIGIL_BOOK_STUDY_SUCCESS = /^You commit the sigil's design to memory/.freeze
   # STUDY with the book at the contents (no page selected) appraises the book
   # instead of memorizing anything, so it must be treated as a failure.
   SIGIL_BOOK_STUDY_APPRAISE = /^You study the book and determine it is well-suited for holding sigil-scrolls/.freeze
+  SIGIL_BOOK_STUDY_UNREAD = /^You must read the current page before you study the book\./.freeze
   SIGIL_BOOK_NOT_HELD = "But you're not holding it."
 
   # Scribe patterns
@@ -113,10 +124,14 @@ class Enchant
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.enchanting_belt
     @stamp = @settings.mark_crafted_goods
-    # Optional: sigil books holding your sigil-scrolls, tried in order. A book
-    # only holds 20 scrolls, so several are usually needed. When unset, sigils
-    # are retrieved loose, as before.
-    @sigil_books = @settings.sigil_books
+    # Optional: sigil type -> book map, one book per sigil type. Types without
+    # a book, and an unset setting, fall back to loose sigil-scrolls as before.
+    @sigil_books = parse_sigil_books(@settings.sigil_books)
+    # The sigil book currently in hand, kept between sigils so that a repeat of
+    # the same type costs no fetching at all.
+    @held_sigil_book = nil
+    # Set once if TRACE turns out to need the book's hand free - see trace_sigil.
+    @trace_needs_free_hand = false
     @worn_trashcan = @settings.worn_trashcan
     @worn_trashcan_verb = @settings.worn_trashcan_verb
 
@@ -166,6 +181,9 @@ class Enchant
       setup_flags
       run_enchant
     ensure
+      # The sigil book is held across the whole scribe loop, so it has to be put
+      # away here too - otherwise a killed or crashed run leaves it in hand.
+      stow_sigil_book
       cleanup_flags
     end
   end
@@ -324,7 +342,7 @@ class Enchant
         Lich::Messaging.msg("bold", "Enchant: Casting Imbue failed. Retrying.")
       end
     else
-      unless DRC.left_hand.to_s.include?(@imbue_wand)
+      unless DRCI.in_hands?(@imbue_wand)
         DRCC.get_crafting_item(@imbue_wand, @bag, @bag_items, @belt)
       end
 
@@ -335,7 +353,7 @@ class Enchant
         return
       end
 
-      DRCC.stow_crafting_item(@imbue_wand, @bag, @belt) if DRC.left_hand.to_s.include?(@imbue_wand)
+      DRCC.stow_crafting_item(@imbue_wand, @bag, @belt) if DRCI.in_hands?(@imbue_wand)
     end
     Flags.reset('enchant-imbue')
   end
@@ -369,14 +387,39 @@ class Enchant
     end
   end
 
+  # Memorizes a sigil and traces it onto the item.
+  #
+  # The sigil book is normally kept in hand across the whole scribe loop. If
+  # TRACE turns out to need that hand free, the book is stowed and the trace
+  # retried, and every later trace stows first - so a run self-corrects once
+  # instead of paying a stow and a fetch per sigil on the chance it is needed.
+  #
+  # @param sigil [String] sigil type, e.g. 'congruence'
+  # @return [void]
   def trace_sigil(sigil)
     return unless study_sigil(sigil)
 
-    DRC.bput("trace #{@item} on #{@brazier_ref}", SIGIL_TRACE_SUCCESS)
+    stow_sigil_book if @trace_needs_free_hand
+    return if trace_memorized_sigil
+
+    # Unrecognized response, most likely because both hands are full.
+    @trace_needs_free_hand = true
+    stow_sigil_book
+    return if trace_memorized_sigil
+
+    Lich::Messaging.msg("bold", "Enchant: Failed to trace #{sigil} sigil.")
   end
 
-  # Memorizes a sigil, from the sigil book when one is configured and holds the
-  # type, otherwise from a loose sigil-scroll.
+  # Traces the sigil currently held in memory onto the item.
+  #
+  # @return [Boolean] true when the trace was accepted
+  def trace_memorized_sigil
+    result = DRC.bput("trace #{@item} on #{@brazier_ref}", { 'timeout' => 5, 'suppress_no_match' => true }, SIGIL_TRACE_SUCCESS)
+    SIGIL_TRACE_SUCCESS.match?(result.to_s)
+  end
+
+  # Memorizes a sigil, from the book dedicated to that type when one is
+  # configured, otherwise from a loose sigil-scroll.
   #
   # @param sigil [String] sigil type, e.g. 'congruence'
   # @return [Boolean] true once the sigil is committed to memory
@@ -392,63 +435,106 @@ class Enchant
     true
   end
 
-  # The configured sigil books, in the order they should be searched. A bare
-  # string is accepted as a single book.
+  # The configured sigil type -> book map.
   #
-  # @return [Array<String>] configured sigil book names
+  # @return [Hash{String => String}] downcased sigil type to book name
   def sigil_books
-    Array(@sigil_books)
+    @sigil_books ||= {}
   end
 
-  # Studies a sigil out of the configured sigil books, taking the first book
-  # that holds the type. A book only holds 20 scrolls, so a run usually spans
-  # several of them.
+  # Parses the sigil_books setting into a sigil type -> book map.
   #
-  # @param sigil [String] sigil type, e.g. 'congruence'
-  # @return [Boolean] true when the sigil was memorized from a book
-  def study_sigil_from_book(sigil)
-    return false if sigil_books.empty?
-
-    return true if sigil_books.any? { |book| study_sigil_from_this_book(book, sigil) }
-
-    Lich::Messaging.msg("bold", "Enchant: No #{sigil} sigil in your sigil books.")
-    false
-  end
-
-  # Studies a sigil out of one book: turn to the type's section, read it for a
-  # page holding that type, turn to that page, confirm the page before studying
-  # it. The book is stowed again before returning, so the caller's hands are
-  # free for the burin and the trace - and so the next book can be picked up
-  # without two same-nouned books being in reach at once.
-  #
-  # Every step is verified by a READ rather than trusted, because studying a
-  # page blanks it and RENUMBERS the remaining pages - a page number is only
-  # valid until the next study, so nothing about a book can be cached.
-  #
-  # @param book [String] the sigil book to search
-  # @param sigil [String] sigil type, e.g. 'congruence'
-  # @return [Boolean] true when the sigil was memorized from this book
-  def study_sigil_from_this_book(book, sigil)
-    return false unless get_sigil_book(book)
-
-    begin
-      page = find_sigil_page(book, sigil)
-      return false unless page
-      return false unless turn_to_sigil_page(book, page, sigil)
-
-      result = DRC.bput("study my #{sigil_book_noun(book)}", SIGIL_BOOK_STUDY_SUCCESS, SIGIL_BOOK_STUDY_APPRAISE, SIGIL_BOOK_NOT_HELD)
-      unless SIGIL_BOOK_STUDY_SUCCESS.match?(result.to_s)
-        Lich::Messaging.msg("bold", "Enchant: Failed to study #{sigil} sigil from #{book}.")
-        return false
-      end
-      waitrt?
-      true
-    ensure
-      DRCC.stow_crafting_item(book, @bag, @belt)
+  # @param setting [Hash, nil] the sigil_books setting
+  # @return [Hash{String => String}] downcased sigil type to book name
+  def parse_sigil_books(setting)
+    case setting
+    when Hash
+      setting.each_with_object({}) { |(type, book), books| books[type.to_s.downcase] = book }
+    when nil, ''
+      {}
+    else
+      # Pre-map configs listed books as a bare Array, which cannot say which
+      # type each book holds.
+      Lich::Messaging.msg("bold", "Enchant: sigil_books must map each sigil type to its own book, e.g. 'nurture: blue book'. Using loose sigil-scrolls.") unless Array(setting).empty?
+      {}
     end
   end
 
-  # The reference used for TURN/READ/STUDY. Always the bare noun - see the
+  # Studies a sigil out of the book dedicated to that type.
+  #
+  # Three commands when that book is already in hand (TURN, READ, STUDY), two
+  # more when it has to be swapped in. No contents listing is read: page 1 of a
+  # dedicated book always holds the type wanted - see the SIGIL_BOOK_ constants.
+  #
+  # A book that cannot supply the sigil - out of scrolls, or holding something
+  # other than the type it is mapped to - is dropped from the map for the rest
+  # of the run, so the type falls back to loose sigil-scrolls instead of failing
+  # the same way again on every later prompt.
+  #
+  # @param sigil [String] sigil type, e.g. 'congruence'
+  # @return [Boolean] true when the sigil was memorized from its book
+  def study_sigil_from_book(sigil)
+    book = sigil_books[sigil.downcase]
+    return false unless book
+    return false unless hold_sigil_book(book)
+
+    unless turn_sigil_book_to_first_page(book)
+      Lich::Messaging.msg("bold", "Enchant: #{book} has no #{sigil} sigils left.")
+      sigil_books.delete(sigil.downcase)
+      return false
+    end
+
+    unless read_sigil_book_page(book, sigil)
+      sigil_books.delete(sigil.downcase)
+      return false
+    end
+
+    result = DRC.bput("study my #{sigil_book_noun(book)}", SIGIL_BOOK_STUDY_SUCCESS, SIGIL_BOOK_STUDY_APPRAISE, SIGIL_BOOK_STUDY_UNREAD, SIGIL_BOOK_NOT_HELD)
+    unless SIGIL_BOOK_STUDY_SUCCESS.match?(result.to_s)
+      @held_sigil_book = nil if result.to_s.include?(SIGIL_BOOK_NOT_HELD)
+      Lich::Messaging.msg("bold", "Enchant: Failed to study #{sigil} sigil from #{book}.")
+      return false
+    end
+    waitrt?
+    true
+  end
+
+  # Reads the selected page, which STUDY requires before it will memorize
+  # anything, and confirms the page holds the sigil type asked for.
+  #
+  # The check is free - the page has to be read either way - and catches a
+  # scroll filed into the wrong book, which would otherwise be traced as the
+  # wrong sigil.
+  #
+  # @param book [String] the book in hand
+  # @param sigil [String] sigil type the page is expected to hold
+  # @return [Boolean] true when the page holds that type and is ready to study
+  def read_sigil_book_page(book, sigil)
+    result = DRC.bput("read my #{sigil_book_noun(book)}", { 'timeout' => 3, 'suppress_no_match' => true }, SIGIL_BOOK_PAGE_TYPE)
+    match = SIGIL_BOOK_PAGE_TYPE.match(result.to_s)
+    unless match
+      Lich::Messaging.msg("bold", "Enchant: Could not read the current page of #{book}.")
+      return false
+    end
+    return true if match[:type].casecmp(sigil).zero?
+
+    Lich::Messaging.msg("bold", "Enchant: #{book} is mapped to #{sigil} but page 1 holds a #{match[:type].downcase} sigil.")
+    false
+  end
+
+  # Turns the held book to page 1, which is always its next unread scroll.
+  #
+  # An empty book cannot select a page, which is how a book that has run out is
+  # detected - its contents never have to be read.
+  #
+  # @param book [String] the book in hand
+  # @return [Boolean] true when a page was selected, false when the book is out
+  def turn_sigil_book_to_first_page(book)
+    result = DRC.bput("turn my #{sigil_book_noun(book)} to page 1", { 'timeout' => 3, 'suppress_no_match' => true }, SIGIL_BOOK_TURN_PAGE, SIGIL_BOOK_ALREADY_AT_PAGE, SIGIL_BOOK_PAGE_MISSING).to_s
+    SIGIL_BOOK_TURN_PAGE.match?(result) || SIGIL_BOOK_ALREADY_AT_PAGE.match?(result)
+  end
+
+  # The reference used for TURN/STUDY. Always the bare noun - see the
   # SIGIL_BOOK_* constants for why a "sigil ..." reference cannot be used.
   #
   # @param book [String] the sigil book name
@@ -457,59 +543,37 @@ class Enchant
     DRC.get_noun(book)
   end
 
-  # Gets a sigil book in hand, which every book command requires.
+  # Gets a sigil book in hand, which every book command requires, and leaves it
+  # there. Only a sigil of a different type causes a swap.
   #
-  # Always fetches rather than short-circuiting on a book already held: sigil
-  # books commonly share the noun "book", so a held book is not proof that the
-  # right one is in hand.
-  #
-  # @param book [String] the sigil book to pick up
+  # @param book [String] the sigil book to hold
   # @return [Boolean] true when the book is held
-  def get_sigil_book(book)
+  def hold_sigil_book(book)
+    return true if @held_sigil_book == book && DRCI.in_hands?(sigil_book_noun(book))
+
+    stow_sigil_book
     DRCC.get_crafting_item(book, @bag, @bag_items, @belt, true)
-    return true if DRCI.in_hands?(sigil_book_noun(book))
+    unless DRCI.in_hands?(sigil_book_noun(book))
+      Lich::Messaging.msg("bold", "Enchant: Failed to get #{book}.")
+      return false
+    end
 
-    Lich::Messaging.msg("bold", "Enchant: Failed to get #{book}.")
-    false
+    @held_sigil_book = book
+    true
   end
 
-  # Finds the first page of a book holding the requested sigil type.
+  # Puts the held sigil book away and forgets it.
   #
-  # Turning to a section that holds nothing still succeeds and simply reads
-  # empty, so presence is decided by the READ, not the TURN.
+  # Safe to call at any point: the cleanup paths stow whatever is in hand, so
+  # the book may already be gone by the time this runs.
   #
-  # @param book [String] the sigil book to read
-  # @param sigil [String] sigil type, e.g. 'congruence'
-  # @return [Integer, nil] page number, or nil when this book has none
-  def find_sigil_page(book, sigil)
-    noun = sigil_book_noun(book)
-    DRC.bput("turn my #{noun} to sigil #{sigil}", { 'timeout' => 3, 'suppress_no_match' => true }, SIGIL_BOOK_TURN_SECTION)
-    lines = Lich::Util.issue_command("read my #{noun}", SIGIL_BOOK_READ_HEADER, SIGIL_BOOK_READ_FOOTER, silent: true, quiet: true, timeout: 3)
-    match = lines
-            .map { |line| SIGIL_BOOK_PAGE_ROW.match(line) }
-            .compact
-            .find { |row| row[:type].casecmp(sigil).zero? }
-    match ? match[:page].to_i : nil
-  end
+  # @return [void]
+  def stow_sigil_book
+    book = @held_sigil_book
+    @held_sigil_book = nil
+    return unless book && DRCI.in_hands?(sigil_book_noun(book))
 
-  # Turns to a page and confirms it holds the expected sigil type.
-  #
-  # @param book [String] the sigil book being read
-  # @param page [Integer] page number to turn to
-  # @param sigil [String] sigil type the page is expected to hold
-  # @return [Boolean] true when the page is selected and ready to study
-  def turn_to_sigil_page(book, page, sigil)
-    noun = sigil_book_noun(book)
-    DRC.bput("turn my #{noun} to page #{page}", { 'timeout' => 3, 'suppress_no_match' => true }, SIGIL_BOOK_TURN_PAGE)
-    lines = Lich::Util.issue_command("read my #{noun}", SIGIL_BOOK_PAGE_HEADER, SIGIL_BOOK_PAGE_FOOTER, silent: true, quiet: true, timeout: 3)
-    match = lines
-            .map { |line| SIGIL_BOOK_PAGE_TYPE.match(line) }
-            .compact
-            .first
-    return true if match && match[:type].casecmp(sigil).zero?
-
-    Lich::Messaging.msg("bold", "Enchant: Page #{page} of #{book} does not hold a #{sigil} sigil.")
-    false
+    DRCC.stow_crafting_item(book, @bag, @belt)
   end
 
   def scribe
@@ -560,7 +624,9 @@ class Enchant
 
   def handle_push_flag
     Flags.reset('enchant-push')
-    DRCC.stow_crafting_item(@burin, @bag, @belt) if DRC.left_hand.to_s.include?('burin')
+    # The loop needs the hand the sigil book has been sitting in.
+    stow_sigil_book
+    DRCC.stow_crafting_item(@burin, @bag, @belt) if DRCI.in_hands?(@burin)
     DRCC.get_crafting_item(@loop, @bag, @bag_items, @belt)
     DRC.bput("push #{@item} on #{@brazier_ref} with my #{@loop}", SCRIBE_RT_PATTERN, SCRIBE_SIGIL_NEEDED)
     waitrt?
@@ -571,7 +637,10 @@ class Enchant
 
   def handle_imbue_flag
     Flags.reset('enchant-imbue')
-    DRCC.stow_crafting_item(@burin, @bag, @belt) if DRC.left_hand.to_s.include?('burin')
+    # Imbuing needs the hand the sigil book has been sitting in, for the wand or
+    # for the casting.
+    stow_sigil_book
+    DRCC.stow_crafting_item(@burin, @bag, @belt) if DRCI.in_hands?(@burin)
     imbue
     DRCC.get_crafting_item(@burin, @bag, @bag_items, @belt)
     scribe
@@ -600,6 +669,7 @@ class Enchant
   end
 
   def cleanup
+    stow_sigil_book
     DRCC.stow_crafting_item(DRC.right_hand, @bag, @belt) if DRC.right_hand
     DRCC.stow_crafting_item(DRC.left_hand, @bag, @belt) if DRC.left_hand
     unless @item == 'fount'

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -996,6 +996,15 @@ enchanting_tools:
   - brazier
   - burin
 
+# Sigil books holding your sigil-scrolls, kept in your crafting container or on
+# your enchanting belt.  A book only holds 20 scrolls, so list as many as you
+# carry - they are searched in the order listed.  When set, enchant studies
+# sigils straight out of the books and only falls back to a loose sigil-scroll
+# when no book holds that type.  Leave blank to always use loose sigil-scrolls.
+sigil_books:
+  # - small sigil book
+  # - large sigil book
+
 # setup custom toolsets to get from clerk-tools.  example of format listed below
 custom_clerk_tools:
   # mining:                   # name of the toolset to use custom=mining in this case

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -997,13 +997,14 @@ enchanting_tools:
   - burin
 
 # Sigil books holding your sigil-scrolls, kept in your crafting container or on
-# your enchanting belt.  A book only holds 20 scrolls, so list as many as you
-# carry - they are searched in the order listed.  When set, enchant studies
-# sigils straight out of the books and only falls back to a loose sigil-scroll
-# when no book holds that type.  Leave blank to always use loose sigil-scrolls.
+# your enchanting belt.  Map each sigil type to the book that holds that type
+# and nothing else - enchant turns such a book straight to page 1, which is
+# always its next scroll of that type, so no book ever has to be read.
+# Sigil types with no book listed, and an empty setting, use loose
+# sigil-scrolls instead.
 sigil_books:
-  # - small sigil book
-  # - large sigil book
+  # congruence: small sigil book
+  # nurture: large sigil book
 
 # setup custom toolsets to get from clerk-tools.  example of format listed below
 custom_clerk_tools:

--- a/spec/enchant_spec.rb
+++ b/spec/enchant_spec.rb
@@ -429,5 +429,84 @@ RSpec.describe Enchant do
 
       instance.send(:handle_resume)
     end
+
+    it 'picks the burin back up and scribes when the item is ready for scribing' do
+      instance = build_instance
+      allow(DRC).to receive(:bput).and_return('The fount is ready for additional scribing.')
+      allow(DRCC).to receive(:get_crafting_item)
+
+      expect(instance).to receive(:scribe_with_burin)
+
+      instance.send(:handle_resume)
+    end
+
+    it 'hands off to the imbue resume when an imbue is still required' do
+      instance = build_instance
+      allow(DRC).to receive(:bput)
+        .and_return('The fount requires an application of an imbue spell to advance the enchanting process.')
+      allow(DRCC).to receive(:get_crafting_item)
+
+      expect(instance).to receive(:handle_imbue_resume)
+
+      instance.send(:handle_resume)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # handle_imbue_resume
+  #
+  # Regression: an imbue is never the last step, so resuming into one must fall
+  # through to the scribe loop. It used to imbue and exit, which dropped the
+  # sigil prompt that only arrives after the imbue roundtime.
+  # ---------------------------------------------------------------------------
+
+  describe '#handle_imbue_resume' do
+    it 'scribes after imbuing when the fount is already on the brazier' do
+      instance = build_instance
+      allow(DRC).to receive(:bput).and_return('On the brass brazier you see a fount and a totem.')
+      allow(instance).to receive(:imbue)
+
+      expect(DRCC).not_to receive(:get_crafting_item).with('fount', any_args)
+      expect(instance).to receive(:scribe_with_burin)
+
+      instance.send(:handle_imbue_resume)
+    end
+
+    it 'waves the fount first, then imbues, then scribes' do
+      instance = build_instance
+      allow(DRC).to receive(:bput).and_return('There is nothing')
+      allow(DRCC).to receive(:get_crafting_item)
+      allow(DRCC).to receive(:stow_crafting_item)
+
+      expect(DRCC).to receive(:get_crafting_item).with('fount', 'backpack', ['burin'], 'toolbelt')
+      expect(instance).to receive(:imbue).ordered
+      expect(instance).to receive(:scribe_with_burin).ordered
+
+      instance.send(:handle_imbue_resume)
+    end
+
+    it 'still scribes when the look on the brazier matches nothing at all' do
+      instance = build_instance
+      # bput returns nil when no pattern matched within the timeout.
+      allow(DRC).to receive(:bput).and_return(nil)
+      allow(DRCC).to receive(:get_crafting_item)
+      allow(DRCC).to receive(:stow_crafting_item)
+      allow(instance).to receive(:imbue)
+
+      expect(instance).to receive(:scribe_with_burin)
+
+      instance.send(:handle_imbue_resume)
+    end
+  end
+
+  describe '#scribe_with_burin' do
+    it 'gets the burin before entering the scribe loop' do
+      instance = build_instance
+
+      expect(DRCC).to receive(:get_crafting_item).with('burin', 'backpack', ['burin'], 'toolbelt').ordered
+      expect(instance).to receive(:scribe).ordered
+
+      instance.send(:scribe_with_burin)
+    end
   end
 end

--- a/spec/enchant_spec.rb
+++ b/spec/enchant_spec.rb
@@ -257,6 +257,474 @@ RSpec.describe Enchant do
 
       instance.send(:trace_sigil, 'induction')
     end
+
+    it 'does not trace when the sigil was never memorized' do
+      instance = build_instance
+
+      allow(instance).to receive(:study_sigil).with('induction').and_return(false)
+      expect(DRC).not_to receive(:bput)
+
+      instance.send(:trace_sigil, 'induction')
+    end
+
+    it 'traces without touching a loose scroll when the book supplied the sigil' do
+      instance = build_instance(sigil_book: 'small sigil book')
+
+      allow(instance).to receive(:study_sigil_from_book).with('induction').and_return(true)
+      expect(DRCI).not_to receive(:get_item?)
+      expect(DRC).to receive(:bput).with('trace totem on brazier', Enchant::SIGIL_TRACE_SUCCESS)
+
+      instance.send(:trace_sigil, 'induction')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Sigil book
+  #
+  # Fixtures are verbatim game output. Note that page numbers are global to the
+  # book and are NOT renumbered per section (congruence 1-2, nurture 3-5), but
+  # they DO renumber when a study blanks a page.
+  # ---------------------------------------------------------------------------
+
+  let(:contents_read) do
+    [
+      'You page through the book to see what scrolls it contains.',
+      '   Page -- Sigil Type, Clarity, Precision',
+      '      1 -- congruence, distinct (54), broad (13)',
+      '      2 -- congruence, distinct (54), broad (13)',
+      '      3 -- nurture, rough (26), broad (21)',
+      '      4 -- nurture, rough (26), broad (21)',
+      '      5 -- nurture, rough (19), broad (15)',
+      '[You can turn the book TO PAGE # or TO SIGIL {Sigil Type}.]'
+    ]
+  end
+
+  let(:nurture_section_read) do
+    [
+      'You page through the nurture section to see what scrolls it contains.',
+      '   Page -- Sigil Type, Clarity, Precision',
+      '      3 -- nurture, rough (26), broad (21)',
+      '      4 -- nurture, rough (26), broad (21)',
+      '      5 -- nurture, rough (19), broad (15)',
+      '[You can turn the book TO PAGE # or TO CONTENTS.]'
+    ]
+  end
+
+  let(:empty_section_read) do
+    [
+      'You page through the rarefaction section to see what scrolls it contains.',
+      '   Page -- Sigil Type, Clarity, Precision',
+      '[You can turn the book TO PAGE # or TO CONTENTS.]'
+    ]
+  end
+
+  let(:nurture_page_read) do
+    [
+      'On this page you see a rough nurture sigil comprised of broad strokes.  You can STUDY the book to bring it into your mind, or PULL the book to remove it.',
+      '   --=== Nurture sigil ===--',
+      '',
+      '   Cardinality: Primary',
+      '       Clarity: 26 (rough)',
+      '     Precision: 21 (comprised of broad strokes)',
+      '[You can now STUDY the book to memorize the sigil.]'
+    ]
+  end
+
+  let(:study_success) { "You commit the sigil's design to memory rendering the page blank, and turn the book back to the contents." }
+  let(:study_appraise) { 'You study the book and determine it is well-suited for holding sigil-scrolls.  These scrolls can be PUT into the book.' }
+
+  # Two books with DIFFERENT nouns, so a spec can tell which one a command
+  # addressed. In game they are usually both "book", which is exactly why the
+  # implementation stows one before picking up the next.
+  let(:first_book) { 'small sigil book' }
+  let(:second_book) { 'battered sigil tome' }
+
+  # Stubs the two READs the book flow issues against one book, keyed by their
+  # start pattern.
+  def stub_book_reads(noun: 'book', section_lines:, page_lines: [])
+    allow(Lich::Util).to receive(:issue_command)
+      .with("read my #{noun}", Enchant::SIGIL_BOOK_READ_HEADER, Enchant::SIGIL_BOOK_READ_FOOTER, silent: true, quiet: true, timeout: 3)
+      .and_return(section_lines)
+    allow(Lich::Util).to receive(:issue_command)
+      .with("read my #{noun}", Enchant::SIGIL_BOOK_PAGE_HEADER, Enchant::SIGIL_BOOK_PAGE_FOOTER, silent: true, quiet: true, timeout: 3)
+      .and_return(page_lines)
+  end
+
+  describe 'sigil book constants' do
+    it 'parses a page row into page number and sigil type' do
+      match = Enchant::SIGIL_BOOK_PAGE_ROW.match('      3 -- nurture, rough (26), broad (21)')
+
+      expect(match[:page]).to eq('3')
+      expect(match[:type]).to eq('nurture')
+    end
+
+    it 'does not treat the table header as a page row' do
+      expect(Enchant::SIGIL_BOOK_PAGE_ROW).not_to match('   Page -- Sigil Type, Clarity, Precision')
+    end
+
+    it 'parses the sigil type off a page banner' do
+      match = Enchant::SIGIL_BOOK_PAGE_TYPE.match('   --=== Congruence sigil ===--')
+
+      expect(match[:type]).to eq('Congruence')
+    end
+
+    it 'matches the read footer in both the contents and section views' do
+      expect(Enchant::SIGIL_BOOK_READ_FOOTER).to match('[You can turn the book TO PAGE # or TO SIGIL {Sigil Type}.]')
+      expect(Enchant::SIGIL_BOOK_READ_FOOTER).to match('[You can turn the book TO PAGE # or TO CONTENTS.]')
+    end
+
+    it 'matches the section and page turn confirmations' do
+      section = Enchant::SIGIL_BOOK_TURN_SECTION.match('You turn the book to the congruence section.')
+      page = Enchant::SIGIL_BOOK_TURN_PAGE.match('You turn the book to page 1.')
+
+      expect(section[:section]).to eq('congruence')
+      expect(page[:page]).to eq('1')
+    end
+
+    it 'distinguishes a memorizing study from the book appraisal' do
+      expect(Enchant::SIGIL_BOOK_STUDY_SUCCESS).to match(study_success)
+      expect(Enchant::SIGIL_BOOK_STUDY_SUCCESS).not_to match(study_appraise)
+      expect(Enchant::SIGIL_BOOK_STUDY_APPRAISE).to match(study_appraise)
+    end
+  end
+
+  describe '#sigil_books' do
+    it 'is empty when nothing is configured' do
+      expect(build_instance.send(:sigil_books)).to eq([])
+    end
+
+    it 'keeps a configured list in order' do
+      instance = build_instance(sigil_books: [first_book, second_book])
+
+      expect(instance.send(:sigil_books)).to eq([first_book, second_book])
+    end
+
+    it 'accepts a bare string as a single book' do
+      instance = build_instance(sigil_books: first_book)
+
+      expect(instance.send(:sigil_books)).to eq([first_book])
+    end
+  end
+
+  describe '#sigil_book_noun' do
+    it 'reduces a book name to its bare noun' do
+      instance = build_instance
+
+      expect(instance.send(:sigil_book_noun, first_book)).to eq('book')
+      expect(instance.send(:sigil_book_noun, second_book)).to eq('tome')
+    end
+  end
+
+  describe '#study_sigil' do
+    it 'prefers the books and skips the loose scroll entirely' do
+      instance = build_instance(sigil_books: [first_book])
+
+      expect(instance).to receive(:study_sigil_from_book).with('nurture').and_return(true)
+      expect(DRCI).not_to receive(:get_item?)
+
+      expect(instance.send(:study_sigil, 'nurture')).to be true
+    end
+
+    it 'falls back to a loose scroll when no book can supply the sigil' do
+      instance = build_instance(sigil_books: [first_book])
+
+      allow(instance).to receive(:study_sigil_from_book).with('nurture').and_return(false)
+      expect(DRCI).to receive(:get_item?).with('nurture sigil').and_return(true)
+      expect(DRC).to receive(:bput).with('study my nurture sigil', Enchant::SIGIL_STUDY_SUCCESS)
+
+      expect(instance.send(:study_sigil, 'nurture')).to be true
+    end
+
+    it 'returns false when neither the books nor a loose scroll has the sigil' do
+      instance = build_instance(sigil_books: [first_book])
+
+      allow(instance).to receive(:study_sigil_from_book).and_return(false)
+      allow(DRCI).to receive(:get_item?).and_return(false)
+      expect(Lich::Messaging).to receive(:msg).with('bold', /Failed to get nurture sigil/)
+
+      expect(instance.send(:study_sigil, 'nurture')).to be false
+    end
+  end
+
+  describe '#study_sigil_from_book' do
+    it 'returns false without touching the game when no books are configured' do
+      instance = build_instance
+
+      expect(DRCC).not_to receive(:get_crafting_item)
+      expect(DRC).not_to receive(:bput)
+
+      expect(instance.send(:study_sigil_from_book, 'nurture')).to be false
+    end
+
+    it 'takes the sigil from the first book that has it' do
+      instance = build_instance(sigil_books: [first_book, second_book])
+
+      expect(instance).to receive(:study_sigil_from_this_book).with(first_book, 'nurture').and_return(true)
+      expect(instance).not_to receive(:study_sigil_from_this_book).with(second_book, anything)
+
+      expect(instance.send(:study_sigil_from_book, 'nurture')).to be true
+    end
+
+    it 'moves on to the next book when the first one is out of that sigil' do
+      instance = build_instance(sigil_books: [first_book, second_book])
+
+      expect(instance).to receive(:study_sigil_from_this_book).with(first_book, 'nurture').and_return(false)
+      expect(instance).to receive(:study_sigil_from_this_book).with(second_book, 'nurture').and_return(true)
+
+      expect(instance.send(:study_sigil_from_book, 'nurture')).to be true
+    end
+
+    it 'reports once when no configured book holds the sigil' do
+      instance = build_instance(sigil_books: [first_book, second_book])
+
+      allow(instance).to receive(:study_sigil_from_this_book).and_return(false)
+
+      expect(Lich::Messaging).to receive(:msg).with('bold', /No nurture sigil in your sigil books/).once
+
+      expect(instance.send(:study_sigil_from_book, 'nurture')).to be false
+    end
+
+    it 'searches every configured book against real book output before giving up' do
+      instance = build_instance(sigil_books: [first_book, second_book])
+
+      allow(DRCI).to receive(:in_hands?).and_return(true)
+      allow(DRC).to receive(:bput).and_return(study_success)
+      allow(DRCC).to receive(:get_crafting_item)
+      allow(DRCC).to receive(:stow_crafting_item)
+      # The first book is out of nurture; the second still has pages.
+      stub_book_reads(noun: 'book', section_lines: empty_section_read)
+      stub_book_reads(noun: 'tome', section_lines: nurture_section_read, page_lines: nurture_page_read)
+
+      expect(instance.send(:study_sigil_from_book, 'nurture')).to be true
+      expect(DRCC).to have_received(:get_crafting_item).with(first_book, 'backpack', ['burin'], 'toolbelt', true)
+      expect(DRCC).to have_received(:get_crafting_item).with(second_book, 'backpack', ['burin'], 'toolbelt', true)
+    end
+
+    it 'stows each book it picks up, including ones that had nothing' do
+      instance = build_instance(sigil_books: [first_book, second_book])
+
+      allow(DRCI).to receive(:in_hands?).and_return(true)
+      allow(DRC).to receive(:bput).and_return(study_success)
+      allow(DRCC).to receive(:get_crafting_item)
+      allow(Lich::Messaging).to receive(:msg)
+      stub_book_reads(noun: 'book', section_lines: empty_section_read)
+      stub_book_reads(noun: 'tome', section_lines: nurture_section_read, page_lines: nurture_page_read)
+
+      expect(DRCC).to receive(:stow_crafting_item).with(first_book, 'backpack', 'toolbelt')
+      expect(DRCC).to receive(:stow_crafting_item).with(second_book, 'backpack', 'toolbelt')
+
+      instance.send(:study_sigil_from_book, 'nurture')
+    end
+  end
+
+  describe '#study_sigil_from_this_book' do
+    it 'turns to the section, reads it, turns to a page, confirms it, then studies' do
+      instance = build_instance(sigil_books: [first_book])
+
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      allow(DRCC).to receive(:get_crafting_item)
+      stub_book_reads(section_lines: nurture_section_read, page_lines: nurture_page_read)
+
+      expect(DRC).to receive(:bput)
+        .with('turn my book to sigil nurture', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_TURN_SECTION)
+      expect(DRC).to receive(:bput)
+        .with('turn my book to page 3', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_TURN_PAGE)
+      expect(DRC).to receive(:bput)
+        .with('study my book', Enchant::SIGIL_BOOK_STUDY_SUCCESS, Enchant::SIGIL_BOOK_STUDY_APPRAISE, Enchant::SIGIL_BOOK_NOT_HELD)
+        .and_return(study_success)
+      expect(DRCC).to receive(:stow_crafting_item).with(first_book, 'backpack', 'toolbelt')
+
+      expect(instance.send(:study_sigil_from_this_book, first_book, 'nurture')).to be true
+    end
+
+    it 'returns false without studying when this book has no page of that type' do
+      instance = build_instance(sigil_books: [first_book])
+
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      allow(DRCC).to receive(:get_crafting_item)
+      allow(DRC).to receive(:bput)
+      stub_book_reads(section_lines: empty_section_read)
+
+      expect(DRC).not_to receive(:bput).with('study my book', any_args)
+
+      expect(instance.send(:study_sigil_from_this_book, first_book, 'rarefaction')).to be false
+    end
+
+    it 'treats the book appraisal as a failed study rather than a memorized sigil' do
+      instance = build_instance(sigil_books: [first_book])
+
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      allow(DRCC).to receive(:get_crafting_item)
+      stub_book_reads(section_lines: nurture_section_read, page_lines: nurture_page_read)
+      allow(DRC).to receive(:bput).and_return(study_appraise)
+
+      expect(Lich::Messaging).to receive(:msg).with('bold', /Failed to study nurture sigil from small sigil book/)
+
+      expect(instance.send(:study_sigil_from_this_book, first_book, 'nurture')).to be false
+    end
+
+    it 'stows the book even when the study fails' do
+      instance = build_instance(sigil_books: [first_book])
+
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      allow(DRCC).to receive(:get_crafting_item)
+      allow(DRC).to receive(:bput)
+      stub_book_reads(section_lines: empty_section_read)
+      allow(Lich::Messaging).to receive(:msg)
+
+      expect(DRCC).to receive(:stow_crafting_item).with(first_book, 'backpack', 'toolbelt')
+
+      instance.send(:study_sigil_from_this_book, first_book, 'nurture')
+    end
+
+    it 'does not stow anything when the book could not be picked up' do
+      instance = build_instance(sigil_books: [first_book])
+
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(false)
+      allow(DRCC).to receive(:get_crafting_item)
+      allow(Lich::Messaging).to receive(:msg)
+
+      expect(DRCC).not_to receive(:stow_crafting_item)
+
+      expect(instance.send(:study_sigil_from_this_book, first_book, 'nurture')).to be false
+    end
+
+    it 're-reads the book for every sigil, because studying renumbers the pages' do
+      instance = build_instance(sigil_books: [first_book])
+
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      allow(DRCC).to receive(:get_crafting_item)
+      allow(DRC).to receive(:bput).and_return(study_success)
+      allow(DRCC).to receive(:stow_crafting_item)
+      stub_book_reads(section_lines: nurture_section_read, page_lines: nurture_page_read)
+
+      instance.send(:study_sigil_from_this_book, first_book, 'nurture')
+      instance.send(:study_sigil_from_this_book, first_book, 'nurture')
+
+      expect(Lich::Util).to have_received(:issue_command)
+        .with('read my book', Enchant::SIGIL_BOOK_READ_HEADER, Enchant::SIGIL_BOOK_READ_FOOTER, silent: true, quiet: true, timeout: 3)
+        .twice
+    end
+  end
+
+  describe '#get_sigil_book' do
+    it 'fetches from the crafting container or belt and confirms it landed in hand' do
+      instance = build_instance
+
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      expect(DRCC).to receive(:get_crafting_item).with(first_book, 'backpack', ['burin'], 'toolbelt', true)
+
+      expect(instance.send(:get_sigil_book, first_book)).to be true
+    end
+
+    it 'always fetches, because a held book may be a different book of the same noun' do
+      instance = build_instance
+
+      allow(DRCI).to receive(:in_hands?).with('tome').and_return(true)
+      expect(DRCC).to receive(:get_crafting_item).with(second_book, 'backpack', ['burin'], 'toolbelt', true)
+
+      instance.send(:get_sigil_book, second_book)
+    end
+
+    it 'reports failure when the book never reaches a hand' do
+      instance = build_instance
+
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(false)
+      allow(DRCC).to receive(:get_crafting_item)
+      expect(Lich::Messaging).to receive(:msg).with('bold', /Failed to get small sigil book/)
+
+      expect(instance.send(:get_sigil_book, first_book)).to be false
+    end
+  end
+
+  describe '#find_sigil_page' do
+    it 'returns the first page of the requested type' do
+      instance = build_instance
+
+      allow(DRC).to receive(:bput)
+      stub_book_reads(section_lines: nurture_section_read)
+
+      expect(instance.send(:find_sigil_page, first_book, 'nurture')).to eq(3)
+    end
+
+    it 'ignores pages of other types when reading the contents view' do
+      instance = build_instance
+
+      allow(DRC).to receive(:bput)
+      stub_book_reads(section_lines: contents_read)
+
+      expect(instance.send(:find_sigil_page, first_book, 'nurture')).to eq(3)
+    end
+
+    it 'matches the sigil type case-insensitively' do
+      instance = build_instance
+
+      allow(DRC).to receive(:bput)
+      stub_book_reads(section_lines: nurture_section_read)
+
+      expect(instance.send(:find_sigil_page, first_book, 'Nurture')).to eq(3)
+    end
+
+    it 'addresses the book by its own noun' do
+      instance = build_instance
+
+      stub_book_reads(noun: 'tome', section_lines: nurture_section_read)
+      expect(DRC).to receive(:bput)
+        .with('turn my tome to sigil nurture', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_TURN_SECTION)
+
+      expect(instance.send(:find_sigil_page, second_book, 'nurture')).to eq(3)
+    end
+
+    it 'returns nil for a section that reads empty' do
+      instance = build_instance
+
+      allow(DRC).to receive(:bput)
+      stub_book_reads(section_lines: empty_section_read)
+
+      expect(instance.send(:find_sigil_page, first_book, 'rarefaction')).to be_nil
+    end
+
+    it 'returns nil when the read times out and captures nothing' do
+      instance = build_instance
+
+      allow(DRC).to receive(:bput)
+      stub_book_reads(section_lines: [])
+
+      expect(instance.send(:find_sigil_page, first_book, 'nurture')).to be_nil
+    end
+  end
+
+  describe '#turn_to_sigil_page' do
+    it 'confirms the page holds the expected sigil type' do
+      instance = build_instance
+
+      stub_book_reads(section_lines: [], page_lines: nurture_page_read)
+      expect(DRC).to receive(:bput)
+        .with('turn my book to page 3', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_TURN_PAGE)
+
+      expect(instance.send(:turn_to_sigil_page, first_book, 3, 'nurture')).to be true
+    end
+
+    it 'rejects a page holding a different sigil type' do
+      instance = build_instance
+
+      allow(DRC).to receive(:bput)
+      stub_book_reads(section_lines: [], page_lines: nurture_page_read)
+
+      expect(Lich::Messaging).to receive(:msg).with('bold', /Page 3 of small sigil book does not hold a congruence sigil/)
+
+      expect(instance.send(:turn_to_sigil_page, first_book, 3, 'congruence')).to be false
+    end
+
+    it 'rejects a read that never reached a page view' do
+      instance = build_instance
+
+      allow(DRC).to receive(:bput)
+      stub_book_reads(section_lines: [], page_lines: nurture_section_read)
+      allow(Lich::Messaging).to receive(:msg)
+
+      expect(instance.send(:turn_to_sigil_page, first_book, 3, 'nurture')).to be false
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/enchant_spec.rb
+++ b/spec/enchant_spec.rb
@@ -243,7 +243,9 @@ RSpec.describe Enchant do
 
       expect(DRCI).to receive(:get_item?).with('induction sigil').and_return(true)
       expect(DRC).to receive(:bput).with('study my induction sigil', Enchant::SIGIL_STUDY_SUCCESS)
-      expect(DRC).to receive(:bput).with('trace totem on brazier', Enchant::SIGIL_TRACE_SUCCESS)
+      expect(DRC).to receive(:bput)
+        .with('trace totem on brazier', { 'timeout' => 5, 'suppress_no_match' => true }, Enchant::SIGIL_TRACE_SUCCESS)
+        .and_return(trace_success)
 
       instance.send(:trace_sigil, 'induction')
     end
@@ -268,11 +270,68 @@ RSpec.describe Enchant do
     end
 
     it 'traces without touching a loose scroll when the book supplied the sigil' do
-      instance = build_instance(sigil_book: 'small sigil book')
+      instance = build_instance(sigil_books: { 'induction' => first_book })
 
       allow(instance).to receive(:study_sigil_from_book).with('induction').and_return(true)
       expect(DRCI).not_to receive(:get_item?)
-      expect(DRC).to receive(:bput).with('trace totem on brazier', Enchant::SIGIL_TRACE_SUCCESS)
+      expect(DRC).to receive(:bput)
+        .with('trace totem on brazier', { 'timeout' => 5, 'suppress_no_match' => true }, Enchant::SIGIL_TRACE_SUCCESS)
+        .and_return(trace_success)
+
+      instance.send(:trace_sigil, 'induction')
+    end
+
+    it 'keeps the book in hand while tracing' do
+      instance = build_instance(sigil_books: { 'induction' => first_book }, held_sigil_book: first_book)
+
+      allow(instance).to receive(:study_sigil).and_return(true)
+      allow(DRC).to receive(:bput).and_return(trace_success)
+
+      expect(instance).not_to receive(:stow_sigil_book)
+
+      instance.send(:trace_sigil, 'induction')
+    end
+
+    # The book occupies a hand for the whole scribe loop. Whether TRACE tolerates
+    # that is not known from the game output we have, so the run finds out once
+    # rather than paying a stow and a fetch per sigil on the chance it matters.
+    it 'stows the book and retries once when the trace is not accepted' do
+      instance = build_instance(sigil_books: { 'induction' => first_book }, held_sigil_book: first_book)
+
+      allow(instance).to receive(:study_sigil).and_return(true)
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      allow(DRC).to receive(:bput).and_return(nil, trace_success)
+
+      expect(DRCC).to receive(:stow_crafting_item).with(first_book, 'backpack', 'toolbelt')
+
+      instance.send(:trace_sigil, 'induction')
+
+      expect(instance.instance_variable_get(:@trace_needs_free_hand)).to be true
+    end
+
+    it 'stows the book before tracing once it knows the trace needs the hand' do
+      instance = build_instance(
+        sigil_books: { 'induction' => first_book },
+        held_sigil_book: first_book,
+        trace_needs_free_hand: true
+      )
+
+      allow(instance).to receive(:study_sigil).and_return(true)
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      allow(DRC).to receive(:bput).and_return(trace_success)
+
+      expect(DRCC).to receive(:stow_crafting_item).with(first_book, 'backpack', 'toolbelt').once
+
+      instance.send(:trace_sigil, 'induction')
+    end
+
+    it 'reports when even a retry with free hands will not trace' do
+      instance = build_instance
+
+      allow(instance).to receive(:study_sigil).and_return(true)
+      allow(DRC).to receive(:bput).and_return(nil)
+
+      expect(Lich::Messaging).to receive(:msg).with('bold', /Failed to trace induction sigil/)
 
       instance.send(:trace_sigil, 'induction')
     end
@@ -281,104 +340,51 @@ RSpec.describe Enchant do
   # ---------------------------------------------------------------------------
   # Sigil book
   #
-  # Fixtures are verbatim game output. Note that page numbers are global to the
-  # book and are NOT renumbered per section (congruence 1-2, nurture 3-5), but
-  # they DO renumber when a study blanks a page.
+  # One book per sigil type. A dedicated book is never read: every page holds
+  # the same type, and studying a page blanks it and renumbers the rest, so the
+  # next scroll of that type is page 1 again.
+  #
+  # Fixtures are verbatim game output.
   # ---------------------------------------------------------------------------
 
-  let(:contents_read) do
-    [
-      'You page through the book to see what scrolls it contains.',
-      '   Page -- Sigil Type, Clarity, Precision',
-      '      1 -- congruence, distinct (54), broad (13)',
-      '      2 -- congruence, distinct (54), broad (13)',
-      '      3 -- nurture, rough (26), broad (21)',
-      '      4 -- nurture, rough (26), broad (21)',
-      '      5 -- nurture, rough (19), broad (15)',
-      '[You can turn the book TO PAGE # or TO SIGIL {Sigil Type}.]'
-    ]
-  end
-
-  let(:nurture_section_read) do
-    [
-      'You page through the nurture section to see what scrolls it contains.',
-      '   Page -- Sigil Type, Clarity, Precision',
-      '      3 -- nurture, rough (26), broad (21)',
-      '      4 -- nurture, rough (26), broad (21)',
-      '      5 -- nurture, rough (19), broad (15)',
-      '[You can turn the book TO PAGE # or TO CONTENTS.]'
-    ]
-  end
-
-  let(:empty_section_read) do
-    [
-      'You page through the rarefaction section to see what scrolls it contains.',
-      '   Page -- Sigil Type, Clarity, Precision',
-      '[You can turn the book TO PAGE # or TO CONTENTS.]'
-    ]
-  end
-
-  let(:nurture_page_read) do
-    [
-      'On this page you see a rough nurture sigil comprised of broad strokes.  You can STUDY the book to bring it into your mind, or PULL the book to remove it.',
-      '   --=== Nurture sigil ===--',
-      '',
-      '   Cardinality: Primary',
-      '       Clarity: 26 (rough)',
-      '     Precision: 21 (comprised of broad strokes)',
-      '[You can now STUDY the book to memorize the sigil.]'
-    ]
-  end
-
+  let(:turn_page) { 'You turn the book to page 1.' }
+  let(:already_at_page) { 'You are already on page 1.' }
+  let(:page_missing) { 'The book does not have that many sigils in it.' }
+  let(:page_banner) { '   --=== Nurture sigil ===--' }
+  let(:study_unread) { 'You must read the current page before you study the book.' }
   let(:study_success) { "You commit the sigil's design to memory rendering the page blank, and turn the book back to the contents." }
   let(:study_appraise) { 'You study the book and determine it is well-suited for holding sigil-scrolls.  These scrolls can be PUT into the book.' }
+  let(:trace_success) { 'Recalling the intricacies of the sigil, you trace its form' }
 
   # Two books with DIFFERENT nouns, so a spec can tell which one a command
-  # addressed. In game they are usually both "book", which is exactly why the
-  # implementation stows one before picking up the next.
+  # addressed. In game they are usually both "book", which is why only one is
+  # ever held at a time.
   let(:first_book) { 'small sigil book' }
   let(:second_book) { 'battered sigil tome' }
 
-  # Stubs the two READs the book flow issues against one book, keyed by their
-  # start pattern.
-  def stub_book_reads(noun: 'book', section_lines:, page_lines: [])
-    allow(Lich::Util).to receive(:issue_command)
-      .with("read my #{noun}", Enchant::SIGIL_BOOK_READ_HEADER, Enchant::SIGIL_BOOK_READ_FOOTER, silent: true, quiet: true, timeout: 3)
-      .and_return(section_lines)
-    allow(Lich::Util).to receive(:issue_command)
-      .with("read my #{noun}", Enchant::SIGIL_BOOK_PAGE_HEADER, Enchant::SIGIL_BOOK_PAGE_FOOTER, silent: true, quiet: true, timeout: 3)
-      .and_return(page_lines)
-  end
-
   describe 'sigil book constants' do
-    it 'parses a page row into page number and sigil type' do
-      match = Enchant::SIGIL_BOOK_PAGE_ROW.match('      3 -- nurture, rough (26), broad (21)')
-
-      expect(match[:page]).to eq('3')
-      expect(match[:type]).to eq('nurture')
+    it 'parses the page turn confirmation' do
+      expect(Enchant::SIGIL_BOOK_TURN_PAGE.match(turn_page)[:page]).to eq('1')
     end
 
-    it 'does not treat the table header as a page row' do
-      expect(Enchant::SIGIL_BOOK_PAGE_ROW).not_to match('   Page -- Sigil Type, Clarity, Precision')
+    it 'parses the already-at-that-page response' do
+      expect(Enchant::SIGIL_BOOK_ALREADY_AT_PAGE.match(already_at_page)[:page]).to eq('1')
+      expect(Enchant::SIGIL_BOOK_ALREADY_AT_PAGE).not_to match('A small black book of sigils is already at the contents.')
+      expect(Enchant::SIGIL_BOOK_ALREADY_AT_PAGE).not_to match(page_missing)
+    end
+
+    it 'recognizes an emptied book refusing the page turn' do
+      expect(Enchant::SIGIL_BOOK_PAGE_MISSING).to match(page_missing)
+      expect(Enchant::SIGIL_BOOK_PAGE_MISSING).not_to match(turn_page)
     end
 
     it 'parses the sigil type off a page banner' do
-      match = Enchant::SIGIL_BOOK_PAGE_TYPE.match('   --=== Congruence sigil ===--')
-
-      expect(match[:type]).to eq('Congruence')
+      expect(Enchant::SIGIL_BOOK_PAGE_TYPE.match(page_banner)[:type]).to eq('Nurture')
     end
 
-    it 'matches the read footer in both the contents and section views' do
-      expect(Enchant::SIGIL_BOOK_READ_FOOTER).to match('[You can turn the book TO PAGE # or TO SIGIL {Sigil Type}.]')
-      expect(Enchant::SIGIL_BOOK_READ_FOOTER).to match('[You can turn the book TO PAGE # or TO CONTENTS.]')
-    end
-
-    it 'matches the section and page turn confirmations' do
-      section = Enchant::SIGIL_BOOK_TURN_SECTION.match('You turn the book to the congruence section.')
-      page = Enchant::SIGIL_BOOK_TURN_PAGE.match('You turn the book to page 1.')
-
-      expect(section[:section]).to eq('congruence')
-      expect(page[:page]).to eq('1')
+    it 'recognizes a study refused for want of a read' do
+      expect(Enchant::SIGIL_BOOK_STUDY_UNREAD).to match(study_unread)
+      expect(Enchant::SIGIL_BOOK_STUDY_UNREAD).not_to match(study_success)
     end
 
     it 'distinguishes a memorizing study from the book appraisal' do
@@ -388,21 +394,39 @@ RSpec.describe Enchant do
     end
   end
 
-  describe '#sigil_books' do
-    it 'is empty when nothing is configured' do
-      expect(build_instance.send(:sigil_books)).to eq([])
+  describe '#parse_sigil_books' do
+    it 'is empty when the setting is unset' do
+      expect(build_instance.send(:parse_sigil_books, nil)).to eq({})
     end
 
-    it 'keeps a configured list in order' do
-      instance = build_instance(sigil_books: [first_book, second_book])
+    it 'maps each sigil type to its book' do
+      instance = build_instance
 
-      expect(instance.send(:sigil_books)).to eq([first_book, second_book])
+      parsed = instance.send(:parse_sigil_books, 'nurture' => first_book, 'congruence' => second_book)
+
+      expect(parsed).to eq('nurture' => first_book, 'congruence' => second_book)
     end
 
-    it 'accepts a bare string as a single book' do
-      instance = build_instance(sigil_books: first_book)
+    it 'downcases the configured sigil types' do
+      instance = build_instance
 
-      expect(instance.send(:sigil_books)).to eq([first_book])
+      expect(instance.send(:parse_sigil_books, 'Nurture' => first_book)).to eq('nurture' => first_book)
+    end
+
+    it 'rejects the pre-map list format, which cannot say what each book holds' do
+      instance = build_instance
+
+      expect(Lich::Messaging).to receive(:msg).with('bold', /must map each sigil type to its own book/)
+
+      expect(instance.send(:parse_sigil_books, [first_book, second_book])).to eq({})
+    end
+
+    it 'says nothing about an empty list' do
+      instance = build_instance
+
+      expect(Lich::Messaging).not_to receive(:msg)
+
+      expect(instance.send(:parse_sigil_books, [])).to eq({})
     end
   end
 
@@ -416,8 +440,8 @@ RSpec.describe Enchant do
   end
 
   describe '#study_sigil' do
-    it 'prefers the books and skips the loose scroll entirely' do
-      instance = build_instance(sigil_books: [first_book])
+    it 'prefers the book and skips the loose scroll entirely' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
 
       expect(instance).to receive(:study_sigil_from_book).with('nurture').and_return(true)
       expect(DRCI).not_to receive(:get_item?)
@@ -425,8 +449,8 @@ RSpec.describe Enchant do
       expect(instance.send(:study_sigil, 'nurture')).to be true
     end
 
-    it 'falls back to a loose scroll when no book can supply the sigil' do
-      instance = build_instance(sigil_books: [first_book])
+    it 'falls back to a loose scroll when the book cannot supply the sigil' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
 
       allow(instance).to receive(:study_sigil_from_book).with('nurture').and_return(false)
       expect(DRCI).to receive(:get_item?).with('nurture sigil').and_return(true)
@@ -435,8 +459,8 @@ RSpec.describe Enchant do
       expect(instance.send(:study_sigil, 'nurture')).to be true
     end
 
-    it 'returns false when neither the books nor a loose scroll has the sigil' do
-      instance = build_instance(sigil_books: [first_book])
+    it 'returns false when neither the book nor a loose scroll has the sigil' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
 
       allow(instance).to receive(:study_sigil_from_book).and_return(false)
       allow(DRCI).to receive(:get_item?).and_return(false)
@@ -447,283 +471,324 @@ RSpec.describe Enchant do
   end
 
   describe '#study_sigil_from_book' do
-    it 'returns false without touching the game when no books are configured' do
-      instance = build_instance
+    it 'returns false without touching the game for a type with no book' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
 
       expect(DRCC).not_to receive(:get_crafting_item)
       expect(DRC).not_to receive(:bput)
 
-      expect(instance.send(:study_sigil_from_book, 'nurture')).to be false
+      expect(instance.send(:study_sigil_from_book, 'rarefaction')).to be false
     end
 
-    it 'takes the sigil from the first book that has it' do
-      instance = build_instance(sigil_books: [first_book, second_book])
+    it 'turns to page 1, reads it, then studies - without reading the contents' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
 
-      expect(instance).to receive(:study_sigil_from_this_book).with(first_book, 'nurture').and_return(true)
-      expect(instance).not_to receive(:study_sigil_from_this_book).with(second_book, anything)
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      allow(DRCC).to receive(:get_crafting_item)
+
+      expect(DRC).to receive(:bput)
+        .with('turn my book to page 1', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_TURN_PAGE, Enchant::SIGIL_BOOK_ALREADY_AT_PAGE, Enchant::SIGIL_BOOK_PAGE_MISSING)
+        .and_return(turn_page)
+      expect(DRC).to receive(:bput)
+        .with('read my book', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_PAGE_TYPE)
+        .and_return(page_banner)
+      expect(DRC).to receive(:bput)
+        .with('study my book', Enchant::SIGIL_BOOK_STUDY_SUCCESS, Enchant::SIGIL_BOOK_STUDY_APPRAISE, Enchant::SIGIL_BOOK_STUDY_UNREAD, Enchant::SIGIL_BOOK_NOT_HELD)
+        .and_return(study_success)
+      expect(Lich::Util).not_to receive(:issue_command)
 
       expect(instance.send(:study_sigil_from_book, 'nurture')).to be true
     end
 
-    it 'moves on to the next book when the first one is out of that sigil' do
-      instance = build_instance(sigil_books: [first_book, second_book])
+    it 'refuses to study a page holding some other sigil type' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
 
-      expect(instance).to receive(:study_sigil_from_this_book).with(first_book, 'nurture').and_return(false)
-      expect(instance).to receive(:study_sigil_from_this_book).with(second_book, 'nurture').and_return(true)
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      allow(DRCC).to receive(:get_crafting_item)
+      allow(DRC).to receive(:bput).and_return(turn_page, '   --=== Congruence sigil ===--')
 
-      expect(instance.send(:study_sigil_from_book, 'nurture')).to be true
-    end
-
-    it 'reports once when no configured book holds the sigil' do
-      instance = build_instance(sigil_books: [first_book, second_book])
-
-      allow(instance).to receive(:study_sigil_from_this_book).and_return(false)
-
-      expect(Lich::Messaging).to receive(:msg).with('bold', /No nurture sigil in your sigil books/).once
+      expect(Lich::Messaging).to receive(:msg).with('bold', /mapped to nurture but page 1 holds a congruence sigil/)
+      expect(DRC).not_to receive(:bput).with('study my book', any_args)
 
       expect(instance.send(:study_sigil_from_book, 'nurture')).to be false
+      expect(instance.send(:sigil_books)).not_to have_key('nurture')
     end
 
-    it 'searches every configured book against real book output before giving up' do
-      instance = build_instance(sigil_books: [first_book, second_book])
+    it 'matches the configured type case-insensitively' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
+
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      allow(DRCC).to receive(:get_crafting_item)
+      allow(DRC).to receive(:bput).and_return(turn_page, page_banner, study_success)
+
+      expect(instance.send(:study_sigil_from_book, 'Nurture')).to be true
+    end
+
+    it 'keeps the book in hand across repeats of the same sigil type' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
+
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      allow(DRC).to receive(:bput).and_return(turn_page, page_banner, study_success, turn_page, page_banner, study_success)
+
+      expect(DRCC).to receive(:get_crafting_item).once
+      expect(DRCC).not_to receive(:stow_crafting_item)
+
+      instance.send(:study_sigil_from_book, 'nurture')
+      instance.send(:study_sigil_from_book, 'nurture')
+    end
+
+    it 'swaps books when the next sigil is a different type' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book, 'congruence' => second_book })
 
       allow(DRCI).to receive(:in_hands?).and_return(true)
-      allow(DRC).to receive(:bput).and_return(study_success)
+      allow(DRC).to receive(:bput).and_return(turn_page, page_banner, study_success, turn_page, '   --=== Congruence sigil ===--', study_success)
       allow(DRCC).to receive(:get_crafting_item)
-      allow(DRCC).to receive(:stow_crafting_item)
-      # The first book is out of nurture; the second still has pages.
-      stub_book_reads(noun: 'book', section_lines: empty_section_read)
-      stub_book_reads(noun: 'tome', section_lines: nurture_section_read, page_lines: nurture_page_read)
 
-      expect(instance.send(:study_sigil_from_book, 'nurture')).to be true
+      instance.send(:study_sigil_from_book, 'nurture')
+
+      expect(DRCC).to receive(:stow_crafting_item).with(first_book, 'backpack', 'toolbelt')
+
+      instance.send(:study_sigil_from_book, 'congruence')
+
       expect(DRCC).to have_received(:get_crafting_item).with(first_book, 'backpack', ['burin'], 'toolbelt', true)
       expect(DRCC).to have_received(:get_crafting_item).with(second_book, 'backpack', ['burin'], 'toolbelt', true)
     end
 
-    it 'stows each book it picks up, including ones that had nothing' do
-      instance = build_instance(sigil_books: [first_book, second_book])
-
-      allow(DRCI).to receive(:in_hands?).and_return(true)
-      allow(DRC).to receive(:bput).and_return(study_success)
-      allow(DRCC).to receive(:get_crafting_item)
-      allow(Lich::Messaging).to receive(:msg)
-      stub_book_reads(noun: 'book', section_lines: empty_section_read)
-      stub_book_reads(noun: 'tome', section_lines: nurture_section_read, page_lines: nurture_page_read)
-
-      expect(DRCC).to receive(:stow_crafting_item).with(first_book, 'backpack', 'toolbelt')
-      expect(DRCC).to receive(:stow_crafting_item).with(second_book, 'backpack', 'toolbelt')
-
-      instance.send(:study_sigil_from_book, 'nurture')
-    end
-  end
-
-  describe '#study_sigil_from_this_book' do
-    it 'turns to the section, reads it, turns to a page, confirms it, then studies' do
-      instance = build_instance(sigil_books: [first_book])
+    it 'drops a book that has run out and falls back to loose scrolls after' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
 
       allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
       allow(DRCC).to receive(:get_crafting_item)
-      stub_book_reads(section_lines: nurture_section_read, page_lines: nurture_page_read)
+      # An emptied book refuses the page turn outright.
+      allow(DRC).to receive(:bput).and_return(page_missing)
 
-      expect(DRC).to receive(:bput)
-        .with('turn my book to sigil nurture', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_TURN_SECTION)
-      expect(DRC).to receive(:bput)
-        .with('turn my book to page 3', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_TURN_PAGE)
-      expect(DRC).to receive(:bput)
-        .with('study my book', Enchant::SIGIL_BOOK_STUDY_SUCCESS, Enchant::SIGIL_BOOK_STUDY_APPRAISE, Enchant::SIGIL_BOOK_NOT_HELD)
-        .and_return(study_success)
-      expect(DRCC).to receive(:stow_crafting_item).with(first_book, 'backpack', 'toolbelt')
-
-      expect(instance.send(:study_sigil_from_this_book, first_book, 'nurture')).to be true
-    end
-
-    it 'returns false without studying when this book has no page of that type' do
-      instance = build_instance(sigil_books: [first_book])
-
-      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
-      allow(DRCC).to receive(:get_crafting_item)
-      allow(DRC).to receive(:bput)
-      stub_book_reads(section_lines: empty_section_read)
-
+      expect(Lich::Messaging).to receive(:msg).with('bold', /small sigil book has no nurture sigils left/)
       expect(DRC).not_to receive(:bput).with('study my book', any_args)
 
-      expect(instance.send(:study_sigil_from_this_book, first_book, 'rarefaction')).to be false
+      expect(instance.send(:study_sigil_from_book, 'nurture')).to be false
+      expect(instance.send(:sigil_books)).not_to have_key('nurture')
     end
 
     it 'treats the book appraisal as a failed study rather than a memorized sigil' do
-      instance = build_instance(sigil_books: [first_book])
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
 
       allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
       allow(DRCC).to receive(:get_crafting_item)
-      stub_book_reads(section_lines: nurture_section_read, page_lines: nurture_page_read)
-      allow(DRC).to receive(:bput).and_return(study_appraise)
+      allow(DRC).to receive(:bput).and_return(turn_page, page_banner, study_appraise)
 
       expect(Lich::Messaging).to receive(:msg).with('bold', /Failed to study nurture sigil from small sigil book/)
 
-      expect(instance.send(:study_sigil_from_this_book, first_book, 'nurture')).to be false
+      expect(instance.send(:study_sigil_from_book, 'nurture')).to be false
     end
 
-    it 'stows the book even when the study fails' do
-      instance = build_instance(sigil_books: [first_book])
+    it 'forgets the held book when the game says it is not being held' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
 
       allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
       allow(DRCC).to receive(:get_crafting_item)
-      allow(DRC).to receive(:bput)
-      stub_book_reads(section_lines: empty_section_read)
+      allow(DRC).to receive(:bput).and_return(turn_page, page_banner, Enchant::SIGIL_BOOK_NOT_HELD)
       allow(Lich::Messaging).to receive(:msg)
 
-      expect(DRCC).to receive(:stow_crafting_item).with(first_book, 'backpack', 'toolbelt')
+      instance.send(:study_sigil_from_book, 'nurture')
 
-      instance.send(:study_sigil_from_this_book, first_book, 'nurture')
+      expect(instance.instance_variable_get(:@held_sigil_book)).to be_nil
     end
 
-    it 'does not stow anything when the book could not be picked up' do
-      instance = build_instance(sigil_books: [first_book])
+    it 'returns false when the book cannot be picked up' do
+      instance = build_instance(sigil_books: { 'nurture' => first_book })
 
       allow(DRCI).to receive(:in_hands?).with('book').and_return(false)
       allow(DRCC).to receive(:get_crafting_item)
-      allow(Lich::Messaging).to receive(:msg)
+      expect(Lich::Messaging).to receive(:msg).with('bold', /Failed to get small sigil book/)
+      expect(DRC).not_to receive(:bput)
 
-      expect(DRCC).not_to receive(:stow_crafting_item)
-
-      expect(instance.send(:study_sigil_from_this_book, first_book, 'nurture')).to be false
-    end
-
-    it 're-reads the book for every sigil, because studying renumbers the pages' do
-      instance = build_instance(sigil_books: [first_book])
-
-      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
-      allow(DRCC).to receive(:get_crafting_item)
-      allow(DRC).to receive(:bput).and_return(study_success)
-      allow(DRCC).to receive(:stow_crafting_item)
-      stub_book_reads(section_lines: nurture_section_read, page_lines: nurture_page_read)
-
-      instance.send(:study_sigil_from_this_book, first_book, 'nurture')
-      instance.send(:study_sigil_from_this_book, first_book, 'nurture')
-
-      expect(Lich::Util).to have_received(:issue_command)
-        .with('read my book', Enchant::SIGIL_BOOK_READ_HEADER, Enchant::SIGIL_BOOK_READ_FOOTER, silent: true, quiet: true, timeout: 3)
-        .twice
+      expect(instance.send(:study_sigil_from_book, 'nurture')).to be false
     end
   end
 
-  describe '#get_sigil_book' do
+  describe '#hold_sigil_book' do
     it 'fetches from the crafting container or belt and confirms it landed in hand' do
       instance = build_instance
 
       allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
       expect(DRCC).to receive(:get_crafting_item).with(first_book, 'backpack', ['burin'], 'toolbelt', true)
 
-      expect(instance.send(:get_sigil_book, first_book)).to be true
+      expect(instance.send(:hold_sigil_book, first_book)).to be true
+      expect(instance.instance_variable_get(:@held_sigil_book)).to eq(first_book)
     end
 
-    it 'always fetches, because a held book may be a different book of the same noun' do
-      instance = build_instance
+    it 'does not re-fetch a book it is already holding' do
+      instance = build_instance(held_sigil_book: first_book)
 
-      allow(DRCI).to receive(:in_hands?).with('tome').and_return(true)
-      expect(DRCC).to receive(:get_crafting_item).with(second_book, 'backpack', ['burin'], 'toolbelt', true)
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      expect(DRCC).not_to receive(:get_crafting_item)
 
-      instance.send(:get_sigil_book, second_book)
+      expect(instance.send(:hold_sigil_book, first_book)).to be true
     end
 
-    it 'reports failure when the book never reaches a hand' do
+    it 're-fetches when the tracked book is no longer in hand' do
+      instance = build_instance(held_sigil_book: first_book)
+
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(false)
+      expect(DRCC).to receive(:get_crafting_item)
+      allow(Lich::Messaging).to receive(:msg)
+
+      instance.send(:hold_sigil_book, first_book)
+    end
+
+    it 'puts the current book away before picking up a different one' do
+      instance = build_instance(held_sigil_book: first_book)
+
+      allow(DRCI).to receive(:in_hands?).and_return(true)
+      allow(DRCC).to receive(:get_crafting_item)
+
+      expect(DRCC).to receive(:stow_crafting_item).with(first_book, 'backpack', 'toolbelt')
+
+      instance.send(:hold_sigil_book, second_book)
+    end
+
+    it 'reports failure and tracks nothing when the book never reaches a hand' do
       instance = build_instance
 
       allow(DRCI).to receive(:in_hands?).with('book').and_return(false)
       allow(DRCC).to receive(:get_crafting_item)
       expect(Lich::Messaging).to receive(:msg).with('bold', /Failed to get small sigil book/)
 
-      expect(instance.send(:get_sigil_book, first_book)).to be false
+      expect(instance.send(:hold_sigil_book, first_book)).to be false
+      expect(instance.instance_variable_get(:@held_sigil_book)).to be_nil
     end
   end
 
-  describe '#find_sigil_page' do
-    it 'returns the first page of the requested type' do
-      instance = build_instance
+  describe '#stow_sigil_book' do
+    it 'puts the held book away and forgets it' do
+      instance = build_instance(held_sigil_book: first_book)
 
-      allow(DRC).to receive(:bput)
-      stub_book_reads(section_lines: nurture_section_read)
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(true)
+      expect(DRCC).to receive(:stow_crafting_item).with(first_book, 'backpack', 'toolbelt')
 
-      expect(instance.send(:find_sigil_page, first_book, 'nurture')).to eq(3)
+      instance.send(:stow_sigil_book)
+
+      expect(instance.instance_variable_get(:@held_sigil_book)).to be_nil
     end
 
-    it 'ignores pages of other types when reading the contents view' do
+    it 'does nothing when no book is being tracked' do
       instance = build_instance
 
-      allow(DRC).to receive(:bput)
-      stub_book_reads(section_lines: contents_read)
+      expect(DRCC).not_to receive(:stow_crafting_item)
 
-      expect(instance.send(:find_sigil_page, first_book, 'nurture')).to eq(3)
+      instance.send(:stow_sigil_book)
     end
 
-    it 'matches the sigil type case-insensitively' do
-      instance = build_instance
+    it 'forgets a book another cleanup path already stowed' do
+      instance = build_instance(held_sigil_book: first_book)
 
-      allow(DRC).to receive(:bput)
-      stub_book_reads(section_lines: nurture_section_read)
+      allow(DRCI).to receive(:in_hands?).with('book').and_return(false)
+      expect(DRCC).not_to receive(:stow_crafting_item)
 
-      expect(instance.send(:find_sigil_page, first_book, 'Nurture')).to eq(3)
-    end
+      instance.send(:stow_sigil_book)
 
-    it 'addresses the book by its own noun' do
-      instance = build_instance
-
-      stub_book_reads(noun: 'tome', section_lines: nurture_section_read)
-      expect(DRC).to receive(:bput)
-        .with('turn my tome to sigil nurture', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_TURN_SECTION)
-
-      expect(instance.send(:find_sigil_page, second_book, 'nurture')).to eq(3)
-    end
-
-    it 'returns nil for a section that reads empty' do
-      instance = build_instance
-
-      allow(DRC).to receive(:bput)
-      stub_book_reads(section_lines: empty_section_read)
-
-      expect(instance.send(:find_sigil_page, first_book, 'rarefaction')).to be_nil
-    end
-
-    it 'returns nil when the read times out and captures nothing' do
-      instance = build_instance
-
-      allow(DRC).to receive(:bput)
-      stub_book_reads(section_lines: [])
-
-      expect(instance.send(:find_sigil_page, first_book, 'nurture')).to be_nil
+      expect(instance.instance_variable_get(:@held_sigil_book)).to be_nil
     end
   end
 
-  describe '#turn_to_sigil_page' do
-    it 'confirms the page holds the expected sigil type' do
+  describe '#read_sigil_book_page' do
+    # STUDY refuses a page that has not been read, so this command is mandatory -
+    # which makes the type check on its banner free.
+    it 'reads the page and accepts a banner of the expected type' do
       instance = build_instance
 
-      stub_book_reads(section_lines: [], page_lines: nurture_page_read)
       expect(DRC).to receive(:bput)
-        .with('turn my book to page 3', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_TURN_PAGE)
+        .with('read my book', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_PAGE_TYPE)
+        .and_return(page_banner)
 
-      expect(instance.send(:turn_to_sigil_page, first_book, 3, 'nurture')).to be true
+      expect(instance.send(:read_sigil_book_page, first_book, 'nurture')).to be true
+    end
+
+    it 'matches the banner case-insensitively' do
+      instance = build_instance
+
+      allow(DRC).to receive(:bput).and_return(page_banner)
+
+      expect(instance.send(:read_sigil_book_page, first_book, 'Nurture')).to be true
     end
 
     it 'rejects a page holding a different sigil type' do
       instance = build_instance
 
-      allow(DRC).to receive(:bput)
-      stub_book_reads(section_lines: [], page_lines: nurture_page_read)
+      allow(DRC).to receive(:bput).and_return('   --=== Congruence sigil ===--')
 
-      expect(Lich::Messaging).to receive(:msg).with('bold', /Page 3 of small sigil book does not hold a congruence sigil/)
+      expect(Lich::Messaging).to receive(:msg).with('bold', /small sigil book is mapped to nurture but page 1 holds a congruence sigil/)
 
-      expect(instance.send(:turn_to_sigil_page, first_book, 3, 'congruence')).to be false
+      expect(instance.send(:read_sigil_book_page, first_book, 'nurture')).to be false
     end
 
-    it 'rejects a read that never reached a page view' do
+    it 'rejects a read that produced no page banner' do
       instance = build_instance
 
-      allow(DRC).to receive(:bput)
-      stub_book_reads(section_lines: [], page_lines: nurture_section_read)
-      allow(Lich::Messaging).to receive(:msg)
+      allow(DRC).to receive(:bput).and_return(nil)
 
-      expect(instance.send(:turn_to_sigil_page, first_book, 3, 'nurture')).to be false
+      expect(Lich::Messaging).to receive(:msg).with('bold', /Could not read the current page of small sigil book/)
+
+      expect(instance.send(:read_sigil_book_page, first_book, 'nurture')).to be false
+    end
+
+    it 'addresses the book by its own noun' do
+      instance = build_instance
+
+      expect(DRC).to receive(:bput)
+        .with('read my tome', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_PAGE_TYPE)
+        .and_return(page_banner)
+
+      instance.send(:read_sigil_book_page, second_book, 'nurture')
+    end
+  end
+
+  describe '#turn_sigil_book_to_first_page' do
+    it 'always turns to page 1, because studying renumbers the pages' do
+      instance = build_instance
+
+      expect(DRC).to receive(:bput)
+        .with('turn my book to page 1', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_TURN_PAGE, Enchant::SIGIL_BOOK_ALREADY_AT_PAGE, Enchant::SIGIL_BOOK_PAGE_MISSING)
+        .and_return(turn_page)
+
+      expect(instance.send(:turn_sigil_book_to_first_page, first_book)).to be true
+    end
+
+    # An interrupted study leaves the book sitting on the page it selected, so
+    # the next turn is a no-op the game reports differently. Treating that as a
+    # failure would wrongly write the book off as empty.
+    it 'accepts a book already sitting on page 1' do
+      instance = build_instance
+
+      allow(DRC).to receive(:bput).and_return(already_at_page)
+
+      expect(instance.send(:turn_sigil_book_to_first_page, first_book)).to be true
+    end
+
+    it 'addresses the book by its own noun' do
+      instance = build_instance
+
+      expect(DRC).to receive(:bput)
+        .with('turn my tome to page 1', { 'timeout' => 3, 'suppress_no_match' => true }, Enchant::SIGIL_BOOK_TURN_PAGE, Enchant::SIGIL_BOOK_ALREADY_AT_PAGE, Enchant::SIGIL_BOOK_PAGE_MISSING)
+        .and_return('You turn the tome to page 1.')
+
+      expect(instance.send(:turn_sigil_book_to_first_page, second_book)).to be true
+    end
+
+    it 'is false when the book has no scrolls left' do
+      instance = build_instance
+
+      allow(DRC).to receive(:bput).and_return(page_missing)
+
+      expect(instance.send(:turn_sigil_book_to_first_page, first_book)).to be false
+    end
+
+    it 'is false when the turn draws no recognized response at all' do
+      instance = build_instance
+
+      allow(DRC).to receive(:bput).and_return(nil)
+
+      expect(instance.send(:turn_sigil_book_to_first_page, first_book)).to be false
     end
   end
 


### PR DESCRIPTION
## Summary

Two changes to `enchant.lic`, one commit each.

**1. Study sigils out of sigil books (new `sigil_books` setting).**

Sigils had to be loose in the crafting container — `trace_sigil` issued a bare `get my <type> sigil`, which cannot reach a scroll filed in a sigil book. Now, when `sigil_books` is configured, each sigil is studied straight out of a book: turn to the type's section, read it for a page of that type, turn to that page, confirm the page, `STUDY` the book. That produces the same memorization as the loose path, so the `trace` afterwards is unchanged.

Books are searched in the listed order and picked up one at a time (stowed again before the next), since sigil books commonly share the noun `book`. A book only holds 20 scrolls, so a run usually spans several. When no book holds the requested type it falls back to the loose scroll exactly as before — with no books configured, behavior is identical to today.

```yaml
sigil_books:
  - small sigil book
  - large sigil book
```

**2. Continue scribing after an imbue resume.**

`handle_imbue_resume` ended at `imbue` and returned, so `run_enchant` finished and the script exited. The sigil prompt only arrives after the imbue roundtime, by which point nothing was listening, leaving the enchant half-finished until it was resumed a second time. `handle_new_enchant` has always followed `imbue` with get-burin-then-`scribe`; the resume path never did. Both now end in a shared `scribe_with_burin`.

## Game text this relies on

Captured in game rather than inferred; the spec fixtures are verbatim book output.

- The item reference for `TURN` must not contain the word "sigil", or the parser reads it as the sigil-type argument (`turn my sigil book to sigil congruence` → `Which sigil did you wish to turn the a small sigil book to?`). Commands use the bare noun.
- Turning to a section holding nothing still succeeds (`You turn the book to the rarefaction section.`) and simply reads empty, so presence is decided by the `READ`, not the `TURN`.
- `STUDY` with the book at the contents appraises the book (`You study the book and determine it is well-suited for holding sigil-scrolls.`) instead of memorizing anything. That reply is matched explicitly and treated as a failure, so a mis-sequenced study can't be mistaken for a memorized sigil.
- Studying blanks the page and renumbers the remaining pages, so no page map is cached — every sigil re-reads.
- The book must be held; both turns use a short timeout with `suppress_no_match`, since the subsequent `READ` is the real verification.

## Testing

- [x] `rspec` — 3054 examples, 0 failures (39 new in `spec/enchant_spec.rb`)
- [x] `rubocop enchant.lic` — clean
- [x] In game: enchant with `sigil_books` set, sigils pulled from the book across multiple sigils (pages renumber between studies)
- [x] In game: book exhausted of a type falls through to the next book, then to a loose sigil-scroll
- [ ] In game: `;enchant resume <item>` on an item awaiting an imbue now proceeds into scribing instead of exiting
- [ ] In game: unset `sigil_books` still retrieves loose sigil-scrolls as before