### PR TITLE
[combat-trainer] Target dead-body dissect/pray by creature id

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1100,8 +1100,13 @@ class LootProcess
     waitrt?
     return if Flags['using-corpse']
 
-    if (Time.now - @last_rites_timer > 600) && @last_rites && game_state.blessed_room
-      DRC.bput("pray #{DRRoom.dead_npcs.first}", 'You beseech your god for mercy', 'You pray fervently', 'You continue praying for guidance', 'Quietly touching your lips with the tips of your fingers', 'murmur a brief prayer for')
+    # Target the specific dead body by its stable <crtrStatus> id, not the bare
+    # DRRoom.dead_npcs noun -- with a live same-noun mob in the room the noun can
+    # bind to the living creature. DRRoom.dead_npcs still gates presence above.
+    corpse = Lich::DragonRealms::Creature.in_room(:dead).first
+
+    if corpse && (Time.now - @last_rites_timer > 600) && @last_rites && game_state.blessed_room
+      DRC.bput("pray ##{corpse.id}", 'You beseech your god for mercy', 'You pray fervently', 'You continue praying for guidance', 'Quietly touching your lips with the tips of your fingers', 'murmur a brief prayer for')
       waitrt?
       fput "recite Meraud, power the holy fires that unleash my righteous vengeance;Chadatru, guide my sword to swing in justice;Everild, give me the power to conquer my enemies;Truffenyi, let me not lose sight of compassion and mercy;Else, I will become like those I despise;Urrem'tier, receive into your fetid grasp these wicked souls;May the Tamsine's realms never know their evil ways again;May all the Immortals guide your faithful soldier #{checkname}."
       waitrt?
@@ -1111,8 +1116,8 @@ class LootProcess
 
     game_state.sheath_whirlwind_offhand
 
-    echo("DRRoom.dead_npcs.first is: #{DRRoom.dead_npcs.first}") if $debug_mode_ct
-    skin_or_dissect(DRRoom.dead_npcs.first, game_state) if check_rituals?(game_state)
+    echo("corpse: #{corpse&.name || corpse&.noun} (##{corpse&.id})") if $debug_mode_ct
+    skin_or_dissect(corpse, game_state) if corpse && check_rituals?(game_state)
 
     game_state.wield_whirlwind_offhand
 
@@ -1152,7 +1157,8 @@ class LootProcess
     end
   end
 
-  def skin_or_dissect(mob_noun, game_state)
+  def skin_or_dissect(corpse, game_state)
+    mob_noun = corpse&.noun
     return unless (game_state.dissectable?(mob_noun) || game_state.skinnable?(mob_noun))
     return unless (@dissect || @skin)
 
@@ -1171,7 +1177,7 @@ class LootProcess
       end
 
       if skill_to_train == 'First Aid' || skill_to_train == 'Thanatology'
-        unless dissected?(mob_noun, game_state)
+        unless dissected?(corpse, game_state)
           arrange_mob(mob_noun, game_state) unless already_arranged
           check_skinning(mob_noun, game_state) if @skin
         end
@@ -1187,7 +1193,8 @@ class LootProcess
     end
   end
 
-  def dissected?(mob_noun, game_state)
+  def dissected?(corpse, game_state)
+    mob_noun = corpse&.noun
     return unless game_state.dissectable?(mob_noun)
 
     if @dissect_for_thanatology
@@ -1196,7 +1203,10 @@ class LootProcess
       return false if DRSkill.getxp('First Aid') == 34
     end
 
