### PR TITLE
combat-trainer: appraise all available mobs each pass, gated by xp + cooldown

### DIFF
--- a/combat-trainer.lic
+++ b/combat-trainer.lic
@@ -3659,8 +3659,6 @@ class TrainerProcess
         end
       end
 
-    @no_app = []
-
     @dont_stalk = settings.dont_stalk
     echo("  @dont_stalk: #{@dont_stalk}") if $debug_mode_ct
 
@@ -4117,13 +4115,24 @@ class TrainerProcess
 
   def appraise(game_state, modifier)
     return if game_state.retreating?
-
-    target = Lich::DragonRealms::Creature.targets.find { |c| !@no_app.include?(c.id) }
-    return unless target
     return if DRSkill.getrank('Appraisal') < 76
-    return if DRC.bput("app ##{target.id} #{modifier}", 'Taking stock of', 'It\'s dead', 'You can\'t determine anything about this creature.', 'I could not find', 'You cannot appraise that', 'roundtime', '^Perhaps that', 'Appraise what') != 'Perhaps that'
+    # XP gate: once Appraisal mindstate is at/over the training threshold there's
+    # nothing left to learn this pulse, so don't appraise anything at all.
+    return if DRSkill.getxp('Appraisal') >= @combat_training_abilities_target
 
-    @no_app << target.id
+    # Now that every creature carries a stable <crtrStatus> id, appraise EVERY mob
+    # in the room on each pass rather than a single one. The App ability's own
+    # cooldown (e.g. `App Quick: 120`) already spaces these passes out via
+    # select_ability, so it doubles as the per-mob "don't re-appraise within the
+    # timer" gate -- appraise runs at most once per cooldown, so no id bookkeeping
+    # is needed. Un-appraisable mobs ('Perhaps that ...') simply get retried on the
+    # next pass rather than being permanently skipped.
+    Lich::DragonRealms::Creature.targets.each do |target|
+      break if game_state.retreating?
+
+      DRC.bput("app ##{target.id} #{modifier}", 'Taking stock of', 'It\'s dead', 'You can\'t determine anything about this creature.', 'I could not find', 'You cannot appraise that', 'roundtime', '^Perhaps that', 'Appraise what')
+      waitrt?
+    end
   end
 
   def moon_mage_perc(game_state)


### PR DESCRIPTION
## What

Reworks `combat-trainer.lic`'s `appraise` (the `App` / `App Quick` / `App Careful` training actions) now that every creature carries a stable `<crtrStatus>` id.

### Before
- Appraised only the **first** non-blacklisted mob per pass.
- Kept a permanent `@no_app` blacklist that was populated **only** on `'Perhaps that ...'` (un-appraisable). A successfully-appraised mob was never recorded, so it got re-appraised every App tick; un-appraisable mobs were skipped for the rest of the session.
- Gate was rank-only (`Appraisal < 76`).

### After
- **XP gate:** skip entirely once Appraisal mindstate is at/over `@combat_training_abilities_target` — nothing left to learn this pulse. The hard rank floor (`< 76`) stays.
- **Appraise every mob:** loop `Creature.targets` and appraise each by id on each pass, instead of one.
- **Cooldown *is* the per-mob timer:** the App ability's configured cooldown (e.g. `App Quick: 120`) already spaces passes via `select_ability`, so it doubles as the "don't re-appraise a mob within the timer" gate. No id bookkeeping needed, and `@no_app` is removed.
- Un-appraisable mobs are simply retried next pass rather than permanently skipped.
- Added `break if game_state.retreating?` inside the loop and `waitrt?` between appraises so a mob's roundtime can't hang the next `app` on an unmatched "still recovering" line.

## Test plan
- `rubocop -A combat-trainer.lic` — no offenses.
- `bundle exec rspec spec/combat-trainer_spec.rb` — 5 examples, 0 failures.
- No spec previously covered `appraise`/`@no_app`; behavior change is confined to the `appraise` method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
