### PR TITLE
fix(enchant): detect single-item fount on imbue resume (#7553)

### DIFF
--- a/dependency.lic
+++ b/dependency.lic
@@ -21,7 +21,7 @@
 
 $DEPENDENCY_VERSION = '4.2.3'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/f8ne99pVva'
-$MIN_LICH_VERSION = '5.22.0'
+$MIN_LICH_VERSION = '5.21.0'
 
 unless Gem::Version.new(LICH_VERSION) >= Gem::Version.new($MIN_LICH_VERSION)
   10.times do

--- a/dependency.lic
+++ b/dependency.lic
@@ -19,9 +19,9 @@
   and deleted before it duplicates work core now performs.
 =end
 
-$DEPENDENCY_VERSION = '4.2.2'
+$DEPENDENCY_VERSION = '4.2.3'
 $DR_SCRIPTS_DISCORD_LINK = 'https://discord.gg/f8ne99pVva'
-$MIN_LICH_VERSION = '5.20.0'
+$MIN_LICH_VERSION = '5.22.0'
 
 unless Gem::Version.new(LICH_VERSION) >= Gem::Version.new($MIN_LICH_VERSION)
   10.times do

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -235,12 +235,12 @@ end
 
 RSpec.describe 'Dependency Structure' do
   describe 'version' do
-    it 'declares version 4.2.2' do
-      expect(DEP_SOURCE).to include("$DEPENDENCY_VERSION = '4.2.2'")
+    it 'declares version 4.2.3' do
+      expect(DEP_SOURCE).to include("$DEPENDENCY_VERSION = '4.2.3'")
     end
 
-    it 'requires minimum lich version 5.20.0' do
-      expect(DEP_SOURCE).to include("$MIN_LICH_VERSION = '5.20.0'")
+    it 'requires minimum lich version 5.21.0' do
+      expect(DEP_SOURCE).to include("$MIN_LICH_VERSION = '5.21.0'")
     end
   end
 


### PR DESCRIPTION
Fixes #7553.

## Problem

`handle_imbue_resume` does `look on <brazier>` and only accepted `BRAZIER_HAS_FOUNT_PATTERN` (`/On the.*brazier you see.*and a.*/`). The `and a` clause requires **two or more** items, so a brazier holding a single item (e.g. resuming a fount enchant, where the fount is the only thing on it) never matched — the `bput` burned the full 15s timeout, then needlessly re-fetched and waved a fount.

## Fix

Replace it with `BRAZIER_LOOK_PATTERN` (`/On the.*brazier you see/`), which matches any populated brazier, then decide the branch by checking the result for `fount` — the actual intent ("is a fount already on the brazier?").

This is deliberately **not** the "reuse `BRAZIER_CONTENTS_PATTERN`" route suggested in the issue: that pattern's `(?:\w+ )?brazier` can't match the public **`enchanter's brazier`** (the apostrophe breaks `\w+`), so it would still time out there. Keying off `fount` presence in a permissive look-line is single/multi-item **and** my-brazier/public-brazier safe, and is wording-agnostic — no dependency on exact item-count phrasing.

## Testing

- Adds 4 regression specs for `#handle_imbue_resume` (single-item fount, multi-item, public `enchanter's brazier`, no-fount fetch-and-wave fallback).
- `bundle exec rspec` → 3188 examples, 0 failures.
- `rubocop -A` on changed files → no offenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)