### PR TITLE
[combat-trainer] Target appraise (app) by creature id

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -4014,14 +4014,13 @@ class TrainerProcess
 
   def appraise(game_state, modifier)
     return if game_state.retreating?
-    return if game_state.npcs.empty?
 
-    target = (game_state.npcs - @no_app).first
+    target = Lich::DragonRealms::Creature.targets.find { |c| !@no_app.include?(c.id) }
     return unless target
     return if DRSkill.getrank('Appraisal') < 76
-    return if DRC.bput("app #{target} #{modifier}", 'Taking stock of', 'It\'s dead', 'You can\'t determine anything about this creature.', 'I could not find', 'You cannot appraise that', 'roundtime', '^Perhaps that', 'Appraise what') != 'Perhaps that'
+    return if DRC.bput("app ##{target.id} #{modifier}", 'Taking stock of', 'It\'s dead', 'You can\'t determine anything about this creature.', 'I could not find', 'You cannot appraise that', 'roundtime', '^Perhaps that', 'Appraise what') != 'Perhaps that'
 
-    @no_app << target
+    @no_app << target.id
   end
 
   def moon_mage_perc(game_state)

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -5007,6 +5007,78 @@ RSpec.describe 'GameState summoned-weapon store/restore' do
       expect(gs).to have_received(:prepare_summoned_weapon).with(false)
     end
   end
+
+  # -----------------------------------------------------------------
+  # #appraise -- targets live creatures by id (Creature migration)
+  #
+  # appraise now walks Lich::DragonRealms::Creature.targets (live +
+  # hostile) and issues `app #<id> <modifier>`, keying the "already
+  # appraised" memory (@no_app) on the creature id instead of the noun.
+  # Verify the id-based command, the id-keyed dedup, and the rank gate.
+  # -----------------------------------------------------------------
+  describe '#appraise' do
+    def build_appraiser(no_app: [])
+      trainer = TrainerProcess.allocate
+      trainer.instance_variable_set(:@no_app, no_app)
+      trainer
+    end
+
+    def appraise_state(retreating: false)
+      double('GameState', retreating?: retreating)
+    end
+
+    before(:each) do
+      allow(DRSkill).to receive(:getrank).with('Appraisal').and_return(100)
+    end
+
+    it 'issues `app #<id>` for the live creature, not `app <noun>`' do
+      allow(Lich::DragonRealms::Creature).to receive(:targets)
+        .and_return([OpenStruct.new(id: 444, noun: 'troll', name: 'a troll')])
+      allow(DRC).to receive(:bput).and_return('Perhaps that')
+
+      build_appraiser.send(:appraise, appraise_state, 'value')
+
+      expect(DRC).to have_received(:bput).with('app #444 value', any_args)
+      expect(DRC).not_to have_received(:bput).with('app troll value', any_args)
+    end
+
+    it 'records the id on a `Perhaps that` response and skips it next call' do
+      allow(Lich::DragonRealms::Creature).to receive(:targets)
+        .and_return([OpenStruct.new(id: 444, noun: 'troll', name: 'a troll')])
+      allow(DRC).to receive(:bput).and_return('Perhaps that')
+
+      trainer = build_appraiser
+      trainer.send(:appraise, appraise_state, 'value')
+      expect(trainer.instance_variable_get(:@no_app)).to eq([444])
+
+      # Only the one live target remains and it is already appraised -> no bput.
+      trainer.send(:appraise, appraise_state, 'value')
+      expect(DRC).to have_received(:bput).once
+    end
+
+    it 'appraises the next live target when the first id is already recorded' do
+      allow(Lich::DragonRealms::Creature).to receive(:targets).and_return([
+        OpenStruct.new(id: 444, noun: 'troll', name: 'a troll'),
+        OpenStruct.new(id: 555, noun: 'ogre', name: 'an ogre')
+      ])
+      allow(DRC).to receive(:bput).and_return('Perhaps that')
+
+      build_appraiser(no_app: [444]).send(:appraise, appraise_state, 'value')
+
+      expect(DRC).to have_received(:bput).with('app #555 value', any_args)
+    end
+
+    it 'does not appraise when Appraisal rank is below 76' do
+      allow(DRSkill).to receive(:getrank).with('Appraisal').and_return(75)
+      allow(Lich::DragonRealms::Creature).to receive(:targets)
+        .and_return([OpenStruct.new(id: 444, noun: 'troll', name: 'a troll')])
+      allow(DRC).to receive(:bput)
+
+      build_appraiser.send(:appraise, appraise_state, 'value')
+
+      expect(DRC).not_to have_received(:bput)
+    end
+  end
 end
 
 # ===================================================================


### PR DESCRIPTION
## What

Migrates `TrainerProcess#appraise` from DRRoom noun targeting to live-creature id targeting, one independent unit of the ongoing DRRoom→Creature migration.

## Why

`Lich::DragonRealms::Creature.targets` returns LIVE + HOSTILE creatures, each exposing `.id`, `.noun`, `.name`. DR accepts `app #<id> <modifier>`, so targeting by id is unambiguous where a shared noun (two "troll"s) is not.

## Changes

- `appraise` now selects the first live target whose id is not already appraised: `Creature.targets.find { |c| !@no_app.include?(c.id) }`.
- Issues `app ##{target.id} #{modifier}` instead of `app #{noun} #{modifier}`; the bput matcher list is unchanged.
- `@no_app` now stores creature ids instead of nouns. Side benefit: dedup is per-creature, fixing the old behavior where marking one noun appraised marked ALL same-noun mobs appraised.
- Dropped the now-redundant `return if game_state.npcs.empty?` guard (subsumed by `return unless target`).

Behavior is otherwise preserved (retreating guard, Appraisal rank < 76 gate, and the `Perhaps that` gate on recording the target).

## Tests

Added `#appraise` specs: id-based command (`app #444`, not `app troll`), id-keyed dedup skipping an already-appraised target and appraising the next live one, and the rank < 76 gate. Full suite green; rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)