### PR TITLE
spec: drop non-deterministic branch coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,7 +90,6 @@ LIC_EVAL_RANGES = Hash.new { |h, k| h[k] = [] }
 if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.enable_coverage :eval
-  SimpleCov.enable_coverage :branch
 
   # Only the class/module bodies a spec extracts are ever eval'd, so a script's
   # remaining code -- the before_dying block, the `Klass.new` entry point, a


### PR DESCRIPTION
Follow-up to #7547. That PR's **line** coverage is correct and stable and stays exactly as-is. This removes only the **branch** coverage it also enabled, because the branch figure is non-deterministic.

## The problem

Identical `COVERAGE=1 bundle exec rspec` runs report a different branch coverage every time:

```
30.02%  (2365 / 7876)
31.18%  (2342 / 7510)
31.22%  (2364 / 7572)
32.31%  (2328 / 7204)
```

The **denominator itself** moves (7204–7876), and it still moves with `--order defined --seed 1` pinned (`7206 / 7549 / 7349`), so it is not spec ordering. Line coverage is stable across all of those runs.

## Root cause

Ruby's `Coverage`, with `eval: true` + branch tracking, accumulates branch tuples non-deterministically when multiple `eval`s are attributed to the same filename — which is precisely `load_lic_class`'s design (each class in a `.lic` is eval'd separately, all attributed to the same path). It concentrates in the file with the most classes eval'd into one filename (`combat-trainer.lic`, ±299 branches/run).

Reproduced with no RSpec at all — 20 classes eval'd per-class into one filename under `Coverage.start(eval: true, branches: true)`, five processes:

```
branch leaves = 124, 154, 124, 240, 124
```

## Why remove rather than fix

The non-determinism is in Ruby's eval branch tracking, not something this repo can configure away without abandoning the per-class-eval approach the specs depend on. A metric that can't be reproduced can't be trended or gated on. Line coverage — the correct, stable, useful half of #7547 — has none of this and is untouched.

## Change

One line: `SimpleCov.enable_coverage :branch` removed. `enable_coverage :eval` and the line backfill stay.

## Test plan

- [x] `bundle exec rspec` — 3163 examples, 0 failures
- [x] `COVERAGE=1 bundle exec rspec` — same, and `coverage/index.html` still generated with **line** coverage (`Line coverage: 7009 / 17315`); no branch section
- [x] `grep -i branch spec/spec_helper.rb` — no dangling references

🤖 Generated with [Claude Code](https://claude.com/claude-code)