### PR TITLE
[script][smith][forge][makesteel] normalize private-forge settings

### DIFF
--- a/forge.lic
+++ b/forge.lic
@@ -303,10 +303,6 @@ class Forge
 
   # @!group Private Forge Constants
 
-  # Default cost for private forge rental in copper
-  # @return [Integer]
-  DEFAULT_PRIVATE_FORGE_COST = 5000
-
   # Patterns for successful private forge entry
   # @return [Array<String>]
   PRIVATE_FORGE_ENTRY_SUCCESS = ['You head through', 'You walk', 'You go', 'Obvious exits'].freeze
@@ -404,7 +400,7 @@ class Forge
   # @return [void]
   def load_settings(args)
     settings = get_settings
-    @hometown = settings.hometown
+    @hometown = crafting_hometown(settings)
     @stamp = settings.mark_crafted_goods
     @cube = settings.cube_armor_piece
     @bag = settings.crafting_container
@@ -422,10 +418,34 @@ class Forge
     @metal = args.metal
     @next_spin = Time.now
     @debug = args.debug || settings.debug_mode
-    @use_private_forge = settings.forge_use_private_forge
-    @private_forge_cost = settings.forge_private_forge_cost || DEFAULT_PRIVATE_FORGE_COST
+    @use_private_forge = use_private_forge?(settings)
+    @private_forge_cost = private_forge_cost(settings)
     @show_progress = settings.forge_show_progress
     @settings = settings
+  end
+
+  # --- Private-forge helpers (normalized across smith/forge/makesteel). --------
+  # Prefer the shared DRCC helpers (lich-5 #1560); fall back to a local copy so
+  # the script keeps working on an older lich-5. The fallbacks can be deleted
+  # once DRCC ships these methods everywhere. (forge keeps its own richer
+  # go_to_private_forge navigation; only the settings resolution is shared.)
+
+  def crafting_hometown(settings)
+    return DRCC.crafting_hometown(settings) if DRCC.respond_to?(:crafting_hometown)
+
+    settings.force_crafting_town || settings.hometown
+  end
+
+  def use_private_forge?(settings)
+    return DRCC.use_private_forge?(settings) if DRCC.respond_to?(:use_private_forge?)
+
+    settings.use_private_forge || settings.forge_use_private_forge || false
+  end
+
+  def private_forge_cost(settings)
+    return DRCC.private_forge_cost(settings) if DRCC.respond_to?(:private_forge_cost)
+
+    settings.forge_private_forge_cost || 50_000
   end
 
   # Validate required settings and preconditions.

--- a/makesteel.lic
+++ b/makesteel.lic
@@ -16,10 +16,10 @@ class MakeSteel
     total_count = args.count.to_i
     type = args.type || 'h'
     @settings = get_settings
-    @hometown = @settings.force_crafting_town || @settings.hometown
+    @hometown = crafting_hometown(@settings)
     @stock_room = get_data('crafting')['blacksmithing'][@hometown]['stock-room']
-    @private_forge = get_data('crafting')['blacksmithing'][@hometown]['private_forge']
-    @use_private_forge = @settings.use_private_forge || false
+    @private_forge = private_forge_room(@hometown)
+    @use_private_forge = use_private_forge?(@settings)
     validate_private_forge
 
     DRCM.ensure_copper_on_hand(2000 * total_count, @settings, @hometown)
@@ -90,20 +90,64 @@ class MakeSteel
     return unless @use_private_forge
     return if @private_forge
 
-    blacksmithing_data = get_data('crafting')['blacksmithing']
-    towns_with_forges = blacksmithing_data.select { |_town, data| data['private_forge'] }.keys
     Lich::Messaging.msg('bold', "makesteel: use_private_forge is enabled, but '#{@hometown}' has no private forge.")
-    Lich::Messaging.msg('bold', "makesteel: Towns with private forges: #{towns_with_forges.join(', ')}")
+    Lich::Messaging.msg('bold', "makesteel: Towns with private forges: #{towns_with_private_forge.join(', ')}")
     Lich::Messaging.msg('bold', 'makesteel: Either set use_private_forge: false, or change hometown/force_crafting_town.')
     exit
   end
 
