### PR TITLE
combat-trainer: fix rebleed death-spiral with heal-over-time-aware bleed-stop (01 of 03)

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1342,30 +1342,19 @@ class SafetyProcess
     @equipment_manager = equipment_manager
     @health_threshold = settings.health_threshold
     @stop_on_bleeding = settings.stop_hunting_if_bleeding
-    @safety_untendable_threshold = settings.safety_untendable_threshold || 3
     @safety_exit_on_bleeding = settings.safety_exit_on_bleeding || false
     @safety_concentration_minimum = settings.safety_concentration_minimum
     @safety_escape_health_threshold = settings.safety_escape_health_threshold
     echo("  @health_threshold: #{@health_threshold}") if $debug_mode_ct
-    echo("  @safety_untendable_threshold: #{@safety_untendable_threshold}") if $debug_mode_ct
     echo("  @safety_exit_on_bleeding: #{@safety_exit_on_bleeding}") if $debug_mode_ct
     echo("  @safety_concentration_minimum: #{@safety_concentration_minimum}") if $debug_mode_ct
     echo("  @safety_escape_health_threshold: #{@safety_escape_health_threshold}") if $debug_mode_ct
-    @untendable_counter = 0
   end
 
   def execute(game_state)
-    # Reset the failure count whenever we are not actively bleeding, so a stale
-    # count from an earlier, since-resolved bleed cannot trip the stop below.
-    @untendable_counter = 0 unless bleeding?
-    if @untendable_counter >= @safety_untendable_threshold && @stop_on_bleeding
-      echo('Skipping tendme check due to untendable backoff') if $debug_mode_ct
-      echo("Couldn't tend bleeders after trying #{@safety_untendable_threshold} time(s). Stopping hunt. Get healed!")
-      $HUNTING_BUDDY.stop_hunting
-      $COMBAT_TRAINER.stop
-    elsif @safety_concentration_minimum && DRStats.concentration < @safety_concentration_minimum
+    if @safety_concentration_minimum && DRStats.concentration < @safety_concentration_minimum
       echo("Concentration below #{@safety_concentration_minimum}. Stopping hunt.")
-      $HUNTING_BUDDY.stop_hunting
+      $HUNTING_BUDDY&.stop_hunting
       $COMBAT_TRAINER.stop
     elsif @safety_escape_health_threshold && DRStats.thief? && DRSpells.known_spells['Vanish'] && (bleeding? || stunned? || DRStats.health < @safety_escape_health_threshold)
       pause 0.1 while stunned?
@@ -1373,25 +1362,36 @@ class SafetyProcess
       echo("Stunned. Activating Vanish and stopping hunt.") if stunned?
       echo("Health below #{@safety_escape_health_threshold}. Activating Vanish and stopping hunt.") if DRStats.health < @safety_escape_health_threshold
       DRCA.activate_khri?(false, "Vanish")
-      $HUNTING_BUDDY.stop_hunting
+      $HUNTING_BUDDY&.stop_hunting
       $COMBAT_TRAINER.stop
