### PR TITLE
Update base.yaml to use stables when trading

### DIFF
--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -1124,7 +1124,7 @@ caravan_coins_on_hand: 9555
 # Have you purchased a 750plat interior from the trade minister?
 caravan_interior: false
 # Store/retrieve caravans in the nearest stable rather than emptying the box/contracts and returning it
-trade_use_stable: false
+trade_use_stable: true
 # skills and cooldowns to train in ;trade.  See https://github.com/elanthia-online/dr-scripts/wiki/Trader-Tutorials for valid skills and what they do
 caravan_training_skills:
   # Augmentation: 5


### PR DESCRIPTION
Changing the default of trade_use_stable to true.

When set to false and the script is closing up, it will empty out the caravan's storage box so that that the caravan can be returned to the guild. This as the potential to dispose of valuable items stored in the box.

Requiring the user to specify that they don't want to use stables is a quick and sensible guardrail.