-  # Locate a crucible to work in. When use_private_forge is set we first walk to
+  # Locate a crucible to work in. When use_private_forge is set we first travel to
   # the town's private forge so find_empty_crucible's in-room check keeps us
   # there instead of falling back to the public crucible rooms.
   def find_crucible
-    DRCT.walk_to(@private_forge) if @use_private_forge
+    go_to_private_forge(@hometown, @settings) if @use_private_forge
     DRCC.find_empty_crucible(@hometown)
+  end
+
+  # --- Private-forge helpers (normalized across smith/forge/makesteel). --------
+  # Prefer the shared DRCC helpers (lich-5 #1560); fall back to a local copy so
+  # the script keeps working on an older lich-5. The fallbacks can be deleted
+  # once DRCC ships these methods everywhere.
+
+  def crafting_hometown(settings)
+    return DRCC.crafting_hometown(settings) if DRCC.respond_to?(:crafting_hometown)
+
+    settings.force_crafting_town || settings.hometown
+  end
+
+  def use_private_forge?(settings)
+    return DRCC.use_private_forge?(settings) if DRCC.respond_to?(:use_private_forge?)
+
+    settings.use_private_forge || settings.forge_use_private_forge || false
+  end
+
+  def private_forge_cost(settings)
+    return DRCC.private_forge_cost(settings) if DRCC.respond_to?(:private_forge_cost)
+
+    settings.forge_private_forge_cost || 50_000
+  end
+
+  def private_forge_room(hometown)
+    return DRCC.private_forge_room(hometown) if DRCC.respond_to?(:private_forge_room)
+
+    get_data('crafting')['blacksmithing'][hometown]['private_forge']
+  end
+
+  def towns_with_private_forge
+    return DRCC.towns_with_private_forge if DRCC.respond_to?(:towns_with_private_forge)
+
+    get_data('crafting')['blacksmithing'].select { |_town, data| data['private_forge'] }.keys
+  end
+
+  def go_to_private_forge(hometown, settings)
+    return DRCC.go_to_private_forge(hometown, settings) if DRCC.respond_to?(:go_to_private_forge)
+
+    room = private_forge_room(hometown)
+    return false unless room
+    return false unless DRCM.ensure_copper_on_hand(private_forge_cost(settings), settings, hometown)
+
+    DRCT.walk_to(room)
+    Room.current.id == room
   end
 end
 

--- a/smith.lic
+++ b/smith.lic
@@ -26,7 +26,7 @@ class Smith
     args = parse_args(arg_definitions)
 
     @settings = get_settings
-    @hometown = @settings.force_crafting_town || @settings.hometown
+    @hometown = crafting_hometown(@settings)
     @bag = @settings.crafting_container
     @bag_items = @settings.crafting_items_in_container
     @belt = @settings.forging_belt
@@ -37,21 +37,18 @@ class Smith
     recipes = get_data('recipes').crafting_recipes.select { |recipe| recipe['type'] =~ /blacksmithing|weaponsmithing|armorsmithing/i }
     recipe = DRCC.recipe_lookup(recipes, args.item_name)
     # Private forge setting - defaults to false
-    blacksmithing_data = get_data('crafting')['blacksmithing']
-    @private_forge = blacksmithing_data[@hometown]['private_forge']
-    @use_private_forge = @settings.use_private_forge || false
+    @private_forge = private_forge_room(@hometown)
+    @use_private_forge = use_private_forge?(@settings)
 
     if @use_private_forge && !@private_forge
-      towns_with_forges = blacksmithing_data.select { |_town, data| data['private_forge'] }.keys
       Lich::Messaging.msg('bold', "smith: use_private_forge is enabled, but '#{@hometown}' has no private forge.")
-      Lich::Messaging.msg('bold', "smith: Towns with private forges: #{towns_with_forges.join(', ')}")
+      Lich::Messaging.msg('bold', "smith: Towns with private forges: #{towns_with_private_forge.join(', ')}")
       Lich::Messaging.msg('bold', "smith: Either set use_private_forge: false, or change hometown/force_crafting_town.")
       exit
     end
     return unless recipe
 
     DRCM.ensure_copper_on_hand(3000, @settings, @hometown) unless args.here
