### PR TITLE
[combat-trainer] Target offensive-spell target_enemy by creature id

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -2562,7 +2562,7 @@ class SpellProcess
     echo "Figuring out ready offensive spells..." if $debug_mode_ct
     ready_spells = @offensive_spells.select do |spell|
       next false if spell_disabled?(spell['abbrev'])
-      next false if spell['target_enemy'] && !game_state.npcs.include?(spell['target_enemy'])
+      next false if spell['target_enemy'] && Lich::DragonRealms::Creature.targets.none? { |c| c.noun == spell['target_enemy'] }
       next false if spell['min_threshold'] && game_state.npcs.length < spell['min_threshold']
       next false if spell['max_threshold'] && game_state.npcs.length > spell['max_threshold']
       next false if spell['expire'] && !Flags["ct-#{spell['abbrev']}"]
@@ -2658,7 +2658,8 @@ class SpellProcess
     echo("prepare spell: #{data}") if $debug_mode_ct
     if data['target_enemy']
       echo("  Target found: #{data['target_enemy']}") if $debug_mode_ct
-      fput("face #{data['target_enemy']}")
+      se_target = Lich::DragonRealms::Creature.targets.find { |c| c.noun == data['target_enemy'] }
+      fput(se_target ? "face ##{se_target.id}" : "face #{data['target_enemy']}")
     end
 
     command = 'prep'

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -3881,6 +3881,101 @@ RSpec.describe SpellProcess do
   end
 
   # ===========================================================================
+  # target_enemy -> live-creature migration. An offensive spell's configured
+  # target_enemy stays a NOUN in config (ids are not stable across hunts), but at
+  # runtime we resolve that noun to a LIVE + HOSTILE Lich::DragonRealms::Creature
+  # and face it by #<id>, falling back to the noun when no live creature matches
+  # (e.g. the name-less crtrStatus window). This branch's harness Creature stub
+  # has no `targets`, so it is stubbed per-example (verify_partial_doubles is off).
+  # ===========================================================================
+  describe 'target_enemy live-creature targeting' do
+    def build_prep_state(**attrs)
+      gs = GameState.allocate
+      { casting: false, cast_timer: nil }.merge(attrs).each { |k, v| gs.send(:"#{k}=", v) }
+      gs
+    end
+
+    describe '#prepare_spell' do
+      before(:each) do
+        # prepare_spell continues into DRCA.prepare? after facing; stop it there
+        # so these examples isolate the face command.
+        allow(DRCA).to receive(:prepare?).and_return(false)
+      end
+
+      it 'faces the live creature by id (#111) when a matching noun is on the roster' do
+        allow(Lich::DragonRealms::Creature).to receive(:targets)
+          .and_return([OpenStruct.new(id: 111, noun: 'kobold', name: 'a kobold')])
+
+        instance = build_spell_process
+        allow(instance).to receive(:fput)
+        gs = build_prep_state
+        data = { 'abbrev' => 'FIRE', 'name' => 'Fire Spirit', 'mana' => 3, 'target_enemy' => 'kobold' }
+
+        instance.send(:prepare_spell, data, gs)
+
+        expect(instance).to have_received(:fput).with('face #111')
+        expect(instance).not_to have_received(:fput).with('face kobold')
+      end
+
+      it 'falls back to the configured noun when no live creature matches' do
+        allow(Lich::DragonRealms::Creature).to receive(:targets).and_return([])
+
+        instance = build_spell_process
+        allow(instance).to receive(:fput)
+        gs = build_prep_state
+        data = { 'abbrev' => 'FIRE', 'name' => 'Fire Spirit', 'mana' => 3, 'target_enemy' => 'kobold' }
+
+        instance.send(:prepare_spell, data, gs)
+
+        expect(instance).to have_received(:fput).with('face kobold')
+      end
+    end
+
+    describe '#check_offensive selection gate' do
+      def build_offensive_state
+        double('GameState', casting: false, npcs: ['a kobold'],
+                            is_offense_allowed?: true, dancing?: false,
+                            sort_by_rate_then_rank: ['Warding'])
+      end
+
+      let(:target_enemy_spell) do
+        { 'abbrev' => 'FIRE', 'name' => 'Fire Spirit', 'skill' => 'Warding', 'target_enemy' => 'kobold' }
+      end
+
+      def build_target_enemy_process
+        build_spell_process(
+          offensive_spells: [target_enemy_spell],
+          offensive_spell_cycle: [],
+          offensive_spell_mana_threshold: 0
+        )
+      end
+
+      it 'rejects the spell when no live creature matches the configured noun' do
+        DRStats.mana = 100
+        allow(Lich::DragonRealms::Creature).to receive(:targets).and_return([])
+
+        instance = build_target_enemy_process
+        gs = build_offensive_state
+
+        expect(instance).not_to receive(:prepare_spell)
+        instance.send(:check_offensive, gs)
+      end
+
+      it 'keeps the spell when a live creature matches the configured noun' do
+        DRStats.mana = 100
+        allow(Lich::DragonRealms::Creature).to receive(:targets)
+          .and_return([OpenStruct.new(id: 111, noun: 'kobold', name: 'a kobold')])
+
+        instance = build_target_enemy_process
+        gs = build_offensive_state
+
+        expect(instance).to receive(:prepare_spell).with(hash_including('target_enemy' => 'kobold'), gs)
+        instance.send(:check_offensive, gs)
+      end
+    end
+  end
+
+  # ===========================================================================
   # #spell_disabled? / #disable_spell -- boundary and edge behavior
   # ===========================================================================
   describe '#disable_spell / #spell_disabled?' do


### PR DESCRIPTION
## What

Migrate `SpellProcess`'s offensive-spell `target_enemy` handling from a DRRoom noun to a **live** `Lich::DragonRealms::Creature` id.

- **Selection gate** (`check_offensive`): the spell is now only considered ready when a live + hostile creature whose `noun` matches the configured `target_enemy` is actually on the roster (`Creature.targets` already filters `!dead` and hostile), instead of consulting the shared `game_state.npcs` roster.
- **Facing** (`prepare_spell`): resolves the configured noun to a live creature at runtime and faces it by `#<id>` (DR verbs accept `#<id>` targeting), so the spell reliably targets a live enemy rather than a room noun that may collide with corpses or other same-noun mobs.

## Why config stays noun-based

Creature ids are not stable across hunts, so the config `target_enemy` remains a **noun**. It is resolved to a live id at runtime via `Creature.targets.find { |c| c.noun == target_enemy }`. When no live creature matches (e.g. the name-less `crtrStatus` window), we **fall back to the noun** in the `face` command — safe, since facing only hits live creatures.

## Scope

This is one small, independent unit of the incremental DRRoom -> Creature targeting migration. It is a migration, not a bug fix: behavior is preserved, only the target is swapped. The shared count/roster layer (`game_state.npcs`, `update_room_npcs`) is untouched.

## Tests

Added a focused `SpellProcess` describe block covering: (1) `prepare_spell` faces `#111` (not `face kobold`) when a live kobold exists; (2) noun fallback `face kobold` when `Creature.targets` is empty; (3) the selection gate rejects the spell when no live target matches the configured noun and keeps it when one does.

`bundle exec rspec`: 3117 examples, 0 failures. `rubocop -A combat-trainer.lic`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)