-    elsif @safety_exit_on_bleeding && (bleeding? || (stunned? && DRStats.health < (@safety_escape_health_threshold || 80)))
-      echo("Bleeding. Stopping hunt.") if bleeding?
-      echo("Stunned with low health. Stopping hunt.") if stunned?
-      $HUNTING_BUDDY.stop_hunting
+    # safety_exit_on_bleeding additionally exits when stunned at low health. That is a
+    # stun escape, not a bleed, so it stays separate from the shared bleed handling below.
+    elsif @safety_exit_on_bleeding && stunned? && DRStats.health < safety_escape_health_floor
+      echo("Stunned with low health. Stopping hunt.")
+      $HUNTING_BUDDY&.stop_hunting
+      $COMBAT_TRAINER.stop
+    # Shared bleed handling for BOTH stop_hunting_if_bleeding and safety_exit_on_bleeding.
+    # The bug: stop_hunting_if_bleeding was gated behind an unreliable tend-failure
+    # counter and effectively never stopped the hunt.
+    #
+    # A heal-over-time spell (Devour/Heal/Regenerate) tends the bleed for us, so bleeding
+    # alone is not a reason to stop while one is active -- only stop once vitality has also
+    # dropped below the floor the HoT can no longer keep up with (the safety_escape_health
+    # floor, default 80). This branch is separate from the no-HoT one below so the echo can
+    # name the low-vitality trigger.
+    elsif bleed_stop_enabled? && bleeding? && heal_over_time_active? && DRStats.health < safety_escape_health_floor
+      echo("Bleeding with vitality below #{safety_escape_health_floor} despite an active heal-over-time. Stopping hunt.")
+      $HUNTING_BUDDY&.stop_hunting
+      $COMBAT_TRAINER.stop
+    # No heal-over-time to tend the bleed for us: stop as soon as we're bleeding.
+    elsif bleed_stop_enabled? && bleeding? && !heal_over_time_active?
+      echo("Bleeding. Stopping hunt.")
+      $HUNTING_BUDDY&.stop_hunting
       $COMBAT_TRAINER.stop
     # If no heal-over-time spells are active then attempt to tend bleeders using ;tendme
-    elsif bleeding? && !Script.running?('tendme') && !(DRSpells.active_spells['Devour'] || DRSpells.active_spells['Heal'] || DRSpells.active_spells['Regenerate'])
+    elsif bleeding? && !Script.running?('tendme') && !heal_over_time_active?
       echo('Checking for tendable bleeders...') if $debug_mode_ct
       DRC.wait_for_script_to_complete('tendme') if DRCH.has_tendable_bleeders?
-      # Only count a failed attempt if still bleeding afterwards, and reset once
-      # bleeding clears so separate, fully-tended episodes earlier in the hunt do
-      # not accumulate toward the stop threshold.
-      if bleeding?
-        @untendable_counter += 1
-      else
-        @untendable_counter = 0
-      end
     end
 
     fput 'exit' if DRStats.health < @health_threshold
@@ -1405,6 +1405,25 @@ class SafetyProcess
   end
 
   private
+
+  # A heal-over-time spell tends bleeders on its own, so both the bleed-stop gate and
+  # the ;tendme fallback key off the same set. Kept in one place so the call sites
+  # cannot silently diverge.
+  def heal_over_time_active?
+    DRSpells.active_spells['Devour'] || DRSpells.active_spells['Heal'] || DRSpells.active_spells['Regenerate']
+  end
+
+  # Either bleed-stop setting enables the shared bleed handling; the heal-over-time
+  # grace and vitality floor then apply identically to both.
+  def bleed_stop_enabled?
+    @stop_on_bleeding || @safety_exit_on_bleeding
+  end
+
+  # Vitality floor below which a heal-over-time is assumed to no longer keep up; also the
+  # stunned-exit floor. Defaults to 80 when safety_escape_health_threshold is unset.
+  def safety_escape_health_floor
+    @safety_escape_health_threshold || 80
+  end
 
   def check_item_recovery(game_state)
     if Flags['ct-germshieldlost']

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -596,7 +596,18 @@ hunting_buddies:
 hunting_buddies_max: 2
 # A list of nemesis or people you do not want to hunt with.
 hunting_nemesis:
+# Stop the hunt when you start bleeding so you can get healed before you bleed out.
+# A heal-over-time spell (Empath Heal/Regenerate, Necromancer Devour) heals bleeds, so while
+# one of those is active the hunt does NOT stop on the bleed alone -- it only stops once your
+# vitality (health %) has also fallen below safety_escape_health_threshold (default 80). With
+# no heal-over-time active, the hunt stops as soon as you bleed.
+# Set to false to keep hunting through bleeds; they are still tended in stride via ;tendme.
 stop_hunting_if_bleeding: true
