### PR TITLE
[combat-trainer] Target Recall ability by creature id

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3733,7 +3733,8 @@ class TrainerProcess
     when /^PrayerMat$/i
       pray_mat(game_state)
     when /^Recall$/i
-      DRC.bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied', 'You search your mind') unless game_state.npcs.empty?
+      recall_target = Lich::DragonRealms::Creature.targets.first
+      DRC.bput("recall ##{recall_target.id}", 'Roundtime', 'You are far too occupied', 'You search your mind') if recall_target
     when /^Barb Research Augmentation$/i
       DRC.bput('meditate research monkey', /^You clear your mind and begin to meditate/, /^What did you want to research/)
     when /^Barb Research Warding$/i

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -4847,6 +4847,47 @@ RSpec.describe TrainerProcess do
 end
 
 # ===================================================================
+# TrainerProcess -- Recall ability (DRRoom->Creature migration)
+#
+# The Recall ability now targets a LIVE hostile creature by id
+# (recall #<id>) via Lich::DragonRealms::Creature.targets, instead of
+# an arbitrary DRRoom noun from game_state.npcs. Driven through
+# #execute with select_ability stubbed to 'Recall', the same way the
+# dispatch fires at runtime.
+# ===================================================================
+RSpec.describe 'TrainerProcess#execute Recall' do
+  before(:each) { ct_setup }
+
+  def build_trainer
+    trainer = TrainerProcess.allocate
+    allow(trainer).to receive(:waitrt?)
+    allow(trainer).to receive(:select_ability).and_return('Recall')
+    trainer
+  end
+
+  it 'recalls the live hostile target by id, not by DRRoom noun' do
+    allow(Lich::DragonRealms::Creature).to receive(:targets)
+      .and_return([OpenStruct.new(id: 333, noun: 'goblin', name: 'a goblin')])
+    allow(DRC).to receive(:bput)
+
+    build_trainer.execute(double('GameState', danger: false))
+
+    expect(DRC).to have_received(:bput)
+      .with('recall #333', 'Roundtime', 'You are far too occupied', 'You search your mind')
+    expect(DRC).not_to have_received(:bput).with('recall goblin', any_args)
+  end
+
+  it 'issues no recall when there are no live targets' do
+    allow(Lich::DragonRealms::Creature).to receive(:targets).and_return([])
+    allow(DRC).to receive(:bput)
+
+    build_trainer.execute(double('GameState', danger: false))
+
+    expect(DRC).not_to have_received(:bput)
+  end
+end
+
+# ===================================================================
 # Summoned-weapon-aware store/restore (Issue 1 regression)
 #
 # A moon mage (or warrior mage) trains with a SUMMONED weapon whose


### PR DESCRIPTION
## What

Migrates the **Recall** ability in `combat-trainer.lic` from targeting an
arbitrary DRRoom noun to targeting a **live, hostile creature by id**.

Before:
```ruby
DRC.bput("recall #{game_state.npcs.first}", 'Roundtime', 'You are far too occupied', 'You search your mind') unless game_state.npcs.empty?
```

After:
```ruby
recall_target = Lich::DragonRealms::Creature.targets.first
DRC.bput("recall ##{recall_target.id}", 'Roundtime', 'You are far too occupied', 'You search your mind') if recall_target
```

`Creature.targets` returns live + hostile creatures, and DR accepts
`recall #<id>`, so the command now resolves to a real live target rather
than an ambiguous room noun (which could match a corpse or the wrong mob).

## Why

This is one independent unit of the incremental DRRoom -> Creature
targeting migration. It is a behavior-preserving migration, not a bug fix:
the bput matchers are identical; only the target selection changes from a
DRRoom noun to a live-creature id. No shared count/roster layer or
`test/test_harness.rb` was touched.

## Tests

Added two specs (spec/combat_trainer_spec.rb) driving `TrainerProcess#execute`
with the Recall dispatch:
- issues `recall #333` (not `recall goblin`) when a live target exists
- issues no recall when `Creature.targets` is empty

`bundle exec rspec`: 3115 examples, 0 failures.
`RBENV_VERSION=4.0.1 bundle exec rubocop -A combat-trainer.lic`: no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)