### PR TITLE
combat-trainer: fix empath passive-heal guard keyed off wrong spell name (Regeneration -> Regenerate)

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2305,7 +2305,7 @@ class SpellProcess
   def check_health_empath(game_state)
     return if DRStats.health > @empath_vitality_threshold && @wounds.empty?
 
-    if DRSpells.active_spells['Regeneration']
+    if DRSpells.active_spells['Regenerate']
       if @empath_spells['VH'] && DRStats.health <= @empath_vitality_threshold
         data = { 'abbrev' => 'vh', 'mana' => @empath_spells['VH'].first, 'cambrinth' => @empath_spells['VH'][1..-1], 'harmless' => true }
         prepare_spell(data, game_state)

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -3573,7 +3573,7 @@ RSpec.describe SpellProcess do
   describe '#check_health_empath' do
     it 'does not ping the game for a disabled Vitality Healing during regeneration' do
       DRStats.health = 50
-      DRSpells._set_active_spells({ 'Regeneration' => 100 })
+      DRSpells._set_active_spells({ 'Regenerate' => 100 })
       allow(DRCA).to receive(:prepare?)
 
       instance = build_spell_process(
@@ -3587,6 +3587,29 @@ RSpec.describe SpellProcess do
       instance.send(:check_health_empath, gs)
 
       expect(DRCA).not_to have_received(:prepare?)
+    end
+
+    # Regression: the passive-heal guard was keyed off 'Regeneration', but the
+    # active_spells key the game reports is 'Regenerate'. The typo meant the guard
+    # never matched, so empaths actively burned FOC/HEAL mana on wounds a running
+    # Regenerate was already clearing. With Regenerate active we must early-return
+    # and NOT prepare an active healing spell.
+    it 'skips active FOC healing while Regenerate is running' do
+      DRStats.health = 100
+      DRSpells._set_active_spells({ 'Regenerate' => 100 })
+
+      instance = build_spell_process(
+        empath_spells: { 'FOC' => [5] },
+        empath_vitality_threshold: 75,
+        perc_health_timer: Time.now, # skip the perceive-health refresh branch
+        wounds: { 'chest' => 3 }
+      )
+      allow(instance).to receive(:prepare_spell)
+      gs = GameState.allocate
+
+      instance.send(:check_health_empath, gs)
+
+      expect(instance).not_to have_received(:prepare_spell)
     end
 
     it 'falls back to HEAL when FOC is disabled' do


### PR DESCRIPTION
## Problem

`SpellProcess#check_health_empath` gates its "a heal-over-time is already running, don't actively heal" early-return on:

```ruby
if DRSpells.active_spells['Regeneration']
```

But the `active_spells` key the game reports for the Empath spell is **`Regenerate`**, not `Regeneration` — as every other reference in the codebase uses (`healme.lic`, `plantheal.lic`). The typo means the guard **never matches**, so an empath with a running Regenerate falls through to the active-healing path and casts FOC/HEAL on wounds the passive spell is already clearing — burning mana every tick.

## Fix

- `combat-trainer.lic`: `active_spells['Regeneration']` → `active_spells['Regenerate']`.
- The existing `check_health_empath` spec only passed because it seeded the same wrong key (`_set_active_spells({ 'Regeneration' => 100 })`); updated it to `'Regenerate'`.
- Added a regression test asserting that no active healing spell is prepared while `Regenerate` is up. It **fails against the old `'Regeneration'` guard and passes with the fix** (verified both directions).

## Tests

Full `bundle exec rspec` green (3040 examples, 0 failures); `rubocop` clean on `combat-trainer.lic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)