### PR TITLE
[combat-trainer] Target battle-cry target_enemy by creature id

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3385,7 +3385,7 @@ class AbilityProcess
     Flags.reset('ct-battle-cry-not-facing')
 
     battle_cries = @battle_cries
-                   .select { |battle_cry| battle_cry['target_enemy'] ? game_state.npcs.include?(battle_cry['target_enemy']) : true }
+                   .select { |battle_cry| battle_cry['target_enemy'] ? Lich::DragonRealms::Creature.targets.any? { |c| c.noun == battle_cry['target_enemy'] } : true }
                    .select { |battle_cry| battle_cry['min_threshold'] ? game_state.npcs.length >= battle_cry['min_threshold'] : true }
                    .select { |battle_cry| battle_cry['max_threshold'] ? game_state.npcs.length <= battle_cry['max_threshold'] : true }
 
@@ -3400,7 +3400,10 @@ class AbilityProcess
       echo "Using roar helm: #{@roar_helm_noun}" if @roar_helm_noun && $debug_mode_ct
 
       command = battle_cry_data['command']
-      command = (command + " at " + battle_cry_data['target_enemy']) if battle_cry_data['target_enemy']
+      if battle_cry_data['target_enemy']
+        bc_target = Lich::DragonRealms::Creature.targets.find { |c| c.noun == battle_cry_data['target_enemy'] }
+        command += " at " + (bc_target ? "##{bc_target.id}" : battle_cry_data['target_enemy'])
+      end
 
       # Use roar helm if specified
       fput("scream #{@roar_helm_noun}") if @roar_helm_noun

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -839,6 +839,58 @@ RSpec.describe AbilityProcess do
       expect(gs).not_to have_received(:pounce)
     end
   end
+
+  # -----------------------------------------------------------------
+  # #check_battle_cries -- DRRoom->Creature target migration.
+  # A target_enemy battle cry now resolves its NOUN to a live creature
+  # id (#<id>) at command time, falling back to the noun when no live
+  # match exists. The readiness gate likewise uses live creatures.
+  # -----------------------------------------------------------------
+  describe '#check_battle_cries live-creature targeting' do
+    def build_cry_ability
+      ap = build_ability(
+        battle_cries: [{ 'name' => 'Roar', 'command' => 'roar', 'target_enemy' => 'orc' }],
+        battle_cry_cycle: ['Roar']
+      )
+      allow(ap).to receive(:waitrt?)
+      allow(ap).to receive(:fput)
+      ap
+    end
+
+    it 'targets a live orc by creature id (at #222), not the noun' do
+      allow(Lich::DragonRealms::Creature).to receive(:targets)
+        .and_return([OpenStruct.new(id: 222, noun: 'orc', name: 'an orc')])
+      ap = build_cry_ability
+      ap.send(:check_battle_cries, gs_double)
+      expect(ap).to have_received(:fput).with('roar at #222')
+    end
+
+    # Fallback: the gate saw a live orc, but by command time the creature
+    # is gone (e.g. died, or the name-less window). find returns nil, so
+    # the command falls back to the configured noun.
+    it 'falls back to the noun (at orc) when no live creature matches' do
+      allow(Lich::DragonRealms::Creature).to receive(:targets)
+        .and_return([OpenStruct.new(id: 222, noun: 'orc', name: 'an orc')], [])
+      ap = build_cry_ability
+      ap.send(:check_battle_cries, gs_double)
+      expect(ap).to have_received(:fput).with('roar at orc')
+    end
+
+    it 'gate keeps a target_enemy battle cry when a live match exists' do
+      allow(Lich::DragonRealms::Creature).to receive(:targets)
+        .and_return([OpenStruct.new(id: 222, noun: 'orc', name: 'an orc')])
+      ap = build_cry_ability
+      ap.send(:check_battle_cries, gs_double)
+      expect(ap).to have_received(:fput).with('roar at #222')
+    end
+
+    it 'gate drops a target_enemy battle cry when no live creature matches' do
+      allow(Lich::DragonRealms::Creature).to receive(:targets).and_return([])
+      ap = build_cry_ability
+      ap.send(:check_battle_cries, gs_double)
+      expect(ap).not_to have_received(:fput)
+    end
+  end
 end
 
 # ===================================================================


### PR DESCRIPTION
## What

Migrates the battle-cry `target_enemy` targeting in `AbilityProcess#check_battle_cries` (combat-trainer.lic) from a DRRoom noun to a **live creature id**, as one independent unit of the ongoing DRRoom→Creature targeting migration.

## Why

Noun-based targeting collides when multiple same-noun creatures (or lingering corpses) share a room. `Lich::DragonRealms::Creature.targets` returns LIVE + HOSTILE creatures, and DR accepts `#<id>` in the battle-cry `at` clause, so we can aim at a specific live creature.

## Changes

- **Readiness gate:** now checks `Lich::DragonRealms::Creature.targets.any? { |c| c.noun == target_enemy }` (live + hostile) instead of `game_state.npcs.include?(target_enemy)`.
- **Command:** resolves the configured `target_enemy` NOUN to a live creature id at command time (`... at #<id>`), and **falls back to the noun** (`... at <noun>`) when no live creature matches — e.g. the name-less window, or the creature is gone by command time.

## Migration, not bug-fix

Behavior is preserved: config `target_enemy` stays a noun and is resolved to an id only at runtime. The `min_threshold`/`max_threshold` selects (which use `game_state.npcs.length`) are unchanged. This is an independent, self-contained unit; the shared count/roster layer is untouched.

## Tests

Adds specs to `spec/combat_trainer_spec.rb` covering: id targeting (`at #222`) when a live orc exists, noun fallback (`at orc`) when the creature is gone at command time, and the gate keep/drop behavior. Full suite: 3117 examples, 0 failures. `rubocop -A` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)