### PR TITLE
feat(moonwatch): map the up-and-new dark-moon reading (v4.5.4)

### DIFF
--- a/moonwatch.lic
+++ b/moonwatch.lic
@@ -3,7 +3,7 @@
 =begin
   Documentation: https://github.com/elanthia-online/dr-scripts/wiki/Documentation-for-moonwatch.lic
 
-  Moonwatch v4.5.3 - Bresenham Moons + Empirical Sun Table + Lunar Phase
+  Moonwatch v4.5.4 - Bresenham Moons + Empirical Sun Table + Lunar Phase
   ======================================================================
 
   This script provides real-time tracking of DragonRealms moons (Katamba, Xibar, Yavash)
@@ -89,6 +89,18 @@
   seen"). The moon does rise during new -- observe finds it, hidden, rather than
   "nowhere" -- so DR merely suppresses the visible rise broadcast for a dark moon.
 
+  v4.5.4 maps the OTHER dark-moon clause v4.5.3 had already identified but could
+  not capture: the up-and-new reading "<M> is hidden from you, but its energy is
+  quite strong." (45/45 = new, an even cleaner signal than "fruitless"). It uses
+  the bare moon name, so MOON_PHASE_LINE_PATTERN (keyed on "moon <M>") never saw
+  it; a dedicated MOON_HIDDEN_PHASE_LINE_PATTERN now captures it, scoped by the
+  same scan line, and it maps to new. A dark moon reads "fruitless" while below
+  the horizon and "hidden ... energy strong" once it has risen, so new is now
+  validated on a Moon Mage in BOTH arcs (above-horizon new was silently dropped
+  before). Confirmed against a fresh Moon Mage (Quilsilgas) capture where the
+  reading flipped from "fruitless" to "hidden ... energy strong" exactly at the
+  model-predicted new-moon rise tick.
+
   Architecture (SOLID principles applied):
   - DRTime: Single responsibility for DR calendar calculations
   - Moons: Single responsibility for moon position calculations
@@ -129,7 +141,7 @@
 no_pause_all
 no_kill_all
 
-$MOONWATCH_VERSION = '4.5.3'
+$MOONWATCH_VERSION = '4.5.4'
 
 # =============================================================================
 # CONSTANTS: Game Event Patterns
@@ -166,6 +178,18 @@ MOON_SCAN_PATTERN = /^You scan the skies/i.freeze
 # @example "The moon Katamba forms a perfect circle in the heavens."
 # @example "Waxing still, half of the black moon Katamba looks down from above."
 MOON_PHASE_LINE_PATTERN = /\bmoon (?<moon>Katamba|Xibar|Yavash)\b(?<phase_desc>.*)\.\s*$/i.freeze
+
+# The one dark-moon reading MOON_PHASE_LINE_PATTERN cannot catch. When a new
+# (dark) moon is UP, a Moon Mage's `observe` reads "<M> is hidden from you, but
+# its energy is quite strong." -- the bare moon name, no "moon <M>" clause -- so
+# the pattern above never captures it (see the OBSERVED_PHASE_MAP notes). This
+# captures that single wording; its clause maps to new (45/45 in validation, the
+# 0 outliers making it a cleaner new signal than "fruitless"). The energy
+# adjective varies, so the capture keys on the stable "is hidden from you, but
+# its energy" fragment. A dark moon below the horizon reads "fruitless" instead;
+# that one already says "moon <M>", so MOON_PHASE_LINE_PATTERN handles it.
+# @example "Xibar is hidden from you, but its energy is quite strong."
+MOON_HIDDEN_PHASE_LINE_PATTERN = /^(?<moon>Katamba|Xibar|Yavash) (?<phase_desc>is hidden from you, but its energy.*)\.\s*$/i.freeze
 
 # Sun rise event patterns - multiple variations exist in-game
 # These cover dawn/sunrise messages across different weather conditions and locations
@@ -950,19 +974,23 @@ module Moons
   # rise for it either (0 rises at model-new across ~2700 logged rises, vs ~130
   # per other phase), so the rise-triggered auto-observe rarely fires while new.
   # It IS observable, but only by a Moon Mage: their `observe` senses the dark