-    DRCM.ensure_copper_on_hand(50_000, @settings, @hometown) if @use_private_forge
 
     parts = recipe['part'] || []
     parts << "leather strip" if args.reinforce # adds part to the list for reinforce
@@ -69,7 +66,7 @@ class Smith
     buy_parts(parts) unless stay
     buy_ingot(discipline) if buy
     if @use_private_forge && !stay
-      DRCT.walk_to(@private_forge)
+      go_to_private_forge(@hometown, @settings)
       check_and_renew_forge_rental
     elsif @use_private_forge && stay
       Lich::Messaging.msg('plain', "smith: Using 'here' -- skipping private forge walk and rental check.")
@@ -190,6 +187,52 @@ class Smith
     rescue StandardError => e
       Lich::Messaging.msg('bold', "smith: Error parsing expiration time '#{expiration_str}': #{e.message}")
     end
+  end
+
+  # --- Private-forge helpers (normalized across smith/forge/makesteel). --------
+  # Prefer the shared DRCC helpers (lich-5 #1560); fall back to a local copy so
+  # the script keeps working on an older lich-5. The fallbacks can be deleted
+  # once DRCC ships these methods everywhere.
+
+  def crafting_hometown(settings)
+    return DRCC.crafting_hometown(settings) if DRCC.respond_to?(:crafting_hometown)
+
+    settings.force_crafting_town || settings.hometown
+  end
+
+  def use_private_forge?(settings)
+    return DRCC.use_private_forge?(settings) if DRCC.respond_to?(:use_private_forge?)
+
+    settings.use_private_forge || settings.forge_use_private_forge || false
+  end
+
+  def private_forge_cost(settings)
+    return DRCC.private_forge_cost(settings) if DRCC.respond_to?(:private_forge_cost)
+
+    settings.forge_private_forge_cost || 50_000
+  end
+
+  def private_forge_room(hometown)
+    return DRCC.private_forge_room(hometown) if DRCC.respond_to?(:private_forge_room)
+
+    get_data('crafting')['blacksmithing'][hometown]['private_forge']
+  end
+
+  def towns_with_private_forge
+    return DRCC.towns_with_private_forge if DRCC.respond_to?(:towns_with_private_forge)
+
+    get_data('crafting')['blacksmithing'].select { |_town, data| data['private_forge'] }.keys
+  end
+
+  def go_to_private_forge(hometown, settings)
+    return DRCC.go_to_private_forge(hometown, settings) if DRCC.respond_to?(:go_to_private_forge)
+
+    room = private_forge_room(hometown)
+    return false unless room
+    return false unless DRCM.ensure_copper_on_hand(private_forge_cost(settings), settings, hometown)
+
+    DRCT.walk_to(room)
+    Room.current.id == room
   end
 end
 

--- a/spec/forge_spec.rb
+++ b/spec/forge_spec.rb
@@ -185,10 +185,6 @@ RSpec.describe Forge do
       expect(Forge::FORGE_EMPTY_PATTERN).to eq('There is nothing')
     end
 
-    it 'defines DEFAULT_PRIVATE_FORGE_COST as 5000 copper (5 plat)' do
-      expect(Forge::DEFAULT_PRIVATE_FORGE_COST).to eq(5000)
-    end
-
     it 'defines PRIVATE_FORGE_ENTRY_SUCCESS as frozen array' do
       expect(Forge::PRIVATE_FORGE_ENTRY_SUCCESS).to be_frozen
       expect(Forge::PRIVATE_FORGE_ENTRY_SUCCESS).to include('You head through')
@@ -1062,6 +1058,28 @@ RSpec.describe Forge do
         expect(forge_instance.instance_variable_get(:@home_tool)).to eq('forging hammer')
         expect(forge_instance.instance_variable_get(:@location)).to eq('on anvil')
       end
