### PR TITLE
combat-trainer: target corpses by id (loot/arrange/skin) + per-id skinned/dissected/looted tracking

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1355,9 +1355,11 @@ class LootProcess
 
     snap = [DRC.left_hand, DRC.right_hand]
     case DRC.bput("skin ##{corpse.id}", 'roundtime', 'skin what', 'cannot be skinned', 'already been skinned', 'carrying far too many items', 'need a more appropriate weapon', 'need to have a bladed instrument to skin', 'You must have one hand free to skin')
-    when 'roundtime'
+    when /roundtime/i
       # Skin started -> this corpse is done; don't re-arrange/re-skin it while it
-      # lingers dead in the roster for the ~6-7s until it decays.
+      # lingers dead in the roster for the ~6-7s until it decays. NB: DRC.bput
+      # returns the matched substring from the game line ("Roundtime"), not the
+      # matcher, so this branch must be case-insensitive, not `when 'roundtime'`.
       @skinned_corpse_ids << corpse.id
       echo("corpse-track: mark ##{corpse.id} skinned") if $debug_mode_ct
     when 'already been skinned'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1122,7 +1122,14 @@ class LootProcess
     game_state.wield_whirlwind_offhand
 
     unless game_state.necro_casting?
-      while DRC.bput("loot #{@custom_loot_type}".strip, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
+      # Loot the specific corpse by its <crtrStatus> id so we know exactly which
+      # body we consumed -- a looted corpse disappears very shortly after. Fall
+      # back to a bare/typed loot when no id is known (Creature roster and
+      # DRRoom.dead_npcs can disagree). @custom_loot_type, when set, still
+      # selects the LOOT type (treasure/equipment/all).
+      loot_target = corpse ? "##{corpse.id}" : nil
+      loot_command = ['loot', loot_target, @custom_loot_type].compact.reject(&:empty?).join(' ')
+      while DRC.bput(loot_command, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
         pause
         waitrt?
       end
@@ -1131,15 +1138,32 @@ class LootProcess
     @loot_timer = Time.now
   end
 
-  def arrange_mob(mob_noun, game_state)
+  # Whether a specific corpse (by its <crtrStatus> id) is still present in the
+  # room. Looting a corpse makes it vanish very shortly after, so arrange/skin
+  # must confirm the id is still around before firing a command at a corpse that
+  # may already be gone -- otherwise the bare verb returns "Arrange what?" /
+  # "Skin what?" and burns roundtime mid-combat.
+  def corpse_present?(corpse)
+    return false unless corpse
+
+    Lich::DragonRealms::Creature.in_room(:dead).any? { |c| c.id == corpse.id }
+  end
+
+  def arrange_mob(mob_noun, game_state, corpse)
     return unless @skin || @arrange_for_dissect
     return unless @arrange_count > 0
     return unless game_state.skinnable?(mob_noun)
     return if game_state.necro_casting?
+    return unless corpse_present?(corpse)
 
     arranges = 0
     type = @arrange_types[mob_noun] || 'skin'
-    arrange_message = @arrange_all ? "arrange all for #{type}" : "arrange for #{type}"
+    # Target the specific corpse by id (e.g. "arrange #12345 for skin") so the
+    # verb can't bind to a live same-noun mob or the wrong corpse. "all" (arrange
+    # up to five times in one command) goes after the id: "arrange #12345 all for
+    # skin". The noun->type lookup above is unchanged.
+    arrange_verb = @arrange_all ? "arrange ##{corpse.id} all" : "arrange ##{corpse.id}"
+    arrange_message = "#{arrange_verb} for #{type}"
     while arranges < @arrange_count
       arranges += 1 # rubocop:disable Lint/UselessAssignment
       case DRC.bput(arrange_message, 'You begin to arrange', 'You continue arranging', 'You make a mistake', 'You complete arranging', 'That creature cannot', 'That has already been arranged', 'Arrange what', 'cannot be skinned', 'You make a serious mistake in the arranging process', 'The .* is currently being arranged to produce')
@@ -1152,7 +1176,7 @@ class LootProcess
         break
       when 'That creature cannot'
         arranges = 0
-        arrange_message = @arrange_all ? 'arrange all' : 'arrange'
+        arrange_message = arrange_verb
       end
     end
   end
@@ -1166,7 +1190,7 @@ class LootProcess
 
     if @dissect && game_state.dissectable?(mob_noun)
       if @arrange_for_dissect
-        arrange_mob(mob_noun, game_state)
+        arrange_mob(mob_noun, game_state, corpse)
         already_arranged = true
       end
 
@@ -1178,16 +1202,16 @@ class LootProcess
 
       if skill_to_train == 'First Aid' || skill_to_train == 'Thanatology'
         unless dissected?(corpse, game_state)
-          arrange_mob(mob_noun, game_state) unless already_arranged
-          check_skinning(mob_noun, game_state) if @skin
+          arrange_mob(mob_noun, game_state, corpse) unless already_arranged
+          check_skinning(mob_noun, game_state, corpse) if @skin
         end
       elsif skill_to_train == 'Skinning'
-        arrange_mob(mob_noun, game_state) unless already_arranged
-        check_skinning(mob_noun, game_state) if @skin
+        arrange_mob(mob_noun, game_state, corpse) unless already_arranged
+        check_skinning(mob_noun, game_state, corpse) if @skin
       end
     elsif @skin && game_state.skinnable?(mob_noun)
-      arrange_mob(mob_noun, game_state) unless already_arranged
-      check_skinning(mob_noun, game_state)
+      arrange_mob(mob_noun, game_state, corpse) unless already_arranged
+      check_skinning(mob_noun, game_state, corpse)
     else
       return
     end
@@ -1249,8 +1273,9 @@ class LootProcess
     return false
   end
 
-  def check_skinning(mob_noun, game_state)
+  def check_skinning(mob_noun, game_state, corpse)
     return unless game_state.skinnable?(mob_noun)
+    return unless corpse_present?(corpse)
 
     if game_state.need_bundle
       case DRC.bput('tap my bundle', 'You tap a \w+ bundle\b.*that you are wearing', 'I could not find what you were referring to', 'You tap a tight bundle inside')
@@ -1285,11 +1310,11 @@ class LootProcess
     end
 
     snap = [DRC.left_hand, DRC.right_hand]
-    case DRC.bput('skin', 'roundtime', 'skin what', 'cannot be skinned', 'carrying far too many items', 'need a more appropriate weapon', 'need to have a bladed instrument to skin', 'You must have one hand free to skin')
+    case DRC.bput("skin ##{corpse.id}", 'roundtime', 'skin what', 'cannot be skinned', 'carrying far too many items', 'need a more appropriate weapon', 'need to have a bladed instrument to skin', 'You must have one hand free to skin')
     when 'You must have one hand free to skin'
       temp_item = DRC.left_hand
       if DRCI.lower_item?(temp_item)
-        check_skinning(mob_noun, game_state)
+        check_skinning(mob_noun, game_state, corpse)
         DRCI.get_item?(temp_item)
       end
     when 'need a more appropriate weapon', 'need to have a bladed instrument to skin'

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -626,6 +626,16 @@ class LootProcess
     Flags.add('pouch-needs-tie', /You'd better tie it up before putting/)
     Flags.add('container-full', 'There isn\'t any more room')
     Flags.add('ct-successful-skin', '^You carefully fit .* into your bundle')
+
+    # Corpse ids we've finished a given action on this session. A looted corpse
+    # lingers in Creature.in_room(:dead) until it DECAYS (~6-7s after loot,
+    # several crtrStatus pulses later), so corpse_present? alone can't stop us
+    # re-arranging/re-skinning/re-dissecting/re-looting it -- track each action
+    # per id and skip it. Marked on terminal outcomes only (success or
+    # already-done), not on retryable ones. Bounded by kills per room.
+    @skinned_corpse_ids = []
+    @dissected_corpse_ids = []
+    @looted_corpse_ids = []
   end
 
   def execute(game_state)
@@ -1126,12 +1136,17 @@ class LootProcess
       # body we consumed -- a looted corpse disappears very shortly after. Fall
       # back to a bare/typed loot when no id is known (Creature roster and
       # DRRoom.dead_npcs can disagree). @custom_loot_type, when set, still
-      # selects the LOOT type (treasure/equipment/all).
-      loot_target = corpse ? "##{corpse.id}" : nil
-      loot_command = ['loot', loot_target, @custom_loot_type].compact.reject(&:empty?).join(' ')
-      while DRC.bput(loot_command, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
-        pause
-        waitrt?
+      # selects the LOOT type (treasure/equipment/all). Skip a corpse we've
+      # already looted: it lingers dead in the roster until decay, so without
+      # this we re-search it every pass.
+      unless corpse && @looted_corpse_ids.include?(corpse.id)
+        loot_target = corpse ? "##{corpse.id}" : nil
+        loot_command = ['loot', loot_target, @custom_loot_type].compact.reject(&:empty?).join(' ')
+        while DRC.bput(loot_command, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
+          pause
+          waitrt?
+        end
+        @looted_corpse_ids << corpse.id if corpse
       end
       @last_ritual = nil
     end
@@ -1155,6 +1170,7 @@ class LootProcess
     return unless game_state.skinnable?(mob_noun)
     return if game_state.necro_casting?
     return unless corpse_present?(corpse)
+    return if corpse && @skinned_corpse_ids.include?(corpse.id)
 
     arranges = 0
     type = @arrange_types[mob_noun] || 'skin'
@@ -1166,8 +1182,11 @@ class LootProcess
     arrange_message = "#{arrange_verb} for #{type}"
     while arranges < @arrange_count
       arranges += 1 # rubocop:disable Lint/UselessAssignment
-      case DRC.bput(arrange_message, 'You begin to arrange', 'You continue arranging', 'You make a mistake', 'You complete arranging', 'That creature cannot', 'That has already been arranged', 'Arrange what', 'cannot be skinned', 'You make a serious mistake in the arranging process', 'The .* is currently being arranged to produce')
+      case DRC.bput(arrange_message, 'You begin to arrange', 'You continue arranging', 'You make a mistake', 'You complete arranging', 'That creature cannot', 'That has already been arranged', 'Arrange what', 'cannot be skinned', 'already been skinned', 'You make a serious mistake in the arranging process', 'The .* is currently being arranged to produce')
       when 'You complete arranging', 'That has already been arranged', 'You make a serious mistake in the arranging process', 'Arrange what'
+        break
+      when 'already been skinned'
+        @skinned_corpse_ids << corpse.id if corpse
         break
       when 'cannot be skinned'
         game_state.unskinnable(mob_noun)
@@ -1220,6 +1239,9 @@ class LootProcess
   def dissected?(corpse, game_state)
     mob_noun = corpse&.noun
     return unless game_state.dissectable?(mob_noun)
+    # Already dissected this corpse -> it's dissected; don't re-fire dissect at a
+    # corpse still lingering dead in the roster until it decays.
+    return true if corpse && @dissected_corpse_ids.include?(corpse.id)
 
     if @dissect_for_thanatology
       return false if (DRSkill.getxp('Thanatology') == 34 && DRSkill.getxp('First Aid') == 34)
@@ -1250,6 +1272,7 @@ class LootProcess
                   "With less concern than you'd give a fresh corpse",
                   'Rituals do not work upon constructs')
     when /You succeed in dissecting the corpse/, /You learn something/i, "With less concern than you'd give a fresh corpse"
+      @dissected_corpse_ids << corpse.id if corpse
       return true
     when /You'll gain no insights from this attempt/
       waitrt?
@@ -1276,6 +1299,7 @@ class LootProcess
   def check_skinning(mob_noun, game_state, corpse)
     return unless game_state.skinnable?(mob_noun)
     return unless corpse_present?(corpse)
+    return if corpse && @skinned_corpse_ids.include?(corpse.id)
 
     if game_state.need_bundle
       case DRC.bput('tap my bundle', 'You tap a \w+ bundle\b.*that you are wearing', 'I could not find what you were referring to', 'You tap a tight bundle inside')
@@ -1310,7 +1334,14 @@ class LootProcess
     end
 
     snap = [DRC.left_hand, DRC.right_hand]
-    case DRC.bput("skin ##{corpse.id}", 'roundtime', 'skin what', 'cannot be skinned', 'carrying far too many items', 'need a more appropriate weapon', 'need to have a bladed instrument to skin', 'You must have one hand free to skin')
+    case DRC.bput("skin ##{corpse.id}", 'roundtime', 'skin what', 'cannot be skinned', 'already been skinned', 'carrying far too many items', 'need a more appropriate weapon', 'need to have a bladed instrument to skin', 'You must have one hand free to skin')
+    when 'roundtime'
+      # Skin started -> this corpse is done; don't re-arrange/re-skin it while it
+      # lingers dead in the roster for the ~6-7s until it decays.
+      @skinned_corpse_ids << corpse.id
+    when 'already been skinned'
+      @skinned_corpse_ids << corpse.id
+      return
     when 'You must have one hand free to skin'
       temp_item = DRC.left_hand
       if DRCI.lower_item?(temp_item)

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1139,14 +1139,19 @@ class LootProcess
       # selects the LOOT type (treasure/equipment/all). Skip a corpse we've
       # already looted: it lingers dead in the roster until decay, so without
       # this we re-search it every pass.
-      unless corpse && @looted_corpse_ids.include?(corpse.id)
+      if corpse && @looted_corpse_ids.include?(corpse.id)
+        echo("corpse-track: skip loot ##{corpse.id} (already looted)") if $debug_mode_ct
+      else
         loot_target = corpse ? "##{corpse.id}" : nil
         loot_command = ['loot', loot_target, @custom_loot_type].compact.reject(&:empty?).join(' ')
         while DRC.bput(loot_command, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
           pause
           waitrt?
         end
-        @looted_corpse_ids << corpse.id if corpse
+        if corpse
+          @looted_corpse_ids << corpse.id
+          echo("corpse-track: mark ##{corpse.id} looted") if $debug_mode_ct
+        end
       end
       @last_ritual = nil
     end
@@ -1170,7 +1175,10 @@ class LootProcess
     return unless game_state.skinnable?(mob_noun)
     return if game_state.necro_casting?
     return unless corpse_present?(corpse)
-    return if corpse && @skinned_corpse_ids.include?(corpse.id)
+    if corpse && @skinned_corpse_ids.include?(corpse.id)
+      echo("corpse-track: skip arrange ##{corpse.id} (already skinned)") if $debug_mode_ct
+      return
+    end
 
     arranges = 0
     type = @arrange_types[mob_noun] || 'skin'
@@ -1186,7 +1194,10 @@ class LootProcess
       when 'You complete arranging', 'That has already been arranged', 'You make a serious mistake in the arranging process', 'Arrange what'
         break
       when 'already been skinned'
-        @skinned_corpse_ids << corpse.id if corpse
+        if corpse
+          @skinned_corpse_ids << corpse.id
+          echo("corpse-track: mark ##{corpse.id} skinned (via arrange)") if $debug_mode_ct
+        end
         break
       when 'cannot be skinned'
         game_state.unskinnable(mob_noun)
@@ -1241,7 +1252,10 @@ class LootProcess
     return unless game_state.dissectable?(mob_noun)
     # Already dissected this corpse -> it's dissected; don't re-fire dissect at a
     # corpse still lingering dead in the roster until it decays.
-    return true if corpse && @dissected_corpse_ids.include?(corpse.id)
+    if corpse && @dissected_corpse_ids.include?(corpse.id)
+      echo("corpse-track: skip dissect ##{corpse.id} (already dissected)") if $debug_mode_ct
+      return true
+    end
 
     if @dissect_for_thanatology
       return false if (DRSkill.getxp('Thanatology') == 34 && DRSkill.getxp('First Aid') == 34)
@@ -1272,7 +1286,10 @@ class LootProcess
                   "With less concern than you'd give a fresh corpse",
                   'Rituals do not work upon constructs')
     when /You succeed in dissecting the corpse/, /You learn something/i, "With less concern than you'd give a fresh corpse"
-      @dissected_corpse_ids << corpse.id if corpse
+      if corpse
+        @dissected_corpse_ids << corpse.id
+        echo("corpse-track: mark ##{corpse.id} dissected") if $debug_mode_ct
+      end
       return true
     when /You'll gain no insights from this attempt/
       waitrt?
@@ -1299,7 +1316,10 @@ class LootProcess
   def check_skinning(mob_noun, game_state, corpse)
     return unless game_state.skinnable?(mob_noun)
     return unless corpse_present?(corpse)
-    return if corpse && @skinned_corpse_ids.include?(corpse.id)
+    if corpse && @skinned_corpse_ids.include?(corpse.id)
+      echo("corpse-track: skip skin ##{corpse.id} (already skinned)") if $debug_mode_ct
+      return
+    end
 
     if game_state.need_bundle
       case DRC.bput('tap my bundle', 'You tap a \w+ bundle\b.*that you are wearing', 'I could not find what you were referring to', 'You tap a tight bundle inside')
@@ -1339,8 +1359,10 @@ class LootProcess
       # Skin started -> this corpse is done; don't re-arrange/re-skin it while it
       # lingers dead in the roster for the ~6-7s until it decays.
       @skinned_corpse_ids << corpse.id
+      echo("corpse-track: mark ##{corpse.id} skinned") if $debug_mode_ct
     when 'already been skinned'
       @skinned_corpse_ids << corpse.id
+      echo("corpse-track: mark ##{corpse.id} skinned (already)") if $debug_mode_ct
       return
     when 'You must have one hand free to skin'
       temp_item = DRC.left_hand

--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -1144,7 +1144,11 @@ class LootProcess
       else
         loot_target = corpse ? "##{corpse.id}" : nil
         loot_command = ['loot', loot_target, @custom_loot_type].compact.reject(&:empty?).join(' ')
-        while DRC.bput(loot_command, 'You search', 'I could not find what you were referring to', 'and get ready to search it') == 'and get ready to search it'
+        # 'already been searched' terminates the loop too: with loot-by-id a
+        # group-mate can search the corpse first, and the game replies "The <mob>
+        # has already been searched for that!" -- unmatched, that hangs bput for
+        # its full 15s timeout mid-combat.
+        while DRC.bput(loot_command, 'You search', 'I could not find what you were referring to', 'and get ready to search it', 'already been searched') == 'and get ready to search it'
           pause
           waitrt?
         end

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -6675,5 +6675,99 @@ RSpec.describe LootProcess do
       expect(DRC).not_to have_received(:bput).with(/\Apray /, any_args)
       expect(DRC).not_to have_received(:bput).with(/\Adissect/, any_args)
     end
+
+    # Loot the exact corpse we processed by its id -- a looted corpse vanishes
+    # shortly after, so a bare LOOT can bind to the wrong/absent body.
+    it 'loots the corpse by its id, keeping the configured loot type' do
+      DRRoom.dead_npcs = ['rat']
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('You search')
+      gs = double('GameState', blessed_room: false, necro_casting?: false)
+      allow(gs).to receive(:mob_died=)
+      allow(gs).to receive(:sheath_whirlwind_offhand)
+      allow(gs).to receive(:wield_whirlwind_offhand)
+      lp = build_dispose_loot(custom_loot_type: 'treasure')
+      allow(lp).to receive(:check_rituals?).and_return(false)
+      lp.dispose_body(gs)
+      expect(DRC).to have_received(:bput).with('loot #111 treasure', any_args)
+    end
+
+    it 'omits the loot-type token when none is configured' do
+      DRRoom.dead_npcs = ['rat']
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('You search')
+      gs = double('GameState', blessed_room: false, necro_casting?: false)
+      allow(gs).to receive(:mob_died=)
+      allow(gs).to receive(:sheath_whirlwind_offhand)
+      allow(gs).to receive(:wield_whirlwind_offhand)
+      lp = build_dispose_loot
+      allow(lp).to receive(:check_rituals?).and_return(false)
+      lp.dispose_body(gs)
+      expect(DRC).to have_received(:bput).with('loot #111', any_args)
+    end
+  end
+
+  describe 'corpse-existence gates' do
+    def gate_game_state
+      gs = double('GameState')
+      allow(gs).to receive(:skinnable?).and_return(true)
+      allow(gs).to receive(:necro_casting?).and_return(false)
+      allow(gs).to receive(:need_bundle).and_return(false)
+      gs
+    end
+
+    def build_gate_loot
+      lp = LootProcess.allocate
+      { skin: true, arrange_for_dissect: true, arrange_count: 1, arrange_all: false,
+        arrange_types: {}, tie_bundle: false }.each { |k, v| lp.instance_variable_set(:"@#{k}", v) }
+      lp
+    end
+
+    it 'arrange_mob does nothing once the corpse has left the room (looted/decayed)' do
+      Lich::DragonRealms::Creature._set_room([])
+      allow(DRC).to receive(:bput)
+      build_gate_loot.send(:arrange_mob, 'rat', gate_game_state, corpse)
+      expect(DRC).not_to have_received(:bput)
+    end
+
+    it 'arrange_mob targets the corpse by id while it is still present' do
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('You complete arranging')
+      build_gate_loot.send(:arrange_mob, 'rat', gate_game_state, corpse)
+      expect(DRC).to have_received(:bput).with('arrange #111 for skin', any_args)
+    end
+
+    it 'arrange_mob keeps the id target in the all-variant' do
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('You complete arranging')
+      lp = build_gate_loot
+      lp.instance_variable_set(:@arrange_all, true)
+      lp.send(:arrange_mob, 'rat', gate_game_state, corpse)
+      expect(DRC).to have_received(:bput).with('arrange #111 all for skin', any_args)
+    end
+
+    # "That creature cannot" be arranged for that type -> retry generically, but
+    # still against the same corpse id (not a bare arrange).
+    it 'arrange_mob retries the id target without the type clause' do
+      Lich::DragonRealms::Creature._set_room([corpse])
+      responses = ['That creature cannot', 'You complete arranging']
+      allow(DRC).to receive(:bput) { responses.shift }
+      build_gate_loot.send(:arrange_mob, 'rat', gate_game_state, corpse)
+      expect(DRC).to have_received(:bput).with('arrange #111', any_args)
+    end
+
+    it 'check_skinning does nothing once the corpse has left the room' do
+      Lich::DragonRealms::Creature._set_room([])
+      allow(DRC).to receive(:bput)
+      build_gate_loot.send(:check_skinning, 'rat', gate_game_state, corpse)
+      expect(DRC).not_to have_received(:bput)
+    end
+
+    it 'check_skinning targets the corpse by id while it is still present' do
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('roundtime')
+      build_gate_loot.send(:check_skinning, 'rat', gate_game_state, corpse)
+      expect(DRC).to have_received(:bput).with('skin #111', any_args)
+    end
   end
 end

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -6737,6 +6737,24 @@ RSpec.describe LootProcess do
       expect(lp.instance_variable_get(:@looted_corpse_ids)).to include(111)
     end
 
+    # Group hunt: a teammate searches the corpse first, so loot-by-id gets
+    # "The <mob> has already been searched for that!". That must be a matcher, or
+    # bput hangs the full 15s mid-combat. Terminal -> loop exits, corpse marked.
+    it 'treats "already been searched" as terminal loot and marks the corpse looted' do
+      DRRoom.dead_npcs = ['rat']
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('already been searched')
+      gs = double('GameState', blessed_room: false, necro_casting?: false)
+      allow(gs).to receive(:mob_died=)
+      allow(gs).to receive(:sheath_whirlwind_offhand)
+      allow(gs).to receive(:wield_whirlwind_offhand)
+      lp = build_dispose_loot
+      allow(lp).to receive(:check_rituals?).and_return(false)
+      lp.dispose_body(gs)
+      expect(DRC).to have_received(:bput).with('loot #111', 'You search', 'I could not find what you were referring to', 'and get ready to search it', 'already been searched')
+      expect(lp.instance_variable_get(:@looted_corpse_ids)).to include(111)
+    end
+
     # A looted corpse lingers dead in the roster until decay; don't re-search it.
     it 'does not re-loot a corpse already recorded as looted' do
       DRRoom.dead_npcs = ['rat']

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -6811,7 +6811,10 @@ RSpec.describe LootProcess do
 
     it 'check_skinning targets the corpse by id while it is still present' do
       Lich::DragonRealms::Creature._set_room([corpse])
-      allow(DRC).to receive(:bput).and_return('roundtime')
+      # DRC.bput returns the matched substring from the game line ("Roundtime"),
+      # not the matcher -- stub it realistically so the case-insensitive branch
+      # is exercised.
+      allow(DRC).to receive(:bput).and_return('Roundtime')
       build_gate_loot.send(:check_skinning, 'rat', gate_game_state, corpse)
       expect(DRC).to have_received(:bput).with('skin #111', any_args)
     end
@@ -6821,7 +6824,9 @@ RSpec.describe LootProcess do
     # arrange/skin passes ("...already been skinned, there's no point.").
     it 'check_skinning records the corpse id after a successful skin' do
       Lich::DragonRealms::Creature._set_room([corpse])
-      allow(DRC).to receive(:bput).and_return('roundtime')
+      # Realistic bput return: the matched substring from "Roundtime: 2 sec.".
+      # (A stub of 'roundtime' would mask a regression to `when 'roundtime'`.)
+      allow(DRC).to receive(:bput).and_return('Roundtime')
       lp = build_gate_loot
       lp.send(:check_skinning, 'rat', gate_game_state, corpse)
       expect(lp.instance_variable_get(:@skinned_corpse_ids)).to include(111)

--- a/spec/combat_trainer_spec.rb
+++ b/spec/combat_trainer_spec.rb
@@ -6589,7 +6589,7 @@ RSpec.describe LootProcess do
 
   def build_dissect_loot(**overrides)
     lp = LootProcess.allocate
-    defaults = { dissect: true, skin: false, dissect_for_thanatology: false, dissect_cycle_skills: [] }
+    defaults = { dissect: true, skin: false, dissect_for_thanatology: false, dissect_cycle_skills: [], dissected_corpse_ids: [] }
     defaults.merge(overrides).each { |k, v| lp.instance_variable_set(:"@#{k}", v) }
     lp
   end
@@ -6637,13 +6637,30 @@ RSpec.describe LootProcess do
       expect(gs).not_to have_received(:construct)
       expect(gs).not_to have_received(:undissectable)
     end
+
+    # A dissected corpse lingers dead in the roster until decay; track the id so
+    # we don't re-fire dissect at it every pass.
+    it 'records the corpse id on a successful dissect' do
+      allow(DRC).to receive(:bput).and_return('You succeed in dissecting the corpse')
+      lp = build_dissect_loot
+      lp.send(:dissected?, corpse, dissect_game_state)
+      expect(lp.instance_variable_get(:@dissected_corpse_ids)).to include(111)
+    end
+
+    it 'reports dissected without re-firing for an already-dissected corpse' do
+      allow(DRC).to receive(:bput)
+      lp = build_dissect_loot(dissected_corpse_ids: [corpse.id])
+      expect(lp.send(:dissected?, corpse, dissect_game_state)).to be true
+      expect(DRC).not_to have_received(:bput).with(/\Adissect/, any_args)
+    end
   end
 
   def build_dispose_loot(**overrides)
     lp = LootProcess.allocate
     defaults = {
       loot_bodies: true, loot_timer: Time.now - 100, loot_delay: 0,
-      last_rites: true, last_rites_timer: Time.now - 700, custom_loot_type: ''
+      last_rites: true, last_rites_timer: Time.now - 700, custom_loot_type: '',
+      looted_corpse_ids: []
     }
     defaults.merge(overrides).each { |k, v| lp.instance_variable_set(:"@#{k}", v) }
     lp
@@ -6705,6 +6722,35 @@ RSpec.describe LootProcess do
       lp.dispose_body(gs)
       expect(DRC).to have_received(:bput).with('loot #111', any_args)
     end
+
+    it 'records the corpse id after looting it' do
+      DRRoom.dead_npcs = ['rat']
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('You search')
+      gs = double('GameState', blessed_room: false, necro_casting?: false)
+      allow(gs).to receive(:mob_died=)
+      allow(gs).to receive(:sheath_whirlwind_offhand)
+      allow(gs).to receive(:wield_whirlwind_offhand)
+      lp = build_dispose_loot
+      allow(lp).to receive(:check_rituals?).and_return(false)
+      lp.dispose_body(gs)
+      expect(lp.instance_variable_get(:@looted_corpse_ids)).to include(111)
+    end
+
+    # A looted corpse lingers dead in the roster until decay; don't re-search it.
+    it 'does not re-loot a corpse already recorded as looted' do
+      DRRoom.dead_npcs = ['rat']
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('You search')
+      gs = double('GameState', blessed_room: false, necro_casting?: false)
+      allow(gs).to receive(:mob_died=)
+      allow(gs).to receive(:sheath_whirlwind_offhand)
+      allow(gs).to receive(:wield_whirlwind_offhand)
+      lp = build_dispose_loot(looted_corpse_ids: [corpse.id])
+      allow(lp).to receive(:check_rituals?).and_return(false)
+      lp.dispose_body(gs)
+      expect(DRC).not_to have_received(:bput).with(/\Aloot/, any_args)
+    end
   end
 
   describe 'corpse-existence gates' do
@@ -6719,7 +6765,7 @@ RSpec.describe LootProcess do
     def build_gate_loot
       lp = LootProcess.allocate
       { skin: true, arrange_for_dissect: true, arrange_count: 1, arrange_all: false,
-        arrange_types: {}, tie_bundle: false }.each { |k, v| lp.instance_variable_set(:"@#{k}", v) }
+        arrange_types: {}, tie_bundle: false, skinned_corpse_ids: [] }.each { |k, v| lp.instance_variable_set(:"@#{k}", v) }
       lp
     end
 
@@ -6768,6 +6814,51 @@ RSpec.describe LootProcess do
       allow(DRC).to receive(:bput).and_return('roundtime')
       build_gate_loot.send(:check_skinning, 'rat', gate_game_state, corpse)
       expect(DRC).to have_received(:bput).with('skin #111', any_args)
+    end
+
+    # A looted corpse lingers dead in the roster for ~6-7s until it decays, so
+    # corpse_present? stays true; per-id tracking is what stops the redundant
+    # arrange/skin passes ("...already been skinned, there's no point.").
+    it 'check_skinning records the corpse id after a successful skin' do
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('roundtime')
+      lp = build_gate_loot
+      lp.send(:check_skinning, 'rat', gate_game_state, corpse)
+      expect(lp.instance_variable_get(:@skinned_corpse_ids)).to include(111)
+    end
+
+    it 'check_skinning records the id and stops on "already been skinned"' do
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('already been skinned')
+      lp = build_gate_loot
+      lp.send(:check_skinning, 'rat', gate_game_state, corpse)
+      expect(lp.instance_variable_get(:@skinned_corpse_ids)).to include(111)
+    end
+
+    it 'check_skinning does not re-skin a corpse already recorded as skinned' do
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput)
+      lp = build_gate_loot
+      lp.instance_variable_set(:@skinned_corpse_ids, [corpse.id])
+      lp.send(:check_skinning, 'rat', gate_game_state, corpse)
+      expect(DRC).not_to have_received(:bput).with(/\Askin/, any_args)
+    end
+
+    it 'arrange_mob skips a corpse already recorded as skinned' do
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput)
+      lp = build_gate_loot
+      lp.instance_variable_set(:@skinned_corpse_ids, [corpse.id])
+      lp.send(:arrange_mob, 'rat', gate_game_state, corpse)
+      expect(DRC).not_to have_received(:bput)
+    end
+
+    it 'arrange_mob records the id and stops on "already been skinned"' do
+      Lich::DragonRealms::Creature._set_room([corpse])
+      allow(DRC).to receive(:bput).and_return('already been skinned')
+      lp = build_gate_loot
+      lp.send(:arrange_mob, 'rat', gate_game_state, corpse)
+      expect(lp.instance_variable_get(:@skinned_corpse_ids)).to include(111)
     end
   end
 end


### PR DESCRIPTION
## Summary

Completes corpse-by-id targeting in combat-trainer's loot process and adds per-id tracking so a finished corpse isn't reprocessed.

`dissect` already addressed the corpse as `dissect #id`; this extends the same to **loot**, **arrange**, and **skin**, so every corpse verb targets the specific dead body instead of the game's implicit current-corpse selection (which can bind to a live same-noun mob or the wrong corpse).

## Why

A looted corpse does **not** leave `Creature.in_room(:dead)` right away — it lingers (flagged dead) until it **decays**, ~6-7s after loot and several room refreshes later (verified in-game). During that window neither `DRRoom.dead_npcs` nor `Creature.in_room(:dead)` can distinguish a finished corpse from a fresh one, so the old bare verbs re-fired every pass: `The <mob>'s already been skinned, there's no point.`, repeat `You search ... nothing of interest`, and re-dissect "worthless".

## Changes

- `loot #id [type]` — preserves `custom_loot_type`; falls back to bare/typed loot when no id is known (roster divergence / name-less window).
- `arrange #id [all] for <type>` — the noun -> `arrange_types` lookup (skin/part/bone) is unchanged.
- `skin #id`.
- `corpse_present?` existence gate (`Creature.in_room(:dead)`) in front of arrange/skin.
- `@skinned_corpse_ids` / `@dissected_corpse_ids` / `@looted_corpse_ids`, marked on **terminal** outcomes only (success or already-done) so retryable failures still retry; the gates skip a corpse already done for that action.
- Debug logging: greppable `corpse-track:` echoes gated on `$debug_mode_ct`, silent otherwise.

## Testing

- **3180 examples, 0 failures**; `rubocop` clean on the changed file.
- New regression specs cover loot-by-id (with/without type), the arrange-all and retry forms, the existence gates, and per-id skinned/dissected/looted marking + skip. One spec deliberately stubs the realistic `DRC.bput` return (`"Roundtime"`, the matched substring — not the matcher) to guard the case-sensitivity fix included here.
- Verified in-game over multi-bull hunts: clean `arrange -> skin -> mark -> loot`, then `skip` on redundant passes; the redundant-action spam is gone.

## Notes

- `arrange #id all for skin` word order confirmed accepted in-game.
- Necromancer multi-pass rituals are unaffected: per-action tracking composes with the existing `using-corpse` flow rather than a blanket per-corpse skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
