### PR TITLE
feat(moonwatch): map the new phase for Moon Mages (v4.5.3)

### DIFF
--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -3,7 +3,7 @@
 =begin
   Documentation: https://github.com/elanthia-online/dr-scripts/wiki/Documentation-for-moonwatch.lic
 
-  Moonwatch v4.5.2 - Bresenham Moons + Empirical Sun Table + Lunar Phase
+  Moonwatch v4.5.3 - Bresenham Moons + Empirical Sun Table + Lunar Phase
   ======================================================================
 
   This script provides real-time tracking of DragonRealms moons (Katamba, Xibar, Yavash)
@@ -78,6 +78,17 @@
   auto-observe never fires while new and no "new" wording exists. All findings
   were validated against ~2700 observe responses logged across two characters.
 
+  v4.5.3 corrects the v4.5.2 claim that new is entirely unobservable, and maps
+  it. A new moon shows no phase and broadcasts no rise, but a MOON MAGE can still
+  observe it: their `observe` senses the dark moon's mana and returns "...moon
+  <M> turns up fruitless." (40/42 = new). That clause is now mapped to new;
+  non-Moon-Mage characters instead get "nowhere to be seen" (below-horizon, every
+  phase), which stays unmapped. So new is now validated on a Moon Mage, giving
+  8/8 there while other guilds remain at 7/8. Confirmed by contrasting a Moon
+  Mage (dark-moon clauses present) with a non-Moon-Mage (only "nowhere to be
+  seen"). The moon does rise during new -- observe finds it, hidden, rather than
+  "nowhere" -- so DR merely suppresses the visible rise broadcast for a dark moon.
+
   Architecture (SOLID principles applied):
   - DRTime: Single responsibility for DR calendar calculations
   - Moons: Single responsibility for moon position calculations
@@ -118,7 +129,7 @@
 no_pause_all
 no_kill_all
 
-$MOONWATCH_VERSION = '4.5.2'
+$MOONWATCH_VERSION = '4.5.3'
 
 # =============================================================================
 # CONSTANTS: Game Event Patterns
@@ -932,17 +943,26 @@ module Moons
   # AFTER "moon <M>" (the distinctive prefix of first/third quarter -- "Waxing
   # still, half of the" / "The waning half of the" -- is dropped by the capture,
   # so the suffix "looks down from above" / "moves across the skies" is what
-  # disambiguates them). All seven OBSERVABLE phases are mapped and validated
-  # against ~2700 logged observe responses across all three moons.
+  # disambiguates them). The seven visible phases are validated against ~2700
+  # logged observe responses across all three moons.
   #
-  # "new" is intentionally absent and unmappable: DR does not broadcast a rise
-  # for a dark (new) moon (0 rises at model-new across ~2700, vs ~130 per other
-  # phase), so the rise-triggered auto-observe never fires while new, and no
-  # "new" wording exists in the logs. The phase model still reports "new"
-  # correctly; there is simply no in-game observe text to validate it against.
+  # "new" is a special case: DR shows no phase for a dark moon, and broadcasts no
+  # rise for it either (0 rises at model-new across ~2700 logged rises, vs ~130
+  # per other phase), so the rise-triggered auto-observe rarely fires while new.
+  # It IS observable, but only by a Moon Mage: their `observe` senses the dark
+  # moon's mana and returns "...moon <M> turns up fruitless." (40/42 = new; the
+  # 2 outliers are new->waxing-crescent boundary reads) or "...<M> is hidden from
+  # you, but its energy is quite strong." (45/45 = new, but that clause lacks
+  # "moon <M>" so the parser above never captures it). Non-Moon-Mage characters
+  # get only "nowhere to be seen", which is below-horizon and spans every phase,
+  # so it is deliberately NOT mapped. The "turns up fruitless" entry is therefore
+  # Moon-Mage-only in practice; it needs no gating because no other guild emits
+  # it. Determined from a Moon Mage (Quilsilgas) vs a non-Moon-Mage (Ytterby):
+  # the dark-moon clauses appear only in the Moon Mage's logs.
   #
   # Entries are in cycle order; find returns the first match, fragments disjoint.
   OBSERVED_PHASE_MAP = [
+    [/turns up fruitless/i, 'new'], # Moon Mage only (dark-moon sense)
     [/growing crescent/i, 'waxing crescent'],
     [/looks down from above/i, 'first quarter'],
     [/nearly turned its full face/i, 'waxing gibbous'],

--- a/spec/moonwatch_spec.rb
+++ b/spec/moonwatch_spec.rb
@@ -411,6 +411,7 @@ RSpec.describe 'moonwatch.lic' do
 
     describe '.observed_phase_name' do
       it 'maps each known DR observe wording to its phase' do
+        expect(Moons.observed_phase_name('turns up fruitless')).to eq('new') # Moon Mage dark-moon sense
         expect(Moons.observed_phase_name('is a growing crescent of light')).to eq('waxing crescent')
         expect(Moons.observed_phase_name('looks down from above')).to eq('first quarter')
         expect(Moons.observed_phase_name('has nearly turned its full face upon Elanthia')).to eq('waxing gibbous')
@@ -463,13 +464,14 @@ RSpec.describe 'moonwatch.lic' do
         end
       end
 
-      # The one non-phase response that says "moon <M>" ("Your search ... turns
-      # up fruitless.") does match, but its clause maps to nil, so it is logged
-      # raw as an unmapped phrasing rather than mis-attributed to a phase.
-      it 'treats the rare "turns up fruitless" line as an unmapped clause, not a phase' do
+      # A Moon Mage observing a dark (new) moon gets "Your search for the ... moon
+      # <M> turns up fruitless." -- it says "moon <M>", so the parser captures it,
+      # and its clause maps to 'new'. This is the only observe-validated signal
+      # for the new phase (and only a Moon Mage produces it).
+      it 'captures the Moon Mage "turns up fruitless" line and maps it to new' do
         m = MOON_PHASE_LINE_PATTERN.match('Your search for the black moon Katamba turns up fruitless.')
         expect(m).not_to be_nil
-        expect(Moons.observed_phase_name(m[:phase_desc].strip)).to be_nil
+        expect(Moons.observed_phase_name(m[:phase_desc].strip)).to eq('new')
       end
     end
   end


### PR DESCRIPTION
## What

Follow-up to #7570. That PR documented the **new** phase as unobservable — which is only true for non-Moon-Mage characters. This maps it.

A Moon Mage's `observe` senses a dark moon's mana even when it shows no phase, returning:

> Your search for the black **moon Katamba** turns up fruitless.

That clause contains "moon <M>", so the existing parser already captures it. This adds `/turns up fruitless/i → 'new'` to `OBSERVED_PHASE_MAP`.

## Evidence

- `turns up fruitless` → **40/42 = new** (the 2 outliers are new→waxing-crescent boundary reads).
- The 100%-clean signal `…is hidden from you, but its energy is quite strong` (45/45 new) is **not** mapped: it lacks "moon <M>" so the parser doesn't capture it, and relaxing the parser to catch it would risk matching weather lines.
- Non-Moon-Mage characters get only `nowhere to be seen`, which is below-horizon and spans every phase — deliberately left unmapped.

Determined by contrasting a Moon Mage (Quilsilgas — dark-moon clauses present) with a non-Moon-Mage (Ytterby — only "nowhere to be seen"). Data gathered from a purpose-built brute-force observer running across predicted new-moon windows, plus ~2,700 historical observe responses.

## Net effect

- **Moon Mage characters:** now 8/8 observe-validated phases.
- **Other guilds:** remain 7/8 (new is genuinely unobservable for them). No behavior change — they never emit the mapped clause, so no gating is needed.

Also corrects the mechanism note: the moon *does* rise during new (observe finds it *hidden*, not "nowhere") — DR merely suppresses the visible rise broadcast for a dark moon.

## Changes

- Add `/turns up fruitless/i → 'new'` (cycle-order first) with an explanatory comment.
- Rewrite the phase-map "new" comment and add a v4.5.3 history entry correcting v4.5.2.
- Bump to **v4.5.3** (constant + header).
- Spec: add the new mapping to the known-wordings example; update the former "fruitless → nil" test to assert it now maps to new.

## Testing

- `bundle exec rspec spec/moonwatch_spec.rb` → 162 examples, 0 failures
- `bundle exec rubocop moonwatch.lic spec/moonwatch_spec.rb` → no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)