+# Same bleed handling as stop_hunting_if_bleeding (the heal-over-time grace above applies
+# identically), but additionally stops the hunt when you are stunned and your vitality is
+# below safety_escape_health_threshold (default 80). Leave false unless you also want that
+# stunned-at-low-health exit.
+safety_exit_on_bleeding: false
 # Room that you will use to prebuff your character before a hunt, utilizes the prehunt_buffs waggle set.
 prehunt_buffing_room:
 # Minimum perc mana to look for in a hunting room. If hunting_room_strict_mana is true, then it will skip a hunt if it can't find the mana

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -1729,11 +1729,9 @@ RSpec.describe SafetyProcess do
       equipment_manager: double('EquipmentManager'),
       health_threshold: 20,
       stop_on_bleeding: true,
-      safety_untendable_threshold: 3,
       safety_exit_on_bleeding: false,
       safety_concentration_minimum: nil,
-      safety_escape_health_threshold: nil,
-      untendable_counter: 0
+      safety_escape_health_threshold: nil
     }
     defaults.merge(overrides).each do |k, v|
       instance.instance_variable_set(:"@#{k}", v)
@@ -1766,51 +1764,191 @@ RSpec.describe SafetyProcess do
     allow(DRCA).to receive(:activate_khri?).and_return(true)
   end
 
+  # DAMP helper: build a SafetyProcess, stub the post-safety tail, seed the exact
+  # game-state the safety branches read, then run one execute tick. Returns the
+  # instance so a caller can assert on the $HUNTING_BUDDY / $COMBAT_TRAINER doubles.
+  # Every scenario reads as one line: `run_safety_tick(bleeding: true, active_spells: { 'Heal' => 5 }, health: 80)`.
+  def run_safety_tick(bleeding: false, stunned: false, health: 100, concentration: 100,
+                      active_spells: {}, **process_overrides)
+    instance = build_safety_process(**process_overrides)
+    stub_post_safety(instance)
+    allow(instance).to receive(:bleeding?).and_return(bleeding)
+    allow(instance).to receive(:stunned?).and_return(stunned)
+    DRStats.health = health
+    DRStats.concentration = concentration
+    DRSpells._set_active_spells(active_spells)
+    instance.execute(build_game_state)
+    instance
+  end
+
   describe '#execute' do
-    describe 'safety_untendable_threshold' do
-      it 'stops hunt at default threshold of 3' do
-        instance = build_safety_process(untendable_counter: 3)
-        stub_post_safety(instance)
-        allow(instance).to receive(:bleeding?).and_return(true) # stop is gated on active bleeding
-        game_state = build_game_state
+    # Readable assertion pairs. A "stop" means BOTH the parent hunt loop and the
+    # combat-trainer itself are told to stop; a "continue" means neither is.
+    def expect_hunt_stopped
+      expect($HUNTING_BUDDY).to have_received(:stop_hunting)
+      expect($COMBAT_TRAINER).to have_received(:stop)
+    end
 
-        instance.execute(game_state)
+    def expect_hunt_continued
+      expect($HUNTING_BUDDY).not_to have_received(:stop_hunting)
+      expect($COMBAT_TRAINER).not_to have_received(:stop)
+    end
 
-        expect($HUNTING_BUDDY).to have_received(:stop_hunting)
+    # The bug: stop_hunting_if_bleeding was gated behind an unreliable tend-failure
+    # counter, so it never reliably stopped the hunt. It now stops as soon as we are
+    # bleeding (default-on), unless a heal-over-time spell is tending us and vitality
+    # is still healthy -- see the heal-over-time block below.
+    describe 'stop_hunting_if_bleeding' do
+      it 'stops the hunt as soon as bleeding with no heal-over-time active' do
+        run_safety_tick(stop_on_bleeding: true, bleeding: true)
+        expect_hunt_stopped
+      end
+
+      it 'does not stop when not bleeding' do
+        run_safety_tick(stop_on_bleeding: true, bleeding: false)
+        expect_hunt_continued
+      end
+
+      it 'does not stop when the setting is disabled, even while bleeding' do
+        run_safety_tick(stop_on_bleeding: false, safety_exit_on_bleeding: false, bleeding: true)
+        expect_hunt_continued
+      end
+
+      it 'does not raise when run standalone without hunting-buddy' do
+        $HUNTING_BUDDY = nil # combat-trainer is often run on its own
+        expect { run_safety_tick(stop_on_bleeding: true, bleeding: true) }.not_to raise_error
         expect($COMBAT_TRAINER).to have_received(:stop)
       end
