### PR TITLE
[script][remedy] stop when alchemy_tools has no container for the recipe

### DIFF
--- a/remedy.lic
+++ b/remedy.lic
@@ -52,13 +52,7 @@ class Remedy
     @herb1 = args.herb1
     @herb2 = args.herb2
     @catalyst = args.catalyst
-    @container = args.container
-    if @container =~ /bowl/
-      # Check for cauldron in place of bowl
-      @container = @settings.alchemy_tools.find { |tool| /cauldron|bowl/ =~ tool }
-    else
-      @container = @settings.alchemy_tools.find { |tool| /#{args.container}/ =~ tool } || args.container
-    end
+    @container = resolve_container(args.container)
     @pestle = @settings.alchemy_tools.find { |tool| /pestle/ =~ tool } || 'pestle'
     @verb = 'crush'
     @noun = args.noun
@@ -125,6 +119,23 @@ class Remedy
     work("analyze my #{@noun}") if args.continue
 
     create_item
+  end
+
+  # Finds the alchemy_tools entry for the container a recipe asks for, so that a
+  # "rustic mortar" answers a recipe that asks for a "mortar". A cauldron answers
+  # a recipe that asks for a bowl.
+  #
+  # Stops when the setting lists no match, because the setting is wrong. Going on
+  # with the word the recipe used sends "get my bowl", which takes whichever bowl
+  # the character happens to carry, and a nil sends "get my " with no item at all.
+  def resolve_container(requested)
+    pattern = requested =~ /bowl/ ? /cauldron|bowl/ : /#{requested}/
+    container = @settings.alchemy_tools.to_a.find { |tool| pattern =~ tool }
+    return container if container
+
+    DRC.message("*** #{@recipe_name} needs a #{requested}, and your alchemy_tools setting lists none. ***")
+    DRC.message("*** Add your #{requested} to alchemy_tools, then run this again. ***")
+    exit
   end
 
   def get_item(name, at_feet = false)

--- a/spec/remedy_spec.rb
+++ b/spec/remedy_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'ostruct'
+
+require_relative 'spec_helper'
+
+load_lic_class('remedy.lic', 'Remedy')
+
+RSpec.describe Remedy do
+  def build_instance(alchemy_tools)
+    instance = described_class.allocate
+    instance.instance_variable_set(:@settings, OpenStruct.new(alchemy_tools: alchemy_tools))
+    instance.instance_variable_set(:@recipe_name, 'some eye wash')
+    instance
+  end
+
+  describe '#resolve_container' do
+    # base-recipes.yaml asks for either "mortar" or "bowl".
+    let(:mortar_only) { ['rustic mortar', 'rustic pestle', 'mesh sieve'] }
+    let(:with_bowl) { ['rustic mortar', 'rustic pestle', 'mesh sieve', 'ceramic bowl'] }
+    let(:with_cauldron) { ['rustic mortar', 'rustic pestle', 'iron cauldron'] }
+
+    it 'matches a recipe container against the tool that holds that word' do
+      expect(build_instance(mortar_only).send(:resolve_container, 'mortar')).to eq('rustic mortar')
+    end
+
+    it 'accepts a cauldron for a recipe that asks for a bowl' do
+      expect(build_instance(with_cauldron).send(:resolve_container, 'bowl')).to eq('iron cauldron')
+    end
+
+    it 'prefers a bowl for a recipe that asks for a bowl' do
+      expect(build_instance(with_bowl).send(:resolve_container, 'bowl')).to eq('ceramic bowl')
+    end
+
+    # Before this, an unlisted container returned nil and the script sent the
+    # malformed command "get my " with no item name.
+    it 'stops when no tool matches a bowl' do
+      messages = []
+      allow(DRC).to receive(:message) { |text| messages << text }
+      expect { build_instance(mortar_only).send(:resolve_container, 'bowl') }.to raise_error(SystemExit)
+      expect(messages.first).to include('some eye wash', 'bowl', 'alchemy_tools')
+      expect(messages.last).to include('Add your bowl to alchemy_tools')
+    end
+
+    it 'stops when no tool matches a mortar' do
+      allow(DRC).to receive(:message)
+      expect { build_instance(['ceramic bowl']).send(:resolve_container, 'mortar') }.to raise_error(SystemExit)
+    end
+
+    it 'stops when alchemy_tools is empty or unset' do
+      allow(DRC).to receive(:message)
+      [[], nil].each do |tools|
+        %w[mortar bowl].each do |requested|
+          expect { build_instance(tools).send(:resolve_container, requested) }.to raise_error(SystemExit)
+        end
+      end
+    end
+
+    it 'never returns nil for any container a recipe can ask for' do
+      allow(DRC).to receive(:message)
+      [mortar_only, with_bowl, with_cauldron, []].each do |tools|
+        %w[mortar bowl].each do |requested|
+          instance = build_instance(tools)
+          begin
+            expect(instance.send(:resolve_container, requested)).not_to be_nil
+          rescue SystemExit
+            # Stopping is the other acceptable answer. A nil is not.
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

A remedy recipe that asks for a bowl sends `get my ` — with no item name — when `alchemy_tools` lists neither a bowl nor a cauldron.

The two branches that resolve the container are not symmetric (`remedy.lic:55`):

```ruby
@container = args.container
if @container =~ /bowl/
  # Check for cauldron in place of bowl
  @container = @settings.alchemy_tools.find { |tool| /cauldron|bowl/ =~ tool }
else
  @container = @settings.alchemy_tools.find { |tool| /#{args.container}/ =~ tool } || args.container
end
```

The mortar branch ends in `|| args.container`. The bowl branch has no such fallback. `Array#find` returns `nil`, `@container` becomes `nil`, and `DRCC.get_crafting_item` interpolates it:

```ruby
command = "get my #{name}"
```

The blank command appears immediately after the recipe book is stowed, because that is where `create_item` calls `get_item(@container)`.

## Scale

`base-recipes.yaml` asks for a mortar for 32 remedy recipes and a bowl for the other 32. The split runs along product type:

| container | count | products |
| --- | --- | --- |
| `mortar` | 32 | creams, salves, ointments, balms, poultices |
| `bowl` | 32 | potions, tonics, elixirs, washes |

So a profile listing only a mortar works for every solid remedy and fails on every liquid one. `craft.lic`, `workorders.lic` and `create_remedies.lic` all pass `recipe['container']` straight through, so any of them can trigger it.

## Change

Neither branch falls back now. A recipe names a generic container — `mortar` or `bowl` — and `alchemy_tools` is what turns that into the item the character actually crafts with. No entry means the setting is wrong, so the script says what is needed and stops:

```
*** some eye wash needs a bowl, and your alchemy_tools setting lists none. ***
*** Add your bowl to alchemy_tools, then run this again. ***
```

The alternative would be to keep the mortar branch's fallback and extend it to bowls. I did not, because the recipe's own word is a poor stand-in. `get my bowl` takes whichever bowl the character happens to carry — an eating bowl, an alms bowl — rather than the one they craft with, and it does so silently. A tool carries one adjective and a noun, so the generic word is frequently not the item's name at all.

Behaviour that does not change: `rustic mortar` still answers a recipe asking for a `mortar`, and a cauldron still answers a recipe asking for a bowl.

## Testing

- New `spec/remedy_spec.rb` — 7 examples covering both containers, the cauldron substitution, an empty and an unset `alchemy_tools`, the message text, and a case asserting the method never returns `nil` for either container a recipe can ask for.
- I confirmed the specs fail against the current code: grafting the old resolution back behind the same method seam produces failures where the old code returns `nil` for a bowl.
- `bundle exec rspec` — 3024 examples, 0 failures.
- `bundle exec rubocop` — clean on both files.

## Note for review

This turns a silent wrong-item risk into a hard stop, so anyone relying on the mortar branch's fallback — owning a mortar without listing it — now has to add it to `alchemy_tools`. That seemed right for a setting whose whole job is naming your tools, but say the word if you would rather it warned and carried on.

## Test plan

- [ ] A mortar recipe still resolves `mortar` to the listed tool, e.g. `rustic mortar`.
- [ ] A bowl recipe resolves to a listed bowl or cauldron when one is present.
- [ ] A bowl recipe on a profile with no bowl stops with the message above instead of sending `get my `.
- [ ] A mortar recipe on a profile with no mortar stops the same way.