+    end
+  end
+
+  # The dr-scripts harness stubs a DRCC without the new private-forge helpers,
+  # so these exercise forge's local fallbacks (the path on an older lich-5).
+  describe 'private-forge settings (gated DRCC helpers with local fallback)' do
+    let(:forge_instance) { Forge.allocate }
+
+    it 'crafting_hometown prefers force_crafting_town over hometown' do
+      expect(forge_instance.send(:crafting_hometown, OpenStruct.new(force_crafting_town: 'Shard', hometown: 'Crossing'))).to eq('Shard')
+      expect(forge_instance.send(:crafting_hometown, OpenStruct.new(hometown: 'Crossing'))).to eq('Crossing')
+    end
+
+    it 'use_private_forge? honors use_private_forge and the legacy forge_use_private_forge' do
+      expect(forge_instance.send(:use_private_forge?, OpenStruct.new(use_private_forge: true))).to be true
+      expect(forge_instance.send(:use_private_forge?, OpenStruct.new(forge_use_private_forge: true))).to be true
+      expect(forge_instance.send(:use_private_forge?, OpenStruct.new)).to be false
+    end
+
+    it 'private_forge_cost uses the setting, else defaults to 50_000' do
+      expect(forge_instance.send(:private_forge_cost, OpenStruct.new(forge_private_forge_cost: 7_500))).to eq(7_500)
+      expect(forge_instance.send(:private_forge_cost, OpenStruct.new)).to eq(50_000)
     end
   end
 end

--- a/spec/makesteel_spec.rb
+++ b/spec/makesteel_spec.rb
@@ -9,11 +9,12 @@ load_lic_class('makesteel.lic', 'MakeSteel')
 RSpec.describe MakeSteel do
   # Build a bare instance and inject the ivars the methods under test read,
   # rather than driving the full #initialize workflow.
-  def build(hometown:, use_private_forge:, private_forge:)
+  def build(hometown: 'Shard', use_private_forge: false, private_forge: nil, settings: OpenStruct.new)
     instance = MakeSteel.allocate
     instance.instance_variable_set(:@hometown, hometown)
     instance.instance_variable_set(:@use_private_forge, use_private_forge)
     instance.instance_variable_set(:@private_forge, private_forge)
+    instance.instance_variable_set(:@settings, settings)
     instance
   end
 
@@ -25,6 +26,47 @@ RSpec.describe MakeSteel do
         'Riverhaven' => {} # no private forge
       }
     }
+  end
+
+  # The dr-scripts test harness stubs a DRCC without the new private-forge
+  # helpers, so these exercise the local fallbacks that run on an older lich-5.
+  describe 'gated private-forge settings helpers (local fallback)' do
+    let(:instance) { build }
+
+    it 'crafting_hometown prefers force_crafting_town, else hometown' do
+      expect(instance.crafting_hometown(OpenStruct.new(force_crafting_town: 'Shard', hometown: 'Crossing'))).to eq('Shard')
+      expect(instance.crafting_hometown(OpenStruct.new(hometown: 'Crossing'))).to eq('Crossing')
+    end
+
+    it 'use_private_forge? honors use_private_forge and the legacy forge_use_private_forge' do
+      expect(instance.use_private_forge?(OpenStruct.new(use_private_forge: true))).to be true
+      expect(instance.use_private_forge?(OpenStruct.new(forge_use_private_forge: true))).to be true
+      expect(instance.use_private_forge?(OpenStruct.new)).to be false
+    end
+
+    it 'private_forge_cost uses the setting, else defaults to 50_000' do
+      expect(instance.private_forge_cost(OpenStruct.new(forge_private_forge_cost: 12_345))).to eq(12_345)
+      expect(instance.private_forge_cost(OpenStruct.new)).to eq(50_000)
+    end
+
+    it 'private_forge_room returns the room id or nil' do
+      expect(instance.private_forge_room('Shard')).to eq(51_058)
+      expect(instance.private_forge_room('Riverhaven')).to be_nil
+    end
+
+    it 'towns_with_private_forge lists only towns with a forge' do
+      expect(instance.towns_with_private_forge).to contain_exactly('Shard', 'Crossing')
+    end
+  end
+
+  describe 'DRCC delegation gate' do
+    it 'delegates to DRCC.use_private_forge? when lich-5 provides it' do
+      instance = build
+      allow(DRCC).to receive(:respond_to?).and_call_original
+      allow(DRCC).to receive(:respond_to?).with(:use_private_forge?).and_return(true)
+      allow(DRCC).to receive(:use_private_forge?).and_return(:from_drcc)
+      expect(instance.use_private_forge?(OpenStruct.new)).to eq(:from_drcc)
+    end
   end
 
   describe '#validate_private_forge' do
