### PR TITLE
[script][makesteel] honor use_private_forge setting

### DIFF
--- a/makesteel.lic
+++ b/makesteel.lic
@@ -18,6 +18,9 @@ class MakeSteel
     @settings = get_settings
     @hometown = @settings.force_crafting_town || @settings.hometown
     @stock_room = get_data('crafting')['blacksmithing'][@hometown]['stock-room']
+    @private_forge = get_data('crafting')['blacksmithing'][@hometown]['private_forge']
+    @use_private_forge = @settings.use_private_forge || false
+    validate_private_forge
 
     DRCM.ensure_copper_on_hand(2000 * total_count, @settings, @hometown)
 
@@ -28,7 +31,7 @@ class MakeSteel
 
   def refine
     DRCT.order_item(get_data('crafting')['blacksmithing'][@hometown]['finisher-room'], 9) unless DRCI.exists?('flux')
-    DRCC.find_empty_crucible(@hometown)
+    find_crucible
     DRCI.get_item('steel ingot')
     DRC.bput('put my steel ingot in crucible', /You put your.*in the.*crucible\./)
     DRC.wait_for_script_to_complete('smelt', ['refine'])
@@ -43,7 +46,7 @@ class MakeSteel
       order_stow(2) if type == 'h'
     end
 
-    DRCC.find_empty_crucible(@hometown)
+    find_crucible
 
     multiplier = case type
                  when 'l'
@@ -79,6 +82,28 @@ class MakeSteel
   def order_stow(num)
     DRCT.order_item(@stock_room, num)
     DRCI.stow_item?('nugget')
+  end
+
+  # Ensure the configured hometown actually has a private forge when the
+  # use_private_forge setting is enabled; otherwise there is nowhere to walk to.
+  def validate_private_forge
+    return unless @use_private_forge
+    return if @private_forge
+
+    blacksmithing_data = get_data('crafting')['blacksmithing']
+    towns_with_forges = blacksmithing_data.select { |_town, data| data['private_forge'] }.keys
+    Lich::Messaging.msg('bold', "makesteel: use_private_forge is enabled, but '#{@hometown}' has no private forge.")
+    Lich::Messaging.msg('bold', "makesteel: Towns with private forges: #{towns_with_forges.join(', ')}")
+    Lich::Messaging.msg('bold', 'makesteel: Either set use_private_forge: false, or change hometown/force_crafting_town.')
+    exit
+  end
+
+  # Locate a crucible to work in. When use_private_forge is set we first walk to
+  # the town's private forge so find_empty_crucible's in-room check keeps us
+  # there instead of falling back to the public crucible rooms.
+  def find_crucible
+    DRCT.walk_to(@private_forge) if @use_private_forge
+    DRCC.find_empty_crucible(@hometown)
   end
 end
 

--- a/spec/makesteel_spec.rb
+++ b/spec/makesteel_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+# Load the MakeSteel class (the trailing MakeSteel.new is not executed;
+# load_lic_class extracts only the class body).
+load_lic_class('makesteel.lic', 'MakeSteel')
+
+RSpec.describe MakeSteel do
+  # Build a bare instance and inject the ivars the methods under test read,
+  # rather than driving the full #initialize workflow.
+  def build(hometown:, use_private_forge:, private_forge:)
+    instance = MakeSteel.allocate
+    instance.instance_variable_set(:@hometown, hometown)
+    instance.instance_variable_set(:@use_private_forge, use_private_forge)
+    instance.instance_variable_set(:@private_forge, private_forge)
+    instance
+  end
+
+  before do
+    $test_data[:crafting] = {
+      'blacksmithing' => {
+        'Shard'      => { 'private_forge' => 51_058 },
+        'Crossing'   => { 'private_forge' => 16_936 },
+        'Riverhaven' => {} # no private forge
+      }
+    }
+  end
+
+  describe '#validate_private_forge' do
+    it 'does nothing when use_private_forge is disabled' do
+      instance = build(hometown: 'Riverhaven', use_private_forge: false, private_forge: nil)
+      expect { instance.validate_private_forge }.not_to raise_error
+    end
+
+    it 'does nothing when the hometown has a private forge' do
+      instance = build(hometown: 'Shard', use_private_forge: true, private_forge: 51_058)
+      expect { instance.validate_private_forge }.not_to raise_error
+    end
+
+    it 'exits when enabled but the hometown has no private forge' do
+      instance = build(hometown: 'Riverhaven', use_private_forge: true, private_forge: nil)
+      expect { instance.validate_private_forge }.to raise_error(SystemExit)
+    end
+
+    it 'lists only blacksmithing towns that have a private forge' do
+      allow(Lich::Messaging).to receive(:msg)
+      instance = build(hometown: 'Riverhaven', use_private_forge: true, private_forge: nil)
+      expect { instance.validate_private_forge }.to raise_error(SystemExit)
+      expect(Lich::Messaging).to have_received(:msg)
+        .with('bold', /Towns with private forges: (Shard, Crossing|Crossing, Shard)/)
+    end
+  end
+
+  describe '#find_crucible' do
+    it 'walks to the private forge before locating a crucible when enabled' do
+      instance = build(hometown: 'Shard', use_private_forge: true, private_forge: 51_058)
+      expect(DRCT).to receive(:walk_to).with(51_058).ordered
+      expect(DRCC).to receive(:find_empty_crucible).with('Shard').ordered
+      instance.find_crucible
+    end
+
+    it 'does not walk to a private forge when disabled' do
+      instance = build(hometown: 'Riverhaven', use_private_forge: false, private_forge: nil)
+      expect(DRCT).not_to receive(:walk_to)
+      expect(DRCC).to receive(:find_empty_crucible).with('Riverhaven')
+      instance.find_crucible
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`makesteel` never read the `use_private_forge` setting, so it always fell back to the public crucible rooms even when a private forge was configured for the hometown — unlike `smith`/`forge`, which both honor it. This teaches `makesteel` to use the private forge when enabled.

## What changed

- **`makesteel.lic`**
  - Read `private_forge` (from the town's blacksmithing data) and `use_private_forge` (from settings) in `initialize`.
  - `validate_private_forge` — if `use_private_forge` is on but the active hometown (`force_crafting_town || hometown`) has no `private_forge`, print an error listing the towns that do and `exit`, mirroring `smith.lic`'s existing message.
  - `find_crucible` — when `use_private_forge` is set, `DRCT.walk_to(@private_forge)` first so `DRCC.find_empty_crucible`'s in-room `tap crucible` check keeps us in the private forge instead of walking the public crucible list. Used by both `smelt_ingot` and `refine`.

- **`spec/makesteel_spec.rb`** (new — first spec for this script)
  - Covers the validation exit path (enabled + no forge → `SystemExit`), the no-op cases (disabled, or forge present), that only blacksmithing towns with a forge are listed, and that `find_crucible` walks to the private forge only when enabled.

## Scope notes

- Deliberately does **not** copy `smith.lic`'s rental-renewal logic (`check_and_renew_forge_rental`). That's ~60 lines living only in `smith.lic`; duplicating it into `makesteel` would create a copy-paste invariant. If forge rental-renewal is wanted across crafting scripts, extracting it into the commons layer (lich-5 `DRCC`) is the better follow-up.
- Behavior is unchanged when `use_private_forge` is unset/false.

## Testing

- `bundle exec rspec` — full suite green (3119 examples, 0 failures).
- `rubocop -A` — clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)