### PR TITLE
[script][inventory-manager) manage BriefInv toggle around character inventory scans

### DIFF
--- a/data/base-help.yaml
+++ b/data/base-help.yaml
@@ -827,6 +827,14 @@ instrument:
   specific_descriptions:
     first-aid: Used just as a Zills check. If you have this specified, first-aid won't try to pause playing.
 
+inventory_manager_briefinv:
+  description: Declares whether BriefInv is currently on, so inventory-manager can skip live-checking `toggle list` before toggling it off (and back on) around a character inventory scan.
+  example: true/false
+  referenced_by:
+    - inventory-manager
+  specific_descriptions:
+    inventory-manager:
+
 lockpick_container:
   description: Name of the container containing a loose lockpick for use with various lockpicking scripts
   example: sturdy backpack

--- a/inventory-manager.lic
+++ b/inventory-manager.lic
@@ -465,7 +465,43 @@ class InventoryManager
   end
 
   def add_current_inv
-    check_inventory("inv list", /^You have:/, 'character')
+    was_on = briefinv_state
+    if was_on.nil?
+      DRC.message('inventory-manager: could not determine BriefInv state -- skipping automatic toggle.')
+      return check_inventory("inv list", /^You have:/, 'character')
+    end
+
+    DRC.bput('toggle briefinv', /^You will/) if was_on
+    begin
+      check_inventory("inv list", /^You have:/, 'character')
+    ensure
+      DRC.bput('toggle briefinv', /^You will/) if was_on
+    end
+  end
+
+  # inventory_manager_briefinv lets a profile declare BriefInv's known state so
+  # add_current_inv can skip the `toggle list` round trip. Unset falls back to
+  # checking live.
+  def briefinv_state
+    configured = @settings.inventory_manager_briefinv
+    return configured unless configured.nil?
+
+    briefinv_on?
+  end
+
+  # Reads the BriefInv row out of `toggle list`'s ASCII table without flipping
+  # anything. Returns nil if the row can't be found, so the caller can leave
+  # the toggle alone rather than guess.
+  def briefinv_on?
+    capture = capture_command('toggle list', /^Your current toggles are:/)
+    capture.each do |line|
+      clean = clean_item_line(line)
+      next if clean.nil?
+      next unless (match = clean.match(/^\|(.)\|\s*BriefInv\s*\|/))
+
+      return match[1].strip.casecmp('X').zero?
+    end
+    nil
   end
 
   def add_register_inv

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2446,8 +2446,9 @@ inventory_manager_vault_surfaces:
 
 # Declares BriefInv's known on/off state so add_current_inv can skip the
 # `toggle list` check before toggling it off (and back on) around a
-# character inventory scan. Leave unset to have the script check for you.
-inventory_manager_briefinv: true
+# character inventory scan. Leave empty (or set true/false per-character) to
+# have the script check for you.
+inventory_manager_briefinv:
 
 ####################
 # Stabbity

--- a/profiles/base.yaml
+++ b/profiles/base.yaml
@@ -2444,6 +2444,11 @@ inventory_manager_vault_surfaces:
   - 'a bottom drawer'
   - 'a large shelf'
 
+# Declares BriefInv's known on/off state so add_current_inv can skip the
+# `toggle list` check before toggling it off (and back on) around a
+# character inventory scan. Leave unset to have the script check for you.
+inventory_manager_briefinv: true
+
 ####################
 # Stabbity
 #   - Thieves only


### PR DESCRIPTION
BriefInv shortens item names in `inv list` output, which returns only the short tap for each item and breaks the container/nesting detection in check_inventory. add_current_inv now turns BriefInv off before scanning and restores its prior state afterward.

Add inventory_manager_briefinv so a profile can declare BriefInv's known state and skip the extra `toggle list` round trip.  

base.yaml update: set key with default to nil, so it uses the `toggle list` validation