### PR TITLE
Update workorders.lic

### DIFF
--- a/workorders.lic
+++ b/workorders.lic
@@ -213,7 +213,7 @@ class WorkOrders
       materials_info = crafting_data['stock'][@workorders_materials['wood_type']]
       skill = 'Engineering'
       @engineering_room = @settings.engineering_room
-      tools = @settings.engineering_tools
+      tools = @settings.shaping_tools || @settings.engineering_tools
       @belt = @settings.engineering_belt
       craft_method = :shape_items
     when 'carving'
@@ -224,7 +224,7 @@ class WorkOrders
                        end
       skill = 'Engineering'
       @engineering_room = @settings.engineering_room
-      tools = @settings.engineering_tools
+      tools = @settings.carving_tools || @settings.engineering_tools
       @belt = @settings.engineering_belt
       craft_method = :carve_items
     when 'remedies'


### PR DESCRIPTION
Backwards compatibility for repairing tools.

In the `workorders` script `repair_items(info, tools)` is called when finishing up.
For engineering this was set as engineering_tools.

This updates `workorders` to set tools as `tools = @settings.carving_tools || @settings.engineering_tools`
or shaping tools - thereby taking into account all the different ways of setting engineering tools.