@@ -53,18 +95,34 @@ RSpec.describe MakeSteel do
   end
 
   describe '#find_crucible' do
-    it 'walks to the private forge before locating a crucible when enabled' do
+    it 'navigates to the private forge, then finds a crucible, when enabled' do
       instance = build(hometown: 'Shard', use_private_forge: true, private_forge: 51_058)
-      expect(DRCT).to receive(:walk_to).with(51_058).ordered
+      expect(instance).to receive(:go_to_private_forge).with('Shard', instance.instance_variable_get(:@settings)).ordered
       expect(DRCC).to receive(:find_empty_crucible).with('Shard').ordered
       instance.find_crucible
     end
 
-    it 'does not walk to a private forge when disabled' do
+    it 'does not navigate to a private forge when disabled' do
       instance = build(hometown: 'Riverhaven', use_private_forge: false, private_forge: nil)
-      expect(DRCT).not_to receive(:walk_to)
+      expect(instance).not_to receive(:go_to_private_forge)
       expect(DRCC).to receive(:find_empty_crucible).with('Riverhaven')
       instance.find_crucible
+    end
+  end
+
+  describe '#go_to_private_forge (local fallback)' do
+    it 'returns false and does not spend when the town has no private forge' do
+      instance = build
+      expect(DRCM).not_to receive(:ensure_copper_on_hand)
+      expect(instance.go_to_private_forge('Riverhaven', OpenStruct.new)).to be false
+    end
+
+    it 'ensures funds, walks, and returns true on arrival' do
+      instance = build
+      allow(Room).to receive(:current).and_return(OpenStruct.new(id: 51_058))
+      expect(DRCM).to receive(:ensure_copper_on_hand).with(50_000, anything, 'Shard').and_return(true)
+      expect(DRCT).to receive(:walk_to).with(51_058)
+      expect(instance.go_to_private_forge('Shard', OpenStruct.new)).to be true
     end
   end
 end