-    case DRC.bput("dissect #{mob_noun}",
+    # Address the specific corpse by id; a nil corpse (the retry below) falls back
+    # to a bare `dissect` on the game's current corpse, as before.
+    dissect_command = corpse ? "dissect ##{corpse.id}" : 'dissect'
+    case DRC.bput(dissect_command,
                   /You'll gain no insights from this attempt/,
                   /You succeed in dissecting the corpse/,
                   'What exactly are you trying to dissect',
@@ -1224,17 +1234,17 @@ class LootProcess
     when 'This ritual may only be performed on a corpse', 'A failed or completed ritual has rendered', 'You realize after a few seconds', 'prevents a meaningful dissection'
       return false
     when 'Rituals do not work upon constructs'
-      game_state.construct(mob_noun)
-      game_state.undissectable(mob_noun)
+      game_state.construct(mob_noun) if mob_noun
+      game_state.undissectable(mob_noun) if mob_noun
       return false
     when 'While likely a fascinating study', "That'd be a waste of time.", 'You do not yet possess the knowledge'
-      game_state.undissectable(mob_noun)
+      game_state.undissectable(mob_noun) if mob_noun
       @dissect_cycle_skills.delete("First Aid")
       @dissect_cycle_skills.delete("Thanatology") if @dissect_for_thanatology
       @dissect = false
       return false
     when 'would probably object', "should be left alone."
-      return dissected?('', game_state)
+      return dissected?(nil, game_state)
     end
     return false
   end

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -6257,3 +6257,119 @@ RSpec.describe LootProcess do
     end
   end
 end
+
+# ===================================================================
+# LootProcess -- dead-body targeting by creature id (non-necro path)
+#
+# `dissect` and last-rites `pray` used to interpolate the bare noun from
+# DRRoom.dead_npcs, which can bind to a LIVE same-noun mob that wandered
+# in between the kill and the dissect (dissect then fails on the living
+# creature). They now address the specific dead body by its stable
+# <crtrStatus> id, selected from Creature.in_room(:dead).
+# ===================================================================
+RSpec.describe LootProcess do
+  before(:each) do
+    ct_setup
+    allow(DRC).to receive(:message)
+  end
+
+  let(:corpse) { OpenStruct.new(id: 111, noun: 'rat', name: 'a giant rat') }
+
+  def dissect_game_state
+    state = double('GameState')
+    allow(state).to receive(:dissectable?).and_return(true)
+    allow(state).to receive(:construct)
+    allow(state).to receive(:undissectable)
+    state
+  end
+
+  def build_dissect_loot(**overrides)
+    lp = LootProcess.allocate
+    defaults = { dissect: true, skin: false, dissect_for_thanatology: false, dissect_cycle_skills: [] }
+    defaults.merge(overrides).each { |k, v| lp.instance_variable_set(:"@#{k}", v) }
+    lp
+  end
+
+  describe '#dissected?' do
+    before(:each) { allow(DRSkill).to receive(:getxp).and_return(0) }
+
+    it 'addresses the corpse by id, never by noun' do
+      allow(DRC).to receive(:bput).and_return('You succeed in dissecting the corpse')
+      build_dissect_loot.send(:dissected?, corpse, dissect_game_state)
+      expect(DRC).to have_received(:bput).with('dissect #111', any_args)
+      expect(DRC).not_to have_received(:bput).with('dissect rat', any_args)
+    end
+
+    it 'falls back to a bare dissect for the nil-corpse retry' do
+      allow(DRC).to receive(:bput).and_return('You succeed in dissecting the corpse')
+      build_dissect_loot.send(:dissected?, nil, dissect_game_state)
+      expect(DRC).to have_received(:bput).with('dissect', any_args)
+    end
+
+    it 'retries with a bare dissect when the corpse "would probably object"' do
+      responses = ['would probably object', 'You succeed in dissecting the corpse']
+      allow(DRC).to receive(:bput) { responses.shift }
+      build_dissect_loot.send(:dissected?, corpse, dissect_game_state)
+      expect(DRC).to have_received(:bput).with('dissect #111', any_args)
+      expect(DRC).to have_received(:bput).with('dissect', any_args)
+    end
+
+    it 'marks a construct by noun when rituals do not work on it' do
+      allow(DRC).to receive(:bput).and_return('Rituals do not work upon constructs')
+      gs = dissect_game_state
+      expect(gs).to receive(:construct).with('rat')
+      expect(gs).to receive(:undissectable).with('rat')
+      build_dissect_loot.send(:dissected?, corpse, gs)
+    end
+
+    # name-less crtrStatus window: id present, noun not yet. We still dissect by
+    # id, and never pollute the species memory with a nil noun.
+    it 'does not construct-mark a nil-noun corpse' do
+      allow(DRC).to receive(:bput).and_return('Rituals do not work upon constructs')
+      nameless = OpenStruct.new(id: 55, noun: nil, name: nil)
+      gs = dissect_game_state
+      build_dissect_loot.send(:dissected?, nameless, gs)
+      expect(DRC).to have_received(:bput).with('dissect #55', any_args)
+      expect(gs).not_to have_received(:construct)
+      expect(gs).not_to have_received(:undissectable)
+    end
+  end
+
+  def build_dispose_loot(**overrides)
+    lp = LootProcess.allocate
+    defaults = {
+      loot_bodies: true, loot_timer: Time.now - 100, loot_delay: 0,
+      last_rites: true, last_rites_timer: Time.now - 700, custom_loot_type: ''
+    }
+    defaults.merge(overrides).each { |k, v| lp.instance_variable_set(:"@#{k}", v) }
+    lp
+  end
+
+  describe '#dispose_body' do
+    it 'prays over the corpse by id for last rites' do
+      DRRoom.dead_npcs = ['rat']
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('You pray fervently')
+      gs = double('GameState', blessed_room: true)
+      allow(gs).to receive(:mob_died=)
+      build_dispose_loot.dispose_body(gs)
+      expect(DRC).to have_received(:bput).with('pray #111', any_args)
+    end
+
+    # DRRoom says a body is present, but no id is available yet (roster divergence
+    # / name-less window). We must NOT fall back to the noun -- that reintroduces
+    # the live/dead collision -- so we skip dead-body actions this tick.
+    it 'skips pray/dissect when no corpse id is available' do
+      DRRoom.dead_npcs = ['rat']
+      Lich::DragonRealms::Creature._set_room([])
+      allow(DRC).to receive(:bput).and_return('Roundtime')
+      gs = double('GameState', blessed_room: true, necro_casting?: false)
+      allow(gs).to receive(:mob_died=)
+      allow(gs).to receive(:sheath_whirlwind_offhand)
+      allow(gs).to receive(:wield_whirlwind_offhand)
+      build_dispose_loot.dispose_body(gs)
+      expect(DRC).not_to have_received(:bput).with(/\Apray /, any_args)
+      expect(DRC).not_to have_received(:bput).with(/\Adissect/, any_args)
+    end
+  end
+end


### PR DESCRIPTION
## What

Migrate the non-necromancer dead-body path — last-rites `pray` and `dissect` — from
the bare `DRRoom.dead_npcs` noun to the specific corpse's stable `<crtrStatus>` id,
selected from `Creature.in_room(:dead).first`.

## Why

`dissect <noun>` / `pray <noun>` resolve the noun **live, at command time**. With a
live same-noun mob in the room — e.g. a fresh kobold wanders in after you kill one —
the command can bind to the **living** creature, and dissect (corpse-only) then
fails, leaving the corpse unprocessed. `DRRoom.dead_npcs` also can't identify *which*
of several same-noun corpses is which (its living/dead noun lists are ordinalized
independently). Only stable ids can. This mirrors the necromancer ritual path, which
already targets `perform ... on #<id>`.

## Details

- `dispose_body` selects the corpse once and threads it through
  `skin_or_dissect` → `dissected?`; `pray`/`dissect` now use `#<id>`.
- If no corpse id is available (roster divergence / name-less `<crtrStatus>` window)
  we **skip** dead-body actions this tick rather than fall back to the noun — a noun
  fallback would reintroduce the exact live/dead collision.
- Species memory (`@no_dissect` / `@constructs`) stays **noun-keyed** and nil-guarded.
- `DRRoom.dead_npcs` presence/count gates, and the nounless `skin` / `arrange for
  <type>` verbs, are intentionally left unchanged.

## Scope

Part of the incremental `DRRoom` → `Creature` migration for combat-trainer.
Independent of the manipulation-by-id change (#7573) — lands/reverts on its own.

## Testing

- Full RSpec suite green: 3120 examples, 0 failures.
- `rubocop -A` clean on the changed `.lic`.
- New specs cover: `dissect #<id>` targeting (never the noun), the bare-`dissect`
  nil-corpse retry, the "would probably object" recursion, noun-keyed construct
  marking, the name-less-window (nil noun) case, `pray #<id>` last rites, and the
  skip-when-no-id path (no noun fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)