+    end
 
-      it 'does not stop hunt below default threshold' do
-        instance = build_safety_process(untendable_counter: 2)
-        stub_post_safety(instance)
-        allow(instance).to receive(:bleeding?).and_return(true) # bleeding so the threshold (not the not-bleeding reset) is what is tested
-        game_state = build_game_state
+    # Finding #2: an active heal-over-time (Devour/Heal/Regenerate) tends the bleed for
+    # us, so a bleed alone must NOT end the hunt -- only a bleed *plus* low vitality
+    # (DRStats.health below safety_escape_health_threshold, default 80) should.
+    describe 'stop_hunting_if_bleeding with an active heal-over-time' do
+      %w[Devour Heal Regenerate].each do |hot|
+        it "keeps hunting while #{hot} is active and vitality is healthy" do
+          run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 100, active_spells: { hot => 20 })
+          expect_hunt_continued
+        end
 
-        instance.execute(game_state)
-
-        expect($HUNTING_BUDDY).not_to have_received(:stop_hunting)
+        it "still stops when #{hot} is active but vitality is below the 80 floor" do
+          run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 50, active_spells: { hot => 20 })
+          expect_hunt_stopped
+        end
       end
 
-      it 'stops hunt at custom threshold of 1' do
-        instance = build_safety_process(safety_untendable_threshold: 1, untendable_counter: 1)
-        stub_post_safety(instance)
-        allow(instance).to receive(:bleeding?).and_return(true) # stop is gated on active bleeding
-        game_state = build_game_state
-
-        instance.execute(game_state)
-
-        expect($HUNTING_BUDDY).to have_received(:stop_hunting)
+      it 'treats multiple simultaneous heal-over-times the same as one' do
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 100,
+                        active_spells: { 'Heal' => 20, 'Regenerate' => 20 })
+        expect_hunt_continued
       end
 
-      it 'requires stop_on_bleeding to be true' do
-        instance = build_safety_process(untendable_counter: 3, stop_on_bleeding: false)
-        stub_post_safety(instance)
-        allow(instance).to receive(:bleeding?).and_return(true) # bleeding so stop_on_bleeding=false is what prevents the stop
-        game_state = build_game_state
+      it 'is not suppressed by an unrelated active spell' do
+        # A random buff must not be mistaken for a heal-over-time.
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 100, active_spells: { 'Heroism' => 20 })
+        expect_hunt_stopped
+      end
 
-        instance.execute(game_state)
+      # Boundary: the gate is `health < threshold`, so exactly-at-threshold keeps hunting.
+      it 'keeps hunting at exactly the 80 vitality floor' do
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 80, active_spells: { 'Heal' => 20 })
+        expect_hunt_continued
+      end
 