-  # moon's mana and returns "...moon <M> turns up fruitless." (40/42 = new; the
-  # 2 outliers are new->waxing-crescent boundary reads) or "...<M> is hidden from
-  # you, but its energy is quite strong." (45/45 = new, but that clause lacks
-  # "moon <M>" so the parser above never captures it). Non-Moon-Mage characters
-  # get only "nowhere to be seen", which is below-horizon and spans every phase,
-  # so it is deliberately NOT mapped. The "turns up fruitless" entry is therefore
-  # Moon-Mage-only in practice; it needs no gating because no other guild emits
-  # it. Determined from a Moon Mage (Quilsilgas) vs a non-Moon-Mage (Ytterby):
-  # the dark-moon clauses appear only in the Moon Mage's logs.
+  # moon's mana and returns one of two clauses depending on the moon's arc.
+  # Below the horizon it reads "...moon <M> turns up fruitless." (40/42 = new; the
+  # 2 outliers are new->waxing-crescent boundary reads); once risen it reads
+  # "...<M> is hidden from you, but its energy is quite strong." (45/45 = new).
+  # The "hidden ... energy" clause lacks "moon <M>", so MOON_PHASE_LINE_PATTERN
+  # cannot see it -- MOON_HIDDEN_PHASE_LINE_PATTERN captures it instead (v4.5.4);
+  # both clauses map to new here. Non-Moon-Mage characters get only "nowhere to
+  # be seen", which is below-horizon and spans every phase, so it is deliberately
+  # NOT mapped. Both new entries are therefore Moon-Mage-only in practice; they
+  # need no gating because no other guild emits them. Determined from a Moon Mage
+  # (Quilsilgas) vs a non-Moon-Mage (Ytterby): the dark-moon clauses appear only
+  # in the Moon Mage's logs.
   #
   # Entries are in cycle order; find returns the first match, fragments disjoint.
   OBSERVED_PHASE_MAP = [
-    [/turns up fruitless/i, 'new'], # Moon Mage only (dark-moon sense)
+    [/turns up fruitless/i, 'new'],               # Moon Mage, dark moon below horizon
+    [/hidden from you, but its energy/i, 'new'],  # Moon Mage, dark moon risen
     [/growing crescent/i, 'waxing crescent'],
     [/looks down from above/i, 'first quarter'],
     [/nearly turned its full face/i, 'waxing gibbous'],
@@ -2625,6 +2653,21 @@ loop do
     # Phase readout from an observe, scoped by the scan line above so ambient sky
     # text is not logged. DR varies the wording per phase; we capture the whole
     # clause and let the logger map/validate it.
+    if awaiting_phase
+      awaiting_phase = false
+      moon_name = Regexp.last_match[:moon].downcase
+      phase_desc = Regexp.last_match[:phase_desc].strip
+      game_time = XMLData.server_time
+      MoonwatchMessaging.debug("phase_obs #{moon_name}: #{phase_desc}", $debug_mode_mm)
+      logger.log_phase_observation(moon_name, phase_desc, game_time)
+    end
+
+  when MOON_HIDDEN_PHASE_LINE_PATTERN
+    # The up-and-new (dark) moon reads by bare name ("<M> is hidden from you, but
+    # its energy ..."), which MOON_PHASE_LINE_PATTERN cannot catch. Capture it here,
+    # scoped by the same scan line, and feed it through the normal phase logger so
+    # the new phase is validated above-horizon too (below-horizon new reads
+    # "fruitless", handled by the branch above).
     if awaiting_phase
       awaiting_phase = false
       moon_name = Regexp.last_match[:moon].downcase

--- a/spec/moonwatch_spec.rb
+++ b/spec/moonwatch_spec.rb
@@ -94,6 +94,7 @@ load_lic_class('moonwatch.lic', 'MoonwatchLogger')
 load_lic_class('moonwatch.lic', 'ServerResetTracker')
 load_lic_class('moonwatch.lic', 'MoonwatchUI')
 load_lic_constant('moonwatch.lic', 'MOON_PHASE_LINE_PATTERN')
+load_lic_constant('moonwatch.lic', 'MOON_HIDDEN_PHASE_LINE_PATTERN')
 
 RSpec.describe 'moonwatch.lic' do
   # A recent server_time landing on day-of-year 307, year 455.
@@ -411,7 +412,8 @@ RSpec.describe 'moonwatch.lic' do
 
     describe '.observed_phase_name' do
       it 'maps each known DR observe wording to its phase' do
-        expect(Moons.observed_phase_name('turns up fruitless')).to eq('new') # Moon Mage dark-moon sense
+        expect(Moons.observed_phase_name('turns up fruitless')).to eq('new') # Moon Mage, dark moon below horizon
+        expect(Moons.observed_phase_name('is hidden from you, but its energy is quite strong')).to eq('new') # Moon Mage, dark moon risen
         expect(Moons.observed_phase_name('is a growing crescent of light')).to eq('waxing crescent')
         expect(Moons.observed_phase_name('looks down from above')).to eq('first quarter')
         expect(Moons.observed_phase_name('has nearly turned its full face upon Elanthia')).to eq('waxing gibbous')
@@ -472,6 +474,45 @@ RSpec.describe 'moonwatch.lic' do
         m = MOON_PHASE_LINE_PATTERN.match('Your search for the black moon Katamba turns up fruitless.')
         expect(m).not_to be_nil
         expect(Moons.observed_phase_name(m[:phase_desc].strip)).to eq('new')
+      end
+
+      # The above-horizon dark-moon reading uses the bare moon name, so
+      # MOON_PHASE_LINE_PATTERN cannot see it -- it must NOT match here.
+      it 'does not match the bare-name "hidden ... energy" reading' do
+        expect(MOON_PHASE_LINE_PATTERN.match('Xibar is hidden from you, but its energy is quite strong.')).to be_nil
+      end
+    end
+
+    # A Moon Mage observing a RISEN dark (new) moon gets "<M> is hidden from you,
+    # but its energy is quite strong." -- bare name, no "moon <M>", so the main
+    # phase pattern misses it. This dedicated pattern captures it, and its clause
+    # maps to 'new'. Below the horizon the same moon reads "fruitless" instead.
+    describe 'MOON_HIDDEN_PHASE_LINE_PATTERN' do
+      it 'captures the up-and-new reading for each moon and maps it to new' do
+        [
+          'Katamba is hidden from you, but its energy is quite strong.',
+          'Xibar is hidden from you, but its energy is quite strong.',
+          'Yavash is hidden from you, but its energy is quite strong.'
+        ].each do |line|
+          m = MOON_HIDDEN_PHASE_LINE_PATTERN.match(line)
+          expect(m).not_to be_nil, "expected to match: #{line}"
+          expect(Moons.observed_phase_name(m[:phase_desc].strip)).to eq('new')
+        end
+      end
+
+      it 'extracts the moon name via the named capture' do
+        m = MOON_HIDDEN_PHASE_LINE_PATTERN.match('Xibar is hidden from you, but its energy is quite strong.')
+        expect(m[:moon].downcase).to eq('xibar')
+      end
+
+      it 'ignores the below-horizon and weather non-readings' do
+        [
+          'Your search for the blue moon Xibar turns up fruitless.',
+          'Katamba is nowhere to be seen.',
+          'Xibar is unobscured by clouds.'
+        ].each do |line|
+          expect(MOON_HIDDEN_PHASE_LINE_PATTERN.match(line)).to be_nil, "should not match: #{line}"
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Completes the new-phase `observe` coverage started in #7571 (v4.5.3).

v4.5.3 identified **both** Moon Mage dark-moon `observe` clauses but could only capture one:

- **Below the horizon:** `...moon <M> turns up fruitless.` — says `moon <M>`, so `MOON_PHASE_LINE_PATTERN` catches it (already mapped to `new`).
- **Above the horizon (risen):** `<M> is hidden from you, but its energy is quite strong.` — **bare name, no `moon <M>`**, so the parser never saw it and every above-horizon new observe was silently dropped.

This adds `MOON_HIDDEN_PHASE_LINE_PATTERN` to capture that bare-name reading (scoped by the same `You scan the skies` line) and maps its clause to `new`, so the new phase is validated in **both** arcs of a dark moon. The hidden/energy clause is actually the cleaner signal (45/45 = new, vs 40/42 for fruitless).

## Validation

Confirmed against a fresh Moon Mage (Quilsilgas) `observe xibar` capture where the reading flipped from `turns up fruitless` to `hidden ... energy strong` **exactly at the model-predicted new-moon rise tick** — the model's Xibar rise/set and phase constants both matched to the tick, and the moon was observably up-and-new immediately after.

## Changes

- New `MOON_HIDDEN_PHASE_LINE_PATTERN` constant + a main-loop `when` branch that captures the up-and-new reading and routes it through the existing phase logger.
- `OBSERVED_PHASE_MAP` gains `[/hidden from you, but its energy/i, 'new']`; comment updated to explain the two arcs.
- Version bump 4.5.3 → 4.5.4 with a changelog entry.
- Specs: the new clause maps to `new`; the new pattern captures the up-and-new reading for all three moons while ignoring below-horizon/weather lines; and `MOON_PHASE_LINE_PATTERN` correctly does **not** match the bare-name reading.

## Test plan

- `bundle exec rspec spec/moonwatch_spec.rb` — 166 examples, 0 failures.
- `bundle exec rubocop moonwatch.lic spec/moonwatch_spec.rb` — no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)