--- a/spec/smith_spec.rb
+++ b/spec/smith_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative 'spec_helper'
+
+# Load the Smith class (the trailing Smith.new is not executed; load_lic_class
+# extracts only the class body).
+load_lic_class('smith.lic', 'Smith')
+
+RSpec.describe Smith do
+  let(:instance) { Smith.allocate }
+
+  before do
+    $test_data[:crafting] = {
+      'blacksmithing' => {
+        'Shard'      => { 'private_forge' => 51_058 },
+        'Crossing'   => { 'private_forge' => 16_936 },
+        'Riverhaven' => {} # no private forge
+      }
+    }
+  end
+
+  # The dr-scripts harness stubs a DRCC without the new private-forge helpers,
+  # so these exercise smith's local fallbacks (the path on an older lich-5).
+  describe 'gated private-forge settings helpers (local fallback)' do
+    it 'crafting_hometown prefers force_crafting_town, else hometown' do
+      expect(instance.crafting_hometown(OpenStruct.new(force_crafting_town: 'Shard', hometown: 'Crossing'))).to eq('Shard')
+      expect(instance.crafting_hometown(OpenStruct.new(hometown: 'Crossing'))).to eq('Crossing')
+    end
+
+    it 'use_private_forge? honors use_private_forge and the legacy forge_use_private_forge' do
+      expect(instance.use_private_forge?(OpenStruct.new(use_private_forge: true))).to be true
+      expect(instance.use_private_forge?(OpenStruct.new(forge_use_private_forge: true))).to be true
+      expect(instance.use_private_forge?(OpenStruct.new)).to be false
+    end
+
+    it 'private_forge_cost uses the setting, else defaults to 50_000' do
+      expect(instance.private_forge_cost(OpenStruct.new(forge_private_forge_cost: 12_345))).to eq(12_345)
+      expect(instance.private_forge_cost(OpenStruct.new)).to eq(50_000)
+    end
+
+    it 'private_forge_room returns the room id or nil' do
+      expect(instance.private_forge_room('Shard')).to eq(51_058)
+      expect(instance.private_forge_room('Riverhaven')).to be_nil
+    end
+
+    it 'towns_with_private_forge lists only towns with a forge' do
+      expect(instance.towns_with_private_forge).to contain_exactly('Shard', 'Crossing')
+    end
+  end
+
+  describe 'DRCC delegation gate' do
+    it 'delegates to DRCC.private_forge_cost when lich-5 provides it' do
+      allow(DRCC).to receive(:respond_to?).and_call_original
+      allow(DRCC).to receive(:respond_to?).with(:private_forge_cost).and_return(true)
+      allow(DRCC).to receive(:private_forge_cost).and_return(99_999)
+      expect(instance.private_forge_cost(OpenStruct.new)).to eq(99_999)
+    end
+  end
+
+  describe '#go_to_private_forge (local fallback)' do
+    it 'returns false and does not spend when the town has no private forge' do
+      expect(DRCM).not_to receive(:ensure_copper_on_hand)
+      expect(instance.go_to_private_forge('Riverhaven', OpenStruct.new)).to be false
+    end
+
+    it 'ensures funds at the configured cost, walks, and returns true on arrival' do
+      allow(Room).to receive(:current).and_return(OpenStruct.new(id: 51_058))
+      expect(DRCM).to receive(:ensure_copper_on_hand).with(50_000, anything, 'Shard').and_return(true)
+      expect(DRCT).to receive(:walk_to).with(51_058)
+      expect(instance.go_to_private_forge('Shard', OpenStruct.new)).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`smith`, `forge`, and `makesteel` each resolved the blacksmithing private forge **differently**, and the divergence was a latent bug:

| Concern | Before |
|---|---|
| Crafting town | `forge` used `settings.hometown` (ignoring `force_crafting_town`), unlike the other 10 crafting scripts |
| Enable toggle | `use_private_forge` (smith/makesteel) vs **`forge_use_private_forge`** (forge) |
| Rental cost | hardcoded **`50_000`** (smith) vs configurable **`5_000`** default (forge) |

Because `smith` delegates the actual forging to `forge`, a user who set `force_crafting_town` (or only `use_private_forge`) could have `smith` walk to the private forge while the delegated `forge` run operated on a different town / a public anvil.

This converges all three on shared helpers, **preferring the `DRCC` versions** (elanthia-online/lich-5#1560) and falling back to a local copy **gated on `DRCC.respond_to?`** so the scripts keep working on an older lich-5. Each local fallback carries a note and can be deleted once the lich-5 change ships.

> **Stacked on #7580** (makesteel private-forge support). Merge that first; until then this PR's diff includes #7580's commit.

## Normalized behavior

- **town** → `force_crafting_town || hometown` (fixes `forge`)
- **toggle** → `use_private_forge`, still accepting the legacy `forge_use_private_forge`
- **cost** → `forge_private_forge_cost || 50_000` (canonical; was `5_000` in forge)
- `makesteel`/`smith` navigate via `go_to_private_forge` (ensure funds + walk); `forge` keeps its own richer navigation and just sources the settings from the shared helpers.

### Intentional behavior changes (both improvements)
- `makesteel` now reserves the forge cost when `use_private_forge` (previously reserved nothing for the forge).
- `smith` no longer pre-reserves the forge cost in `here` mode (you are already standing in the forge), and reserves it right before walking rather than at startup.

## Testing

- `bundle exec rspec` — full suite green (**3137 examples, 0 failures**).
- `rubocop -A` — clean on all changed files.
- Adds **`spec/smith_spec.rb`** (first spec for `smith`) and expands the `makesteel`/`forge` specs to cover the gated helpers (local-fallback **and** DRCC-delegation paths) and the navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)