-        expect($HUNTING_BUDDY).not_to have_received(:stop_hunting)
+      it 'stops one point below the 80 vitality floor' do
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 79, active_spells: { 'Heal' => 20 })
+        expect_hunt_stopped
+      end
+
+      # A non-thief with a custom safety_escape_health_threshold uses that value as the
+      # floor (the Thief/Vanish branch above is skipped for non-thieves), not the 80 default.
+      it 'honors a custom safety_escape_health_threshold as the floor' do
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 50,
+                        safety_escape_health_threshold: 40, active_spells: { 'Heal' => 20 })
+        expect_hunt_continued # 50 >= 40, HoT keeps up
+
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 39,
+                        safety_escape_health_threshold: 40, active_spells: { 'Heal' => 20 })
+        expect_hunt_stopped # 39 < 40
+      end
+
+      it 'never stops on bleed when the setting is disabled, even at low vitality with a heal-over-time' do
+        run_safety_tick(stop_on_bleeding: false, safety_exit_on_bleeding: false,
+                        bleeding: true, health: 10, active_spells: { 'Heal' => 20 })
+        expect_hunt_continued
+      end
+    end
+
+    # Guards the elsif ordering my new branch sits inside: the ;tendme fallback must
+    # remain reachable when we are NOT stopping, and must be pre-empted when we are.
+    describe 'tend (;tendme) fallback reachability' do
+      it 'attempts to tend bleeders when not stopping and no heal-over-time is active' do
+        allow(DRCH).to receive(:has_tendable_bleeders?).and_return(true)
+        allow(DRC).to receive(:wait_for_script_to_complete)
+
+        run_safety_tick(stop_on_bleeding: false, safety_exit_on_bleeding: false, bleeding: true)
+
+        expect(DRC).to have_received(:wait_for_script_to_complete).with('tendme')
+      end
+
+      it 'does not tend while a heal-over-time is handling the bleed' do
+        allow(DRCH).to receive(:has_tendable_bleeders?).and_return(true)
+        allow(DRC).to receive(:wait_for_script_to_complete)
+
+        # HoT active, vitality healthy: no stop AND no tend -- the HoT owns the bleed.
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 100, active_spells: { 'Heal' => 20 })
+
+        expect(DRC).not_to have_received(:wait_for_script_to_complete)
+        expect_hunt_continued
+      end
+
+      it 'stops instead of tending when stop_on_bleeding pre-empts the fallback' do
+        allow(DRCH).to receive(:has_tendable_bleeders?).and_return(true)
+        allow(DRC).to receive(:wait_for_script_to_complete)
+
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 100)
+
+        expect(DRC).not_to have_received(:wait_for_script_to_complete)
+        expect_hunt_stopped
+      end
+    end
+
+    # Adversarial: my branch must not jump ahead of higher-priority safety branches,
+    # and those branches must still fire in cases where my branch would NOT stop.
+    describe 'stop_hunting_if_bleeding branch precedence' do
+      # Non-theater precedence test: pick the exact state where the bleed branches do
+      # NOT stop (heal-over-time active + healthy vitality). If concentration did not
+      # take precedence / fire independently, nothing would stop the hunt here.
+      it 'still stops for low concentration even when a heal-over-time suppresses the bleed stop' do
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 100,
+                        active_spells: { 'Heal' => 20 },
+                        safety_concentration_minimum: 10, concentration: 5)
+        expect_hunt_stopped
+        expect(displayed_messages).to include(a_string_matching(/Concentration below/))
+      end
+
+      it 'yields to the Thief Vanish escape when bleeding' do
+        DRStats.guild = 'Thief'
+        DRSpells._set_known_spells({ 'Vanish' => true })
+
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, safety_escape_health_threshold: 90)
+
+        expect(DRCA).to have_received(:activate_khri?).with(false, 'Vanish')
+        expect_hunt_stopped
+      end
+    end
+
+    # Finding #6: the two stop reasons must be distinguishable in the log -- a plain
+    # bleed vs. a bleed that only stopped because vitality fell under an active HoT.
+    describe 'stop_hunting_if_bleeding echo messages' do
+      it 'names a plain bleed stop' do
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 100)
+        expect(displayed_messages).to include(a_string_matching(/Bleeding\. Stopping hunt/))
+      end
+
+      it 'names the low-vitality-under-heal-over-time stop distinctly' do
+        run_safety_tick(stop_on_bleeding: true, bleeding: true, health: 50, active_spells: { 'Heal' => 20 })
+        expect(displayed_messages).to include(a_string_matching(/vitality below 80 despite an active heal-over-time/))
       end
     end
 
@@ -1917,7 +2055,9 @@ RSpec.describe SafetyProcess do
 
     describe 'safety_exit_on_bleeding' do
       it 'stops hunt when bleeding and setting is true' do
-        instance = build_safety_process(safety_exit_on_bleeding: true)
+        # Disable stop_on_bleeding so only safety_exit_on_bleeding can drive the stop --
+        # otherwise this passes even if safety_exit_on_bleeding were ignored.
+        instance = build_safety_process(safety_exit_on_bleeding: true, stop_on_bleeding: false)
         stub_post_safety(instance)
         allow(instance).to receive(:bleeding?).and_return(true)
         game_state = build_game_state
@@ -1925,6 +2065,26 @@ RSpec.describe SafetyProcess do
         instance.execute(game_state)
 
         expect($HUNTING_BUDDY).to have_received(:stop_hunting)
+      end
+
+      # The heal-over-time grace is shared: safety_exit_on_bleeding honors it too, not just
+      # stop_hunting_if_bleeding. stop_on_bleeding is disabled here so only the
+      # safety_exit_on_bleeding path can drive the decision.
+      it 'keeps hunting on a bleed a heal-over-time is tending at healthy vitality' do
+        run_safety_tick(safety_exit_on_bleeding: true, stop_on_bleeding: false,
+                        bleeding: true, health: 100, active_spells: { 'Heal' => 20 })
+        expect_hunt_continued
+      end
+
+      it 'stops on a bleed when a heal-over-time is active but vitality is below the floor' do
+        run_safety_tick(safety_exit_on_bleeding: true, stop_on_bleeding: false,
+                        bleeding: true, health: 50, active_spells: { 'Heal' => 20 })
+        expect_hunt_stopped
+      end
+
+      it 'stops on a bleed with no heal-over-time active' do
+        run_safety_tick(safety_exit_on_bleeding: true, stop_on_bleeding: false, bleeding: true)
+        expect_hunt_stopped
       end
 
       it 'stops hunt when stunned with low health' do
@@ -1952,7 +2112,8 @@ RSpec.describe SafetyProcess do
       end
 
       it 'does not fire when setting is false' do
-        instance = build_safety_process(safety_exit_on_bleeding: false)
+        # stop_on_bleeding also stops on bleeding, so disable it too to isolate this case.
+        instance = build_safety_process(safety_exit_on_bleeding: false, stop_on_bleeding: false)
         stub_post_safety(instance)
         allow(instance).to receive(:bleeding?).and_return(true)
         game_state = build_game_state


### PR DESCRIPTION
**Stacked PR 01 of 03** — merge in order: **01 → 02 → 03**. This PR is the standalone bug fix; 02 (refactor) and 03 (settings) build on it, so their diffs are cumulative until this merges.

## Problem
`stop_hunting_if_bleeding` was gated behind an unreliable tend-failure counter (`@untendable_counter` / `safety_untendable_threshold`). The counter reset the instant bleeding cleared and only incremented in a tend branch a heal-over-time already suppressed, so a re-bleed spiral never reached the threshold and the hunt ran on while the character bled out.

## Fix
- Delete the counter and its state; stop on bleeding directly when a bleed-stop setting is on.
- **Heal-over-time grace:** an active Devour/Heal/Regenerate tends the bleed, so bleeding alone stops the hunt only when no such spell is active or vitality (`DRStats.health`) has fallen below `safety_escape_health_threshold` (default 80). Applies to both `stop_hunting_if_bleeding` and `safety_exit_on_bleeding`.
- Guard `$HUNTING_BUDDY&.stop_hunting` so standalone runs don't raise.
- Document the bleed settings in `base.yaml`.

## Tests
Specs cover the stop, the heal-over-time gate across the vitality boundary, and the standalone (nil `$HUNTING_BUDDY`) guard. `bundle exec rspec` green (3062 examples); rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)