### PR TITLE
fix(healer): match "Whisper what to who?" so bput fails fast

### DIFF
--- a/healer.lic
+++ b/healer.lic
@@ -145,11 +145,16 @@ class Healer
   TRANSFER_NOT_FOUND_PATTERN = /What do you want to get/.freeze
   TRANSFER_RESPONSES = [TRANSFER_SUCCESS_PATTERN, TRANSFER_NOT_FOUND_PATTERN].freeze
 
-  # Patterns for whisper responses
+  # Patterns for whisper responses. "Whisper what to who?" is the game's reply when
+  # the target isn't a valid whisper recipient (e.g. the patient left the room in the
+  # window between our in-room check and the whisper). Without it, DRC.bput finds no
+  # match and blocks for its full timeout while spamming "No match found" before
+  # returning -- so it's matched here to let the whisper fail fast.
   WHISPER_RESPONSES = [
     /^You whisper/i,
     /could not find/i,
-    /You are unable to whisper/i
+    /You are unable to whisper/i,
+    /^Whisper what to who\?/i
   ].freeze
 
   # All trigger patterns for healing requests (order matters - first match wins)

--- a/spec/healer_spec.rb
+++ b/spec/healer_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe Healer do
       allow(DRCH).to receive(:perceive_health_other).with('Tenuk').and_return(dead_clear)
 
       expect(DRC).to receive(:bput)
-        .with("whisper Tenuk You're dead -- get a cleric!", anything, anything, anything)
+        .with("whisper Tenuk You're dead -- get a cleric!", *Healer::WHISPER_RESPONSES)
 
       healer.send(:heal_patient, healer.get_patient('Tenuk'))
 
@@ -348,6 +348,36 @@ RSpec.describe Healer do
       healer.send(:heal_patient, healer.get_patient('Tenuk'))
 
       expect(healer.instance_variable_get(:@spell_task)).to be_nil
+    end
+  end
+
+  # ============================================================
+  # Whisper Responses
+  # ============================================================
+
+  describe 'WHISPER_RESPONSES' do
+    # Regression: the game replies "Whisper what to who?" when the target isn't a
+    # valid recipient (e.g. the patient left between our room check and the whisper).
+    # If no pattern matches it, DRC.bput blocks for its full timeout and spams
+    # "No match found" before returning. See complete_healing / dead-patient whispers.
+    it 'matches the "Whisper what to who?" failure so bput does not block on timeout' do
+      expect(Healer::WHISPER_RESPONSES.any? { |p| p.match?('Whisper what to who?') }).to be true
+    end
+
+    it 'still matches a successful whisper' do
+      expect(Healer::WHISPER_RESPONSES.any? { |p| p.match?('You whisper to Tenuk, "Done!"') }).to be true
+    end
+
+    it 'passes the whisper responses to bput when completing healing' do
+      healer = build_healer(friends: ['Tenuk'])
+      healer.add_patient('Tenuk')
+
+      expect(DRC).to receive(:bput)
+        .with('whisper Tenuk Done!', *Healer::WHISPER_RESPONSES)
+
+      healer.send(:complete_healing, 'Tenuk')
+
+      expect(healer.patients).to be_empty
     end
   end
 


### PR DESCRIPTION
## Problem

While healing, the healer whispers patients — `complete_healing` sends `whisper <name> Done!`, and the dead-patient path sends `whisper <name> You're dead -- get a cleric!`. In practice the game sometimes replies:

```
[healer]>whisper Gnarta Done!
Whisper what to who?
```

This happens when the target isn't a valid whisper recipient at the moment the command lands — e.g. the patient left the room in the window between the healer's in-room check and the whisper.

`"Whisper what to who?"` matched **none** of the `WHISPER_RESPONSES` patterns:

```ruby
WHISPER_RESPONSES = [
  /^You whisper/i,
  /could not find/i,
  /You are unable to whisper/i
].freeze
```

`DRC.bput` doesn't re-send on an unmatched line — it loops until its timeout (default 15s), then prints `DRC: No match was found after 15 seconds ...` plus every line it saw, and returns `''`. So each occurrence **stalls the heal loop for the full timeout and floods the user with error output**.

## Fix

Add `/^Whisper what to who\?/i` to `WHISPER_RESPONSES` so the whisper fails fast and `bput` returns immediately. Both whisper call sites (`complete_healing` and the dead-patient message) share this constant, so both are covered. The result isn't acted on — both sites remove the patient regardless — so matching the failure line is all that's needed.

## Tests

- New regression specs asserting `WHISPER_RESPONSES` matches `"Whisper what to who?"` (and still matches a successful whisper), plus a `complete_healing` test.
- De-coupled the existing dead-patient whisper spec from the pattern count by splatting `Healer::WHISPER_RESPONSES` instead of hard-coding `anything` matchers.
- Full suite green: `3184 examples, 0 failures`. `